### PR TITLE
Unpin fastapi and charset-normalizer

### DIFF
--- a/packages/requires.txt
+++ b/packages/requires.txt
@@ -1,7 +1,7 @@
-charset-normalizer==2.0.7
+charset-normalizer~=2.0.7
 idna<3,>=2.5
 typer
-fastapi==0.65.2
+fastapi
 fastapi_websocket_pubsub>=0.2.0
 fastapi_websocket_rpc>=0.1.21
 gunicorn


### PR DESCRIPTION
It doesn't make sense for a library to pin specific versions of dependencies -- libraries need to be compatible with a range of dependency versions, otherwise they are not meaningfully useful. We can use the [compatible release](https://peps.python.org/pep-0440/#compatible-release) operator (`~=`) for `charset-normalizer`, to indicate that this library is tested with version 2.0.7 but should work with any compatible version of this library. Unfortunately, we can't do the same thing for the `fastapi` dependency -- in my local testing, `pip` isn't willing to install a different version, possibly because `fastapi` is still at version 0.x, which [specifically disclaims any guarantees of compatibility between releases](https://semver.org).