### PR TITLE
Only install rookout deps for a dedicated image tag

### DIFF
--- a/.github/workflows/on_release.yml
+++ b/.github/workflows/on_release.yml
@@ -28,6 +28,10 @@ jobs:
   # - Runs only if test phase completes with no errors.
   # - Pushes images (built at BUILD PHASE) to docker hub.
   docker_build_and_publish:
+    strategy:
+      matrix:
+        suffix: ["","-rookout"]
+
     runs-on: ubuntu-latest
     steps:
       # BUILD PHASE
@@ -42,15 +46,19 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
 
+      - name: Set latest tag
+        run: |
+          echo "opal_latest_tag=latest${{ matrix.suffix }}" >> $GITHUB_ENV
+
       - name: Get version tag from github release
         if: github.event_name == 'release' && github.event.action == 'created'
         run: |
-          echo "opal_version_tag=${{ github.event.release.tag_name }}" >> $GITHUB_ENV
+          echo "opal_version_tag=${{ github.event.release.tag_name }}${{ matrix.suffix }}" >> $GITHUB_ENV
 
       - name: Get version tag from git history
         if: ${{ !(github.event_name == 'release' && github.event.action == 'created') }}
         run: |
-          echo "opal_version_tag=$(git describe --tags --abbrev=0)" >> $GITHUB_ENV
+          echo "opal_version_tag=$(git describe --tags --abbrev=0)${{ matrix.suffix }}" >> $GITHUB_ENV
 
       - name: Echo version tag
         run: |
@@ -63,12 +71,14 @@ jobs:
           file: docker/Dockerfile
           push: false
           target: client
-          cache-from: type=registry,ref=permitio/opal-client:latest
+          cache-from: type=registry,ref=permitio/opal-client:${{ env.opal_latest_tag }}
           cache-to: type=inline
           load: true
+          build-args: |
+            rookout=${{ matrix.suffix }}
           tags: |
             permitio/opal-client:test
-            permitio/opal-client:latest
+            permitio/opal-client:${{ env.opal_latest_tag }}
             permitio/opal-client:${{ env.opal_version_tag }}
 
       - name: Build client-standalone
@@ -78,12 +88,12 @@ jobs:
           file: docker/Dockerfile
           push: false
           target: client-standalone
-          cache-from: type=registry,ref=permitio/opal-client-standalone:latest
+          cache-from: type=registry,ref=permitio/opal-client-standalone:${{ env.opal_latest_tag }}
           cache-to: type=inline
           load: true
           tags: |
             permitio/opal-client-standalone:test
-            permitio/opal-client-standalone:latest
+            permitio/opal-client-standalone:${{ env.opal_latest_tag }}
             permitio/opal-client-standalone:${{ env.opal_version_tag }}
 
       - name: Build server
@@ -93,12 +103,12 @@ jobs:
           file: docker/Dockerfile
           push: false
           target: server
-          cache-from: type=registry,ref=permitio/opal-server:latest
+          cache-from: type=registry,ref=permitio/opal-server:${{ env.opal_latest_tag }}
           cache-to: type=inline
           load: true
           tags: |
             permitio/opal-server:test
-            permitio/opal-server:latest
+            permitio/opal-server:${{ env.opal_latest_tag }}
             permitio/opal-server:${{ env.opal_version_tag }}
 
       # TEST PHASE
@@ -129,12 +139,12 @@ jobs:
       # each image is pushed with the versioned tag first, if it succeeds the image is pushed with the latest tag as well.
       - name: Push client
         if: ${{ !(github.event_name == 'workflow_dispatch' && github.event.inputs.dry_run == 'true') }}
-        run: docker push permitio/opal-client:${{ env.opal_version_tag }} && docker push permitio/opal-client:latest
+        run: docker push permitio/opal-client:${{ env.opal_version_tag }} && docker push permitio/opal-client:${{ env.opal_latest_tag }}
 
       - name: Push client-standalone
         if: ${{ !(github.event_name == 'workflow_dispatch' && github.event.inputs.dry_run == 'true') }}
-        run: docker push permitio/opal-client-standalone:${{ env.opal_version_tag }} && docker push permitio/opal-client-standalone:latest
+        run: docker push permitio/opal-client-standalone:${{ env.opal_version_tag }} && docker push permitio/opal-client-standalone:${{ env.opal_latest_tag }}
 
       - name: Push server
         if: ${{ !(github.event_name == 'workflow_dispatch' && github.event.inputs.dry_run == 'true') }}
-        run: docker push permitio/opal-server:${{ env.opal_version_tag }} && docker push permitio/opal-server:latest
+        run: docker push permitio/opal-server:${{ env.opal_version_tag }} && docker push permitio/opal-server:${{ env.opal_latest_tag }}

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -31,8 +31,10 @@ FROM python:3.8-alpine3.11 as common
 
 # copy libraries from build stage (This won't copy redundant libraries we used in BuildStage)
 COPY --from=BuildStage /usr/local /usr/local
+
+ARG rookout
 # needed for rookout
-RUN apk add g++ python3-dev linux-headers
+RUN if [ "$rookout" = "" ]; then echo "Skipping rookout deps"; else apk add --update --no-cache g++ python3-dev linux-headers; fi
 
 # Add non-root user
 RUN addgroup -S opal && adduser -S opal -G opal -h /opal


### PR DESCRIPTION
Example (dry run): [https://github.com/permitio/opal/runs/6921534753](https://github.com/permitio/opal/runs/6921534753)

The release job would create 2 version tags for each opal container:
* `x.y.z` / `latest` - without rookout dependencies
* `x.y.z-rookout` / `latest-rookout` - with rookout dependencies

This is controlled by a build arg in the Dockerfile