### PR TITLE
Automatic Release |  Validate opa/opal version

### DIFF
--- a/.github/workflows/diff_opa_version.yml
+++ b/.github/workflows/diff_opa_version.yml
@@ -1,0 +1,30 @@
+name: Check OPA / Opal Versions
+
+on:
+  schedule:
+    # every day at 12:00
+    - cron:  '0 12 * * *'
+  workflow_dispatch:
+
+jobs:
+  check_opa_version:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Get Latest OPA Version
+      run: |
+        curl -L -o ./opa https://openpolicyagent.org/downloads/latest/opa_linux_amd64_static && chmod 755 ./opa
+        echo "opa_lts_version=$(./opa version | grep -v Go | grep Version | sed -e 's/Version: //g')" >> $GITHUB_ENV
+    - name: Get OPAL OPA Version
+      run: |
+        echo "opal_opa_current_version=$(docker run authorizon/opal-client:latest /opa version | grep -v Go | grep Version | sed -e 's/Version: //g')" >> $GITHUB_ENV
+    - name: Notifiy On OPA Version Change
+      if: ${{ (env.opa_lts_version != env.opal_opa_current_version) }}
+      id: slack
+      uses: slackapi/slack-github-action@v1.14.0
+      with:
+          payload: "{\"text\":\"OPA version has changed! \\n opa_lts_version: ${{ env.opa_lts_version }} \\n opal_opa_current_version: ${{ env.opal_opa_current_version }} \"}"
+      env:
+        # add slack webhook in secrets
+        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/on_release.yml
+++ b/.github/workflows/on_release.yml
@@ -1,7 +1,5 @@
 name: Publish to Docker Hub
 on:
-  release:
-    types: [published]
     # You should add a personal access token to github secrets for creating the release,
     # When using the default GITHUB_TOKEN an on-release trigger wll not be fired
   workflow_dispatch:

--- a/.github/workflows/on_release.yml
+++ b/.github/workflows/on_release.yml
@@ -1,16 +1,17 @@
-name: Build and publish to Docker Hub
+name: Publish to Docker Hub
 on:
   release:
-    # job will automatically run after a new "release" is create on github.
-    types: [created]
-
-  # Allows you to run this workflow manually from the Actions tab
+    types: [published]
+    # You should add a personal access token to github secrets for creating the release,
+    # When using the default GITHUB_TOKEN an on-release trigger wll not be fired
   workflow_dispatch:
     inputs:
         dry_run:
           description: 'If true, will not push the built images to docker hub.'
           required: false
           default: 'false'
+
+
 
 jobs:
   # this job will build, test and (potentially) push the docker images to docker hub
@@ -42,16 +43,8 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
 
-      - name: Get version tag from github release
-        if: github.event_name == 'release' && github.event.action == 'created'
-        run: |
-          echo "opal_version_tag=${{ github.event.release.tag_name }}" >> $GITHUB_ENV
-
-      - name: Get version tag from git history
-        if: ${{ !(github.event_name == 'release' && github.event.action == 'created') }}
-        run: |
-          echo "opal_version_tag=$(git describe --tags --abbrev=0)" >> $GITHUB_ENV
-
+      - name: Get Release Version
+        run: echo "opal_version_tag=$(python -c "exec(open('setup/__version__.py').read()) ; print(__version__)")" >> $GITHUB_ENV
       - name: Echo version tag
         run: |
           echo "The version tag that will be published to docker hub is: ${{ env.opal_version_tag }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,66 @@
+name: Publish to GitHub / Pypi
+on:
+  workflow_dispatch:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.7, 3.8, 3.9]
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install flake8 pytest pytest-asyncio
+        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+        if [ -f ./tests/requirements.txt ]; then pip install -r ./tests/requirements.txt; fi
+    - name: Lint with flake8
+      run: |
+        # stop the build if there are Python syntax errors or undefined names
+        flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+        # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
+        flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+    - name: Test with pytest
+      run: pytest
+
+  build_and_publish:
+    needs: test
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install flake8 pytest pytest-asyncio twine
+        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+        if [ -f ./tests/requirements.txt ]; then pip install -r ./tests/requirements.txt; fi
+    - name: Create modified .pypirc file
+      # PyPI API token needs to be added to github secrets
+      # added pypi non interactive login 
+      run: |
+        sed 's/#PYPI_TOKEN/${{ secrets.PYPI_TOKEN}}/g' -i .pypirc
+        cp .pypirc ~/
+    - name: Run Make
+      run: make publish
+    - name: Get Release Version
+      run: echo "opal_version_tag=$(python -c "exec(open('setup/__version__.py').read()) ; print(__version__)")" >> $GITHUB_ENV
+    - name: Create Github Release
+      uses: softprops/action-gh-release@v1
+      with:
+        files: |
+            dist-common/*
+            dist-client/*
+            dist-server/*
+        name: "v${{ env.opal_version_tag }}"
+        tag_name: "${{ env.opal_version_tag }}"
+      env:
+        # You should add a personal access token to github secrets for creating the release,
+        # When using the default GITHUB_TOKEN an on-release trigger wll not be fired
+        GITHUB_TOKEN: ${{ secrets.PAT_GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: Publish to GitHub / Pypi
+name: Publish to GitHub / Pypi / DockerHub
 on:
   workflow_dispatch:
 
@@ -38,16 +38,21 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        python -m pip install flake8 pytest pytest-asyncio twine
+        python -m pip install wheel twine
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
-        if [ -f ./tests/requirements.txt ]; then pip install -r ./tests/requirements.txt; fi
     - name: Create modified .pypirc file
       # PyPI API token needs to be added to github secrets
-      # added pypi non interactive login 
       run: |
-        sed 's/#PYPI_TOKEN/${{ secrets.PYPI_TOKEN}}/g' -i .pypirc
-        cp .pypirc ~/
-    - name: Run Make
+        echo "[distutils]
+        index-servers =
+            pypi
+
+        [pypi]
+          repository = https://upload.pypi.org/legacy/
+          username = __token__
+          password = ${{ secrets.PYPI_TOKEN}}
+        " > ~/.pypirc
+    - name: Upload python packages to PyPI
       run: make publish
     - name: Get Release Version
       run: echo "opal_version_tag=$(python -c "exec(open('setup/__version__.py').read()) ; print(__version__)")" >> $GITHUB_ENV
@@ -55,12 +60,113 @@ jobs:
       uses: softprops/action-gh-release@v1
       with:
         files: |
-            dist-common/*
-            dist-client/*
-            dist-server/*
+            GithubRelease/*
         name: "v${{ env.opal_version_tag }}"
         tag_name: "${{ env.opal_version_tag }}"
       env:
-        # You should add a personal access token to github secrets for creating the release,
-        # When using the default GITHUB_TOKEN an on-release trigger wll not be fired
-        GITHUB_TOKEN: ${{ secrets.PAT_GITHUB_TOKEN }}
+        GITHUB_TOKEN: ${{ env.GITHUB_TOKEN }}
+
+  docker_build_and_publish:
+    needs: build_and_publish
+    runs-on: ubuntu-latest
+    steps:
+      # BUILD PHASE
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Get Release Version
+        run: echo "opal_version_tag=$(python -c "exec(open('setup/__version__.py').read()) ; print(__version__)")" >> $GITHUB_ENV
+      - name: Echo version tag
+        run: |
+          echo "The version tag that will be published to docker hub is: ${{ env.opal_version_tag }}"
+
+      - name: Build client
+        id: build_client
+        uses: docker/build-push-action@v2
+        with:
+          file: docker/Dockerfile
+          push: false
+          target: client
+          cache-from: type=registry,ref=authorizon/opal-client:latest
+          cache-to: type=inline
+          load: true
+          tags: |
+            authorizon/opal-client:test
+            authorizon/opal-client:latest
+            authorizon/opal-client:${{ env.opal_version_tag }}
+
+      - name: Build client-standalone
+        id: build_client_standalone
+        uses: docker/build-push-action@v2
+        with:
+          file: docker/Dockerfile
+          push: false
+          target: client-standalone
+          cache-from: type=registry,ref=authorizon/opal-client-standalone:latest
+          cache-to: type=inline
+          load: true
+          tags: |
+            authorizon/opal-client-standalone:test
+            authorizon/opal-client-standalone:latest
+            authorizon/opal-client-standalone:${{ env.opal_version_tag }}
+
+      - name: Build server
+        id: build_server
+        uses: docker/build-push-action@v2
+        with:
+          file: docker/Dockerfile
+          push: false
+          target: server
+          cache-from: type=registry,ref=authorizon/opal-server:latest
+          cache-to: type=inline
+          load: true
+          tags: |
+            authorizon/opal-server:test
+            authorizon/opal-server:latest
+            authorizon/opal-server:${{ env.opal_version_tag }}
+
+      # TEST PHASE
+      - name: Create modified docker compose file
+        run: sed 's/:latest/:test/g' docker/docker-compose-example.yml > docker/docker-compose-test.yml
+
+      - name: Bring up stack
+        run: docker-compose -f docker/docker-compose-test.yml up -d
+
+      - name: Check if OPA is healthy
+        run: ./scripts/wait-for.sh -t 60 http://localhost:8181/v1/data/users -- sleep 10 && curl -s "http://localhost:8181/v1/data/users" | jq '.result.bob.location.country == "US"'
+
+      - name: Output container logs
+        run: docker-compose -f docker/docker-compose-test.yml logs
+
+      # PUSH PHASE
+      - name: Output local docker images
+        run: docker image ls --digests | grep opal
+
+      - name: Login to DockerHub
+        if: ${{ !(github.event_name == 'workflow_dispatch' && github.event.inputs.dry_run == 'true') }}
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      # pushes the *same* docker images that were previously tested as part of e2e sanity test.
+      # each image is pushed with the versioned tag first, if it succeeds the image is pushed with the latest tag as well.
+      - name: Push client
+        if: ${{ !(github.event_name == 'workflow_dispatch' && github.event.inputs.dry_run == 'true') }}
+        run: docker push authorizon/opal-client:${{ env.opal_version_tag }} && docker push authorizon/opal-client:latest
+
+      - name: Push client-standalone
+        if: ${{ !(github.event_name == 'workflow_dispatch' && github.event.inputs.dry_run == 'true') }}
+        run: docker push authorizon/opal-client-standalone:${{ env.opal_version_tag }} && docker push authorizon/opal-client-standalone:latest
+
+      - name: Push server
+        if: ${{ !(github.event_name == 'workflow_dispatch' && github.event.inputs.dry_run == 'true') }}
+        run: docker push authorizon/opal-server:${{ env.opal_version_tag }} && docker push authorizon/opal-server:latest

--- a/.pypirc
+++ b/.pypirc
@@ -1,0 +1,8 @@
+[distutils]
+index-servers =
+    pypi
+
+[pypi]
+  repository = https://upload.pypi.org/legacy/
+  username = __token__
+  password = #PYPI_TOKEN

--- a/.pypirc
+++ b/.pypirc
@@ -1,8 +1,0 @@
-[distutils]
-index-servers =
-    pypi
-
-[pypi]
-  repository = https://upload.pypi.org/legacy/
-  username = __token__
-  password = #PYPI_TOKEN

--- a/Makefile
+++ b/Makefile
@@ -11,22 +11,42 @@ OPAL_POLICY_STORE_URL ?= http://host.docker.internal:8181/v1
 clean:
 	rm -rf *.egg-info build/ dist/
 
-publish-common:
+build-common:
 	$(MAKE) clean
 	python setup/setup_common.py sdist bdist_wheel
-	python -m twine upload dist/*
+	mv dist dist-common
 
-publish-client:
+build-client:
 	$(MAKE) clean
 	python setup/setup_client.py sdist bdist_wheel
-	python -m twine upload dist/*
+	mv dist dist-client
 
-publish-server:
+build-server:
 	$(MAKE) clean
 	python setup/setup_server.py sdist bdist_wheel
-	python -m twine upload dist/*
+	mv dist dist-server
+
+
+publish-common:
+	python -m twine upload --repository pypi dist-common/*
+
+publish-client:
+	python -m twine upload --repository pypi dist-client/*
+
+publish-server:
+	python -m twine upload --repository pypi dist-server/*
+
+# Split the build and publish to ensure all packegs has been built before uploading to PyPI
+build:
+	# build
+	$(MAKE) build-common
+	$(MAKE) build-client
+	$(MAKE) build-server
 
 publish:
+	# build
+	$(MAKE) build
+	# Publish
 	$(MAKE) publish-common
 	$(MAKE) publish-client
 	$(MAKE) publish-server


### PR DESCRIPTION
added workflow to validate opa/opal version
added release workflow to GitHub & pypi 
it is also possible to add release notes to the automation (ref: https://github.com/softprops/action-gh-release)
fixed the trigger for on release workflow
