### PR TITLE
Rk/python3.10 image base

### DIFF
--- a/.github/workflows/on_release.yml
+++ b/.github/workflows/on_release.yml
@@ -28,10 +28,6 @@ jobs:
   # - Runs only if test phase completes with no errors.
   # - Pushes images (built at BUILD PHASE) to docker hub.
   docker_build_and_publish:
-    strategy:
-      matrix:
-        suffix: ["","-rookout"]
-
     runs-on: ubuntu-latest
     steps:
       # BUILD PHASE
@@ -46,19 +42,15 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
 
-      - name: Set latest tag
-        run: |
-          echo "opal_latest_tag=latest${{ matrix.suffix }}" >> $GITHUB_ENV
-
       - name: Get version tag from github release
         if: github.event_name == 'release' && github.event.action == 'created'
         run: |
-          echo "opal_version_tag=${{ github.event.release.tag_name }}${{ matrix.suffix }}" >> $GITHUB_ENV
+          echo "opal_version_tag=${{ github.event.release.tag_name }}" >> $GITHUB_ENV
 
       - name: Get version tag from git history
         if: ${{ !(github.event_name == 'release' && github.event.action == 'created') }}
         run: |
-          echo "opal_version_tag=$(git describe --tags --abbrev=0)${{ matrix.suffix }}" >> $GITHUB_ENV
+          echo "opal_version_tag=$(git describe --tags --abbrev=0)" >> $GITHUB_ENV
 
       - name: Echo version tag
         run: |
@@ -71,14 +63,12 @@ jobs:
           file: docker/Dockerfile
           push: false
           target: client
-          cache-from: type=registry,ref=permitio/opal-client:${{ env.opal_latest_tag }}
+          cache-from: type=registry,ref=permitio/opal-client:latest
           cache-to: type=inline
           load: true
-          build-args: |
-            rookout=${{ matrix.suffix }}
           tags: |
             permitio/opal-client:test
-            permitio/opal-client:${{ env.opal_latest_tag }}
+            permitio/opal-client:latest
             permitio/opal-client:${{ env.opal_version_tag }}
 
       - name: Build client-standalone
@@ -88,12 +78,12 @@ jobs:
           file: docker/Dockerfile
           push: false
           target: client-standalone
-          cache-from: type=registry,ref=permitio/opal-client-standalone:${{ env.opal_latest_tag }}
+          cache-from: type=registry,ref=permitio/opal-client-standalone:latest
           cache-to: type=inline
           load: true
           tags: |
             permitio/opal-client-standalone:test
-            permitio/opal-client-standalone:${{ env.opal_latest_tag }}
+            permitio/opal-client-standalone:latest
             permitio/opal-client-standalone:${{ env.opal_version_tag }}
 
       - name: Build server
@@ -103,12 +93,12 @@ jobs:
           file: docker/Dockerfile
           push: false
           target: server
-          cache-from: type=registry,ref=permitio/opal-server:${{ env.opal_latest_tag }}
+          cache-from: type=registry,ref=permitio/opal-server:latest
           cache-to: type=inline
           load: true
           tags: |
             permitio/opal-server:test
-            permitio/opal-server:${{ env.opal_latest_tag }}
+            permitio/opal-server:latest
             permitio/opal-server:${{ env.opal_version_tag }}
 
       # TEST PHASE
@@ -139,12 +129,12 @@ jobs:
       # each image is pushed with the versioned tag first, if it succeeds the image is pushed with the latest tag as well.
       - name: Push client
         if: ${{ !(github.event_name == 'workflow_dispatch' && github.event.inputs.dry_run == 'true') }}
-        run: docker push permitio/opal-client:${{ env.opal_version_tag }} && docker push permitio/opal-client:${{ env.opal_latest_tag }}
+        run: docker push permitio/opal-client:${{ env.opal_version_tag }} && docker push permitio/opal-client:latest
 
       - name: Push client-standalone
         if: ${{ !(github.event_name == 'workflow_dispatch' && github.event.inputs.dry_run == 'true') }}
-        run: docker push permitio/opal-client-standalone:${{ env.opal_version_tag }} && docker push permitio/opal-client-standalone:${{ env.opal_latest_tag }}
+        run: docker push permitio/opal-client-standalone:${{ env.opal_version_tag }} && docker push permitio/opal-client-standalone:latest
 
       - name: Push server
         if: ${{ !(github.event_name == 'workflow_dispatch' && github.event.inputs.dry_run == 'true') }}
-        run: docker push permitio/opal-server:${{ env.opal_version_tag }} && docker push permitio/opal-server:${{ env.opal_latest_tag }}
+        run: docker push permitio/opal-server:${{ env.opal_version_tag }} && docker push permitio/opal-server:latest

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,17 +1,7 @@
 # BUILD STAGE ---------------------------------------
 # split this stage to save time and reduce image size
 # ---------------------------------------------------
-# NOTE: at the moment we use alpine3.11 instead of alpine latest
-# due to https://github.com/gliderlabs/docker-alpine/issues/539
-# which broke alpine dns lookup methods starting at alpine 3.12.
-FROM python:3.8-alpine3.11 as BuildStage
-# update apk cache
-RUN apk update
-# TODO: remove this when upgrading to a new alpine version
-# more details: https://github.com/pyca/cryptography/issues/5771
-ENV CRYPTOGRAPHY_DONT_BUILD_RUST=1
-# install linux libraries necessary to compile some python packages
-RUN apk add --update --no-cache --virtual .build-deps gcc git build-base alpine-sdk python3-dev musl-dev postgresql-dev libffi-dev libressl-dev
+FROM python:3.10 as BuildStage
 # from now on, work in the /app directory
 WORKDIR /app/
 # Layer dependency install (for caching)
@@ -24,20 +14,17 @@ RUN pip install --no-cache-dir --upgrade pip && pip install --no-cache-dir -r ./
 
 # COMMON IMAGE --------------------------------------
 # ---------------------------------------------------
-# NOTE: at the moment we use alpine3.11 instead of alpine latest
-# due to https://github.com/gliderlabs/docker-alpine/issues/539
-# which broke alpine dns lookup methods starting at alpine 3.12.
-FROM python:3.8-alpine3.11 as common
+FROM python:3.10-slim as common
 
 # copy libraries from build stage (This won't copy redundant libraries we used in BuildStage)
 COPY --from=BuildStage /usr/local /usr/local
 
-ARG rookout
+# ARG rookout
 # needed for rookout
-RUN if [ "$rookout" = "" ]; then echo "Skipping rookout deps"; else apk add --update --no-cache g++ python3-dev linux-headers; fi
+# RUN if [ "$rookout" = "" ]; then echo "Skipping rookout deps"; else apk add --update --no-cache g++ python3-dev linux-headers; fi
 
-# Add non-root user
-RUN addgroup -S opal && adduser -S opal -G opal -h /opal
+# Add non-root user (with home dir at /opal)
+RUN useradd -m -b / -s /bin/bash opal
 WORKDIR /opal
 
 # copy wait-for script (create link at old path to maintain backward compatibility)
@@ -90,8 +77,9 @@ FROM client-standalone as client
 
 # Temporarily move back to root for additional setup
 USER root
-# curl is needed for next section
-RUN apk add --update --no-cache curl
+
+RUN apt-get update && apt-get install -y curl && apt-get clean
+
 # copy opa from official image (main binary and lib for web assembly)
 RUN curl -L -o ./opa https://openpolicyagent.org/downloads/latest/opa_linux_amd64_static && chmod 755 ./opa
 # enable inline OPA
@@ -104,10 +92,11 @@ USER opal
 # SERVER IMAGE --------------------------------------
 # ---------------------------------------------------
 FROM common as server
-# git is needed by opal server (for policy repo tracking)
-RUN apk add --update --no-cache git openssh
+
+RUN apt-get update && apt-get install -y openssh-client git && apt-get clean
 
 USER opal
+
 # Potentially trust POLICY REPO HOST ssh signature --
 # opal trackes a remote (git) repository and fetches policy (e.g rego) from it.
 # however, if the policy repo uses an ssh url scheme, authentication to said repo
@@ -124,7 +113,7 @@ USER opal
 ARG TRUST_POLICY_REPO_HOST_SSH_FINGERPRINT="true"
 ARG POLICY_REPO_HOST="github.com"
 
-RUN if [[ "$TRUST_POLICY_REPO_HOST_SSH_FINGERPRINT" == "true" ]] ; then \
+RUN if [ "$TRUST_POLICY_REPO_HOST_SSH_FINGERPRINT" = "true" ] ; then \
   mkdir -p ~/.ssh && \
   chmod 0700 ~/.ssh && \
   ssh-keyscan -t rsa ${POLICY_REPO_HOST} >> ~/.ssh/known_hosts ; fi

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -19,10 +19,6 @@ FROM python:3.10-slim as common
 # copy libraries from build stage (This won't copy redundant libraries we used in BuildStage)
 COPY --from=BuildStage /usr/local /usr/local
 
-# ARG rookout
-# needed for rookout
-# RUN if [ "$rookout" = "" ]; then echo "Skipping rookout deps"; else apk add --update --no-cache g++ python3-dev linux-headers; fi
-
 # Add non-root user (with home dir at /opal)
 RUN useradd -m -b / -s /bin/bash opal
 WORKDIR /opal

--- a/docker/docker-compose-example.yml
+++ b/docker/docker-compose-example.yml
@@ -32,7 +32,7 @@ services:
       # configures from where the opal client should initially fetch data (when it first goes up, after disconnection, etc).
       # the data sources represents from where the opal clients should get a "complete picture" of the data they need.
       # after the initial sources are fetched, the client will subscribe only to update notifications sent by the server.
-      - OPAL_DATA_CONFIG_SOURCES={"config":{"entries":[{"url":"http://host.docker.internal:7002/policy-data","topics":["policy_data"],"dst_path":"/static"}]}}
+      - OPAL_DATA_CONFIG_SOURCES={"config":{"entries":[{"url":"http://opal_server:7002/policy-data","topics":["policy_data"],"dst_path":"/static"}]}}
       - OPAL_LOG_FORMAT_INCLUDE_PID=true
     ports:
       # exposes opal server on the host machine, you can access the server at: http://localhost:7002

--- a/packages/opal-server/opal_server/config.py
+++ b/packages/opal-server/opal_server/config.py
@@ -231,6 +231,8 @@ class OpalServerConfig(Confi):
         description="Server is leader or follower",
     )
 
+    SCOPES = confi.bool("SCOPES", default=False)
+
     REDIS_URL = confi.str("REDIS_URL", default="redis://localhost")
 
     BASE_DIR = confi.str("BASE_DIR", default=pathlib.Path.home() / ".local/state/opal")

--- a/packages/opal-server/opal_server/server.py
+++ b/packages/opal-server/opal_server/server.py
@@ -179,8 +179,9 @@ class OpalServer:
 
         self.watcher: Optional[PolicyWatcherTask] = None
 
-        self._redis_db = RedisDB(opal_server_config.REDIS_URL)
-        self._scopes = ScopeRepository(self._redis_db)
+        if opal_server_config.SCOPES:
+            self._redis_db = RedisDB(opal_server_config.REDIS_URL)
+            self._scopes = ScopeRepository(self._redis_db)
 
         # init fastapi app
         self.app: FastAPI = self._init_fast_api_app()
@@ -255,11 +256,13 @@ class OpalServer:
             tags=["Client Load Limiting"],
             dependencies=[Depends(authenticator)],
         )
-        app.include_router(
-            init_scope_router(self._scopes, authenticator),
-            tags=["Scopes"],
-            prefix="/scopes",
-        )
+
+        if opal_server_config.SCOPES:
+            app.include_router(
+                init_scope_router(self._scopes, authenticator),
+                tags=["Scopes"],
+                prefix="/scopes",
+            )
 
         if self.jwks_endpoint is not None:
             # mount jwts (static) route
@@ -302,8 +305,9 @@ class OpalServer:
         return app
 
     async def start(self):
-        await load_scopes(self._scopes)
-        await self.sync_all_scopes()
+        if opal_server_config.SCOPES:
+            await load_scopes(self._scopes)
+            await self.sync_all_scopes()
 
     async def sync_all_scopes(self):
         from opal_server.worker import sync_scope
@@ -368,21 +372,13 @@ class OpalServer:
                                 f"Policy repo will be cloned to: {full_local_repo_path}"
                             )
 
-                            scope = None
-
-                            try:
-                                scope = await self._scopes.get(DEFAULT_SCOPE_ID)
-                            except ScopeNotFoundError:
-                                pass
-
-                            if scope is not None:
-                                self.watcher = setup_watcher_task(
-                                    self.publisher,
-                                    remote_source_url=scope.policy.url,
-                                    ssh_key=scope.policy.auth.private_key,
-                                    branch_name=scope.policy.branch,
-                                    clone_path_finder=clone_path_finder,
-                                )
+                            self.watcher = setup_watcher_task(
+                                self.publisher,
+                                remote_source_url=opal_server_config.POLICY_REPO_URL,
+                                ssh_key=opal_server_config.POLICY_REPO_SSH_KEY,
+                                branch_name=opal_server_config.POLICY_REPO_MAIN_BRANCH,
+                                clone_path_finder=clone_path_finder,
+                            )
                         # the leader listens to the webhook topic (webhook api route can be hit randomly in all workers)
                         # and triggers the watcher to check for changes in the tracked upstream remote.
                         await self.pubsub.endpoint.subscribe(

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -1,4 +1,4 @@
-#! /usr/bin/env sh
+#! /usr/bin/env bash
 set -e
 
 export GUNICORN_CONF=${GUNICORN_CONF:-./gunicorn_conf.py}


### PR DESCRIPTION
- This would fix the snyk issue as we won't longer use the out of date alpine version.
- This drastically reduce the overall image size (actually only comparing to the rookout flavor)
- This makes the rookout flavor redundant as no need to install special deps for `pip install rook` to work.