### PR TITLE
WIP: fixed DataSourceEntry not able to load subclasses of FetcherConfig

### DIFF
--- a/opal_common/schemas/data.py
+++ b/opal_common/schemas/data.py
@@ -2,7 +2,11 @@ from logging import basicConfig
 from typing import List, Dict, Union
 from pydantic import BaseModel, Field
 
-from opal_common.fetcher.events import FetcherConfig
+from opal_common.fetcher.events import FetcherConfig as BaseFetcherConfig
+from opal_common.fetcher.providers.http_get_fetch_provider import HttpGetFetcherConfig
+from opal_common.fetcher.providers.fastapi_rpc_fetch_provider import FastApiRpcFetchConfig
+
+FetcherConfig = Union[HttpGetFetcherConfig, FastApiRpcFetchConfig, BaseFetcherConfig]
 
 
 class DataSourceEntry(BaseModel):


### PR DESCRIPTION
this is not a perfect fix but it works. i think we can get by with this for now and open a ticket.

pydantic will try to validate input data against each model in the union according to the order the models are defined.
so first will try http fetch config, then rpc fetch config, then the base.