### PR TITLE
Read OPAL_LOG_SERIALIZE as boolean

### DIFF
--- a/packages/opal-common/opal_common/config.py
+++ b/packages/opal-common/opal_common/config.py
@@ -27,7 +27,7 @@ class OpalCommonConfig(Confi):
     LOG_TRACEBACK = confi.bool("LOG_TRACEBACK", True)
     LOG_DIAGNOSE = confi.bool("LOG_DIAGNOSE", True)
     LOG_COLORIZE = confi.bool("LOG_COLORIZE", True)
-    LOG_SERIALIZE = confi.str("LOG_SERIALIZE", False)
+    LOG_SERIALIZE = confi.bool("LOG_SERIALIZE", False)
     LOG_SHOW_CODE_LINE = confi.bool("LOG_SHOW_CODE_LINE", True)
     #  - log level
     LOG_LEVEL = confi.str("LOG_LEVEL", "INFO")


### PR DESCRIPTION
This is a proposal to fix the `OPAL_LOG_SERIALIZE` logging flag that is not parsed properly, and thus not taken into account.

### Issue

When setting `OPAL_LOG_SERIALIZE` to `False`, we expect the output logs not to be JSON records (as in the default behavior). But setting it to any value (including `False`) actually enables the JSON output.

This has been reproduced with commit 1fb6b625c4752d9f66286c77eaa0efd4ce11d644 (latest commit as of this writing) and with version 0.1.21 of the published packages.

The following are the output of some test commands to reproduce the error:

```bash
❯ python3 -m opal_server.main
2022-08-02T13:18:44.146965+0200 | opal_server.server                      | INFO  | OPAL was not provided with JWT encryption keys, cannot verify api requests!

❯ OPAL_LOG_SERIALIZE=False python3 -m opal_server.main
{"text": "\u001b[32m2022-08-02T13:19:12.794311+0200\u001b[0m | \u001b[34mopal_server.server                      \u001b[0m|\u001b[1m INFO  | OPAL was not provided with JWT encryption keys, cannot verify api requests!\u001b[0m\n", "record": {"elapsed": {"repr": "0:00:00.574027", "seconds": 0.574027}, "exception": null, "extra": {}, "file": {"name": "server.py", "path": "/Users/tnle/Projects/opal/packages/opal-server/opal_server/server.py"}, "function": "__init__", "level": {"icon": "ℹ️", "name": "INFO", "no": 20}, "line": 137, "message": "OPAL was not provided with JWT encryption keys, cannot verify api requests!", "module": "server", "name": "opal_server.server", "process": {"id": 18631, "name": "MainProcess"}, "thread": {"id": 4540765696, "name": "MainThread"}, "time": {"repr": "2022-08-02 13:19:12.794311+02:00", "timestamp": 1659439152.794311}}}

❯ OPAL_LOG_SERIALIZE=True python3 -m opal_server.main
{"text": "\u001b[32m2022-08-02T13:19:30.285155+0200\u001b[0m | \u001b[34mopal_server.server                      \u001b[0m|\u001b[1m INFO  | OPAL was not provided with JWT encryption keys, cannot verify api requests!\u001b[0m\n", "record": {"elapsed": {"repr": "0:00:00.586565", "seconds": 0.586565}, "exception": null, "extra": {}, "file": {"name": "server.py", "path": "/Users/tnle/Projects/opal/packages/opal-server/opal_server/server.py"}, "function": "__init__", "level": {"icon": "ℹ️", "name": "INFO", "no": 20}, "line": 137, "message": "OPAL was not provided with JWT encryption keys, cannot verify api requests!", "module": "server", "name": "opal_server.server", "process": {"id": 18639, "name": "MainProcess"}, "thread": {"id": 4508702208, "name": "MainThread"}, "time": {"repr": "2022-08-02 13:19:30.285155+02:00", "timestamp": 1659439170.285155}}}
```

### Probable cause

This is most likely due to the `config.py` module in `opal_common`:

```python
LOG_SERIALIZE = confi.str("LOG_SERIALIZE", False)
```

When we don't set the environment variable, the serialization is disabled. But when we do set a value, it is retrieved as a string and passed to loguru which only tests if the value is true-ish (https://github.com/Delgan/loguru/blob/8371e7d1fbd0d12b58457c08f50a4cfc96347aed/loguru/_handler.py#L165).

### Proposed fix

By switching from `str` to `bool`, it seems that the issue is fixed.

The following are the same commands with the fix applied:

```bash
❯ python3 -m opal_server.main
2022-08-02T13:20:02.672285+0200 | opal_server.server                      | INFO  | OPAL was not provided with JWT encryption keys, cannot verify api requests!

❯ OPAL_LOG_SERIALIZE=False python3 -m opal_server.main
2022-08-02T13:20:19.293250+0200 | opal_server.server                      | INFO  | OPAL was not provided with JWT encryption keys, cannot verify api requests!

❯ OPAL_LOG_SERIALIZE=True python3 -m opal_server.main
{"text": "\u001b[32m2022-08-02T13:20:30.754624+0200\u001b[0m | \u001b[34mopal_server.server                      \u001b[0m|\u001b[1m INFO  | OPAL was not provided with JWT encryption keys, cannot verify api requests!\u001b[0m\n", "record": {"elapsed": {"repr": "0:00:00.568569", "seconds": 0.568569}, "exception": null, "extra": {}, "file": {"name": "server.py", "path": "/Users/tnle/Projects/opal/packages/opal-server/opal_server/server.py"}, "function": "__init__", "level": {"icon": "ℹ️", "name": "INFO", "no": 20}, "line": 137, "message": "OPAL was not provided with JWT encryption keys, cannot verify api requests!", "module": "server", "name": "opal_server.server", "process": {"id": 18715, "name": "MainProcess"}, "thread": {"id": 4576892416, "name": "MainThread"}, "time": {"repr": "2022-08-02 13:20:30.754624+02:00", "timestamp": 1659439230.754624}}}
```