### PR TITLE
integrate rookout

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -28,12 +28,16 @@ RUN pip install --no-cache-dir --upgrade pip && pip install --no-cache-dir --use
 FROM python:3.8-alpine3.11 as common
 # copy libraries from build stage
 COPY --from=BuildStage /root/.local /root/.local
+# needed for rookout
+RUN apk add g++ python3-dev linux-headers
 # copy wait-for script
 COPY scripts/wait-for.sh /usr/wait-for.sh
 RUN chmod +x /usr/wait-for.sh
 # copy startup script
 COPY ./scripts/start.sh /start.sh
 RUN chmod +x /start.sh
+# copy gunicorn_config
+COPY ./scripts/gunicorn_conf.py /gunicorn_conf.py
 # copy app code
 COPY . ./
 # install sidecar package

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,3 +19,4 @@ tenacity==6.3.1
 typing-extensions
 uvicorn[standard]
 websockets==9.1
+rook

--- a/scripts/gunicorn_conf.py
+++ b/scripts/gunicorn_conf.py
@@ -1,0 +1,25 @@
+import os
+
+from opal_common.logger import logger
+
+
+def post_fork(server, worker):
+    """
+    this hook takes effect if we are using gunicorn to run OPAL.
+    """
+    rookout_token = os.getenv("ROOKOUT_TOKEN", None)
+    if not rookout_token:
+        logger.info("No rookout token found, skipping.")
+        return
+
+    service = os.getenv("ROOKOUT_SERVICE", "opal_server")
+    env = os.getenv("ROOKOUT_ENV", "dev")
+    user = os.getenv("ROOKOUT_USER", None)
+
+    logger.info("Running Rookout...")
+    labels = {"env": env, "service": service}
+    if user is not None:
+        labels.update({"user": user})
+
+    import rook
+    rook.start(token=rookout_token, labels=labels)

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -1,5 +1,7 @@
 #! /usr/bin/env sh
 set -e
 
+export GUNICORN_CONF=${GUNICORN_CONF:-/gunicorn_conf.py}
+
 # Start Gunicorn
-exec gunicorn -b 0.0.0.0:${UVICORN_PORT} -k uvicorn.workers.UvicornWorker --workers=${UVICORN_NUM_WORKERS} ${UVICORN_ASGI_APP}
+exec gunicorn -b 0.0.0.0:${UVICORN_PORT} -k uvicorn.workers.UvicornWorker --workers=${UVICORN_NUM_WORKERS} -c ${GUNICORN_CONF} ${UVICORN_ASGI_APP}


### PR DESCRIPTION
Rookout integration is only active for dockerized version of OPAL.
The integration will be off if no valid access token is provided.
To activate - provide the `ROOKOUT_TOKEN` env var.