### PR TITLE
Add dependency on asgiref

### DIFF
--- a/packages/opal-server/requires.txt
+++ b/packages/opal-server/requires.txt
@@ -9,3 +9,4 @@ slowapi>=0.1.5,<1
 aioredis>=2.0.1,<3
 celery>=5.2.7,<6
 pygit2>=1.9.2,<2
+asgiref>=3.5.2,<4


### PR DESCRIPTION
Looks like b100d2f7922eb3404213cac43c18f70a25d12dfd added a dependency on the `asgiref` library, but didn't actually add it to the requires.txt file