### PR TITLE
Remove un-needed usage of len()

### DIFF
--- a/docs/HOWTO/write_your_own_fetch_provider.md
+++ b/docs/HOWTO/write_your_own_fetch_provider.md
@@ -298,7 +298,7 @@ async def _process_(self, records: List[asyncpg.Record]):
 
     # when fetch_one is true, we want to return a dict (and not a list)
     if self._event.config.fetch_one:
-        if records and len(records) > 0:
+        if records:
             # we transform the asyncpg record to a dict that we can be later serialized to json
             return dict(records[0])
         else:

--- a/opal_client/policy_store/base_policy_store_client.py
+++ b/opal_client/policy_store/base_policy_store_client.py
@@ -136,17 +136,17 @@ class BasePolicyStoreClient(AbstractPolicyStore):
             actions (List[str], optional): All the methods called in the transaction. Defaults to None.
         """
         exception_fetching_transaction = []
-        if remotes_status and len(remotes_status):
+        if remotes_status:
             exception_fetching_transaction = [remote for remote in remotes_status if not remote['succeed']]
         elif transaction_id is None or not actions:
             return # skip, nothing to do if we have no data to log
 
         end_time = datetime.utcnow().isoformat()
-        if exc is not None or len(exception_fetching_transaction):
+        if exc is not None or exception_fetching_transaction:
             try:
                 if exc is not None:
                     error_message = repr(exc)
-                elif len(exception_fetching_transaction) > 0:
+                elif exception_fetching_transaction:
                     network_errors = [remote.get("error", None) for remote in exception_fetching_transaction]
                     network_errors = [str(err) for err in network_errors if err is not None]
                     error_message = ";".join(network_errors) if network_errors else None

--- a/opal_common/security/sslcontext.py
+++ b/opal_common/security/sslcontext.py
@@ -17,7 +17,10 @@ def get_custom_ssl_context() -> Optional[ssl.SSLContext]:
 
     if ca_file is None:
         return None
-
+    
+    if not ca_file:
+        return None
+    
     ca_file_path = os.path.expanduser(ca_file)
     if not os.path.isfile(ca_file_path):
         return None

--- a/opal_common/security/sslcontext.py
+++ b/opal_common/security/sslcontext.py
@@ -18,7 +18,7 @@ def get_custom_ssl_context() -> Optional[ssl.SSLContext]:
     if ca_file is None:
         return None
 
-    if len(ca_file) == 0:
+    if ca_file:
         return None
 
     ca_file_path = os.path.expanduser(ca_file)

--- a/opal_common/security/sslcontext.py
+++ b/opal_common/security/sslcontext.py
@@ -18,9 +18,6 @@ def get_custom_ssl_context() -> Optional[ssl.SSLContext]:
     if ca_file is None:
         return None
 
-    if ca_file:
-        return None
-
     ca_file_path = os.path.expanduser(ca_file)
     if not os.path.isfile(ca_file_path):
         return None

--- a/opal_server/data/data_update_publisher.py
+++ b/opal_server/data/data_update_publisher.py
@@ -26,7 +26,7 @@ class DataUpdatePublisher:
             List[str]: The combinations of sub topics for the given topic
         """
         sub_topics = topic.split(delimeter)
-        if len(sub_topics) > 0:
+        if sub_topics:
             topic_combos = []
             current_topic = sub_topics[0]
             topic_combos.append(current_topic)


### PR DESCRIPTION
Removing usage of len() when it used to check if sequence (list, string etc..) is empty
Those are the main 2 reasons:

1. Align to PEP8, and make the code more pythonic:

> For sequences, (strings, lists, tuples), use the fact that empty sequences are false:
> ```
> # Correct:
> if not seq: 
> if seq:
> # Wrong:
> if len(seq):
> if not len(seq):

2. Faster.
```
import timeit
a = []
min(timeit.repeat(lambda: len(a) != 0, repeat=100))
>>>0.08818189999874448
min(timeit.repeat(lambda: len(a), repeat=100))
>>>0.08564540000043053
min(timeit.repeat(lambda: a, repeat=100))
>>>0.06261199999971723
``` 