### PR TITLE
Introduce client load limiting feature

### DIFF
--- a/docker/docker-compose-with-rate-limiting.yml
+++ b/docker/docker-compose-with-rate-limiting.yml
@@ -1,0 +1,85 @@
+# This docker compose example shows how to configure OPAL's rate limiting feature
+version: "3.8"
+services:
+  # When scaling the opal-server to multiple nodes and/or multiple workers, we use
+  # a *broadcast* channel to sync between all the instances of opal-server.
+  # Under the hood, this channel is implemented by encode/broadcaster (see link below).
+  # At the moment, the broadcast channel can be either: postgresdb, redis or kafka.
+  # The format of the broadcaster URI string (the one we pass to opal server as `OPAL_BROADCAST_URI`) is specified here:
+  # https://github.com/encode/broadcaster#available-backends
+  broadcast_channel:
+    image: postgres:alpine
+    environment:
+      - POSTGRES_DB=postgres
+      - POSTGRES_USER=postgres
+      - POSTGRES_PASSWORD=postgres
+  opal_server:
+    # by default we run opal-server from latest official image
+    image: permitio/opal-server:next
+    environment:
+      # number of uvicorn workers to run inside the opal-server container
+      - UVICORN_NUM_WORKERS=1
+      # the git repo hosting our policy
+      # - if this repo is not public, you can pass an ssh key via `OPAL_POLICY_REPO_SSH_KEY`)
+      # - the repo we pass in this example is *public* and acts as an example repo with dummy rego policy
+      # - for more info, see: https://github.com/permitio/opal/blob/master/docs/HOWTO/track_a_git_repo.md
+      - OPAL_POLICY_REPO_URL=https://github.com/permitio/opal-example-policy-repo
+      # in this example we will use a polling interval of 30 seconds to check for new policy updates (git commits affecting the rego policy).
+      # however, it is better to utilize a git *webhook* to trigger the server to check for changes only when the repo has new commits.
+      # for more info see: https://github.com/permitio/opal/blob/master/docs/HOWTO/track_a_git_repo.md
+      - OPAL_POLICY_REPO_POLLING_INTERVAL=30
+      # configures from where the opal client should initially fetch data (when it first goes up, after disconnection, etc).
+      # the data sources represents from where the opal clients should get a "complete picture" of the data they need.
+      # after the initial sources are fetched, the client will subscribe only to update notifications sent by the server.
+      - OPAL_DATA_CONFIG_SOURCES={"config":{"entries":[{"url":"http://host.docker.internal:7002/policy-data","topics":["policy_data"],"dst_path":"/static"}]}}
+      - OPAL_LOG_FORMAT_INCLUDE_PID=true
+      # Turns on rate limiting in the server
+      # supported formats documented here: https://limits.readthedocs.io/en/stable/quickstart.html#rate-limit-string-notation
+      - OPAL_CLIENT_LOAD_LIMIT_NOTATION=1/minute
+    ports:
+      # exposes opal server on the host machine, you can access the server at: http://localhost:7002
+      - "7002:7002"
+    depends_on:
+      - broadcast_channel
+  opal_client1:
+    # by default we run opal-client from latest official image
+    image: permitio/opal-client:next
+    environment:
+      - OPAL_SERVER_URL=http://opal_server:7002
+      - OPAL_LOG_FORMAT_INCLUDE_PID=true
+      - OPAL_INLINE_OPA_LOG_FORMAT=http
+      # Turns on rate limiting in the client (without this flag the client won't respect the server's rate limiting)
+      - OPAL_WAIT_ON_SERVER_LOAD=true
+    ports:
+      # exposes opal client on the host machine, you can access the client at: http://localhost:7000
+      - "7003:7000"
+      # exposes the OPA agent (being run by OPAL) on the host machine
+      # you can access the OPA api that you know and love at: http://localhost:8181
+      # OPA api docs are at: https://www.openpolicyagent.org/docs/latest/rest-api/
+      - "8181:8181"
+    depends_on:
+      - opal_server
+    # this command is not necessary when deploying OPAL for real, it is simply a trick for dev environments
+    # to make sure that opal-server is already up before starting the client.
+    command: sh -c "./wait-for.sh opal_server:7002 --timeout=20 -- ./start.sh"
+  opal_client2:
+    # by default we run opal-client from latest official image
+    image: permitio/opal-client:next
+    environment:
+      - OPAL_SERVER_URL=http://opal_server:7002
+      - OPAL_LOG_FORMAT_INCLUDE_PID=true
+      - OPAL_INLINE_OPA_LOG_FORMAT=http
+      # Turns on rate limiting in the client (without this flag the client won't respect the server's rate limiting)
+      - OPAL_WAIT_ON_SERVER_LOAD=true
+    ports:
+      # exposes opal client on the host machine, you can access the client at: http://localhost:7000
+      - "7004:7000"
+      # exposes the OPA agent (being run by OPAL) on the host machine
+      # you can access the OPA api that you know and love at: http://localhost:8181
+      # OPA api docs are at: https://www.openpolicyagent.org/docs/latest/rest-api/
+      - "8182:8181"
+    depends_on:
+      - opal_server
+    # this command is not necessary when deploying OPAL for real, it is simply a trick for dev environments
+    # to make sure that opal-server is already up before starting the client.
+    command: sh -c "./wait-for.sh opal_server:7002 --timeout=20 -- ./start.sh"

--- a/packages/opal-client/opal_client/config.py
+++ b/packages/opal-client/opal_client/config.py
@@ -72,6 +72,9 @@ class OpalClientConfig(Confi):
     CLIENT_API_SERVER_PORT = confi.int("CLIENT_API_SERVER_PORT", 7000,
                                        description="(if run via CLI)  Port for the opal-client's internal server to bind")
 
+    WAIT_ON_SERVER_LOAD = confi.bool("WAIT_ON_SERVER_LOAD", False, 
+                                           description="If set, client would wait for 200 from server's loadlomit endpoint before starting background tasks")
+
     # Policy updater configuration ------------------------------------------------
 
     # directories in policy repo we should subscribe to for policy code (rego) modules

--- a/packages/opal-client/opal_client/config.py
+++ b/packages/opal-client/opal_client/config.py
@@ -72,8 +72,8 @@ class OpalClientConfig(Confi):
     CLIENT_API_SERVER_PORT = confi.int("CLIENT_API_SERVER_PORT", 7000,
                                        description="(if run via CLI)  Port for the opal-client's internal server to bind")
 
-    WAIT_ON_SERVER_LOAD = confi.bool("WAIT_ON_SERVER_LOAD", False, 
-                                           description="If set, client would wait for 200 from server's loadlomit endpoint before starting background tasks")
+    WAIT_ON_SERVER_LOAD = confi.bool("WAIT_ON_SERVER_LOAD", False,
+                                           description="If set, client would wait for 200 from server's loadlimit endpoint before starting background tasks")
 
     # Policy updater configuration ------------------------------------------------
 

--- a/packages/opal-client/opal_client/limiter.py
+++ b/packages/opal-client/opal_client/limiter.py
@@ -1,0 +1,50 @@
+import aiohttp
+
+from fastapi import status, HTTPException
+from tenacity import retry, wait_random_exponential, stop
+
+from opal_common.utils import tuple_to_dict, get_authorization_header
+from opal_common.security.sslcontext import get_custom_ssl_context
+
+from opal_client.logger import logger
+from opal_client.config import opal_client_config
+
+class StartupLoadLimiter:
+    """
+    Validates OPAL server is not too loaded before starting up
+    """
+
+    def __init__(self, backend_url=None, token=None):
+        """
+        Args:
+            backend_url (str): Defaults to opal_client_config.SERVER_URL.
+            token ([type], optional): [description]. Defaults to opal_client_config.CLIENT_TOKEN.
+        """
+        self._backend_url = backend_url or opal_client_config.SERVER_URL
+        self._loadlimit_endpoint_url = f"{self._backend_url}/loadlimit"
+
+        self._token = token or opal_client_config.CLIENT_TOKEN
+        self._auth_headers = tuple_to_dict(get_authorization_header(self._token))
+        self._custom_ssl_context = get_custom_ssl_context()
+        self._ssl_context_kwargs = {'ssl': self._custom_ssl_context} if self._custom_ssl_context is not None else {}
+
+
+    @retry(wait=wait_random_exponential(max=10), stop=stop.stop_never, reraise=True)
+    async def wait_for_server_ready(self):
+        logger.info("Trying to get server's load limit pass")
+        async with aiohttp.ClientSession() as session:
+            try:
+                async with session.get(
+                    self._loadlimit_endpoint_url,
+                    headers={'content-type': 'text/plain', **self._auth_headers},
+                    **self._ssl_context_kwargs
+                ) as response:
+                    if response.status != status.HTTP_200_OK:
+                        logger.warning(f"loadlimit endpoint returned status {response.status}")
+                        raise HTTPException(response.status)
+            except aiohttp.ClientError as e:
+                logger.warning("server connection error: {err}", err=repr(e))
+                raise
+
+    def __call__(self):
+        return self.wait_for_server_ready()

--- a/packages/opal-server/opal_server/config.py
+++ b/packages/opal-server/opal_server/config.py
@@ -17,6 +17,7 @@ class OpalServerConfig(Confi):
     # ws server
     OPAL_WS_LOCAL_URL = confi.str("WS_LOCAL_URL", "ws://localhost:7002/ws")
     OPAL_WS_TOKEN = confi.str("WS_TOKEN", "THIS_IS_A_DEV_SECRET")
+    CLIENT_LOAD_LIMIT_NOTATION = confi.str("CLIENT_LOAD_LIMIT_NOTATION", None, "If supplied, rate limit would be enforced on server's websocket endpoint. format is `limits`-style notation (e.g '10 per second')")
     # The URL for the backbone pub/sub server (e.g. Postgres, Kfaka, Redis) @see
     BROADCAST_URI = confi.str("BROADCAST_URI", None)
     # The name to be used for segmentation in the backbone pub/sub (e.g. the Kafka topic)

--- a/packages/opal-server/opal_server/config.py
+++ b/packages/opal-server/opal_server/config.py
@@ -17,7 +17,12 @@ class OpalServerConfig(Confi):
     # ws server
     OPAL_WS_LOCAL_URL = confi.str("WS_LOCAL_URL", "ws://localhost:7002/ws")
     OPAL_WS_TOKEN = confi.str("WS_TOKEN", "THIS_IS_A_DEV_SECRET")
-    CLIENT_LOAD_LIMIT_NOTATION = confi.str("CLIENT_LOAD_LIMIT_NOTATION", None, "If supplied, rate limit would be enforced on server's websocket endpoint. format is `limits`-style notation (e.g '10 per second')")
+    CLIENT_LOAD_LIMIT_NOTATION = confi.str(
+        "CLIENT_LOAD_LIMIT_NOTATION",
+        None,
+        "If supplied, rate limit would be enforced on server's websocket endpoint. " + \
+        "Format is `limits`-style notation (e.g '10 per second'), " + \
+        "see link: https://limits.readthedocs.io/en/stable/quickstart.html#rate-limit-string-notation")
     # The URL for the backbone pub/sub server (e.g. Postgres, Kfaka, Redis) @see
     BROADCAST_URI = confi.str("BROADCAST_URI", None)
     # The name to be used for segmentation in the backbone pub/sub (e.g. the Kafka topic)

--- a/packages/opal-server/opal_server/loadlimiting.py
+++ b/packages/opal-server/opal_server/loadlimiting.py
@@ -1,6 +1,8 @@
 from slowapi import Limiter
 from fastapi import APIRouter, Request
 
+from opal_common.logger import logger
+
 def init_loadlimit_router(loadlimit_notation: str = None):
     """
     initializes a route where a client (or any other network peer) can inquire what opal
@@ -14,6 +16,7 @@ def init_loadlimit_router(loadlimit_notation: str = None):
     limiter = Limiter(key_func=lambda: "global")
 
     if loadlimit_notation:
+        logger.info(f"rate limiting is on, configured limit: {loadlimit_notation}")
         @router.get('/loadlimit')
         @limiter.limit(loadlimit_notation)
         async def loadlimit(request: Request):

--- a/packages/opal-server/opal_server/loadlimiting.py
+++ b/packages/opal-server/opal_server/loadlimiting.py
@@ -1,0 +1,26 @@
+from slowapi import Limiter
+from fastapi import APIRouter, Request
+
+def init_loadlimit_router(loadlimit_notation: str = None):
+    """
+    initializes a route where a client (or any other network peer) can inquire what opal
+    clients are currently connected to the server and on what topics are they registered.
+
+    If the OPAL server does not have statistics enabled, the route will return 501 Not Implemented
+    """
+    router = APIRouter()
+
+    # We want to globally limit the endpoint, not per client
+    limiter = Limiter(key_func=lambda: "global")
+
+    if loadlimit_notation:
+        @router.get('/loadlimit')
+        @limiter.limit(loadlimit_notation)
+        async def loadlimit(request: Request):
+            return
+    else:
+        @router.get('/loadlimit')
+        async def loadlimit(request: Request):
+            return
+
+    return router

--- a/packages/opal-server/requires.txt
+++ b/packages/opal-server/requires.txt
@@ -4,3 +4,4 @@ gitpython
 pyjwt[crypto]==2.1.0
 websockets==9.1
 ddtrace
+slowapi


### PR DESCRIPTION
To turn on this feature:
set on client `OPAL_WAIT_ON_SERVER_LOAD=true`
and on server `CLIENT_LOAD_LIMIT_NOTATION=10 per minute`

Client would try to get the "/loadlimit" endpoint from server before starting its background tasks (policy & data fetchers).
Slowapi is used to limit access to that endpoint. 429 is returned if too many clients connected.

Limitations:

1. The limit is per worker. If you have 8 workers and limit of "10 per minute" then we would actually allow 80 per minute.
2. Same goes for client though - each worker in the client container would be counted as 1. 