### PR TITLE
Add retry options for the policy store

### DIFF
--- a/packages/opal-client/opal_client/config.py
+++ b/packages/opal-client/opal_client/config.py
@@ -1,6 +1,7 @@
 from enum import Enum
 
 from opal_client.opa.options import OpaServerOptions
+from opal_client.policy_store.options import PolicyStoreConnRetryOptions
 from opal_client.policy_store.schemas import PolicyStoreTypes
 from opal_common.confi import Confi, confi
 from opal_common.config import opal_common_config
@@ -26,6 +27,12 @@ class OpalClientConfig(Confi):
         "POLICY_STORE_AUTH_TOKEN",
         None,
         description="the authentication (bearer) token OPAL client will use to authenticate against the policy store (i.e: OPA agent)",
+    )
+    POLICY_STORE_CONN_RETRY = confi.model(
+        "POLICY_STORE_CONN_RETRY",
+        PolicyStoreConnRetryOptions,
+        {},  # defaults are being set according to PolicyStoreConnRetryOptions pydantic definitions (see class)
+        description="retry options when connecting to the policy store",
     )
     # create an instance of a policy store upon load
 

--- a/packages/opal-client/opal_client/policy_store/opa_client.py
+++ b/packages/opal-client/opal_client/policy_store/opa_client.py
@@ -11,31 +11,18 @@ from opal_client.policy_store.base_policy_store_client import (
     BasePolicyStoreClient,
     JsonableValue,
 )
-from opal_client.policy_store.options import WaitStrategy
 from opal_client.utils import proxy_response
 from opal_common.git.bundle_utils import BundleUtils
 from opal_common.opa.parsing import get_rego_package
 from opal_common.schemas.policy import DataModule, PolicyBundle
 from opal_common.schemas.store import JSONPatchAction, StoreTransaction, TransactionType
 from pydantic import BaseModel
-from tenacity import retry, stop_after_attempt, wait_exponential, wait_fixed
+from tenacity import retry
 
 JSONPatchDocument = List[JSONPatchAction]
 
 
-def fetchRetryConfig():
-    config = opal_client_config.POLICY_STORE_CONN_RETRY
-    wait_strategy = config.wait_strategy
-    wait_time = config.wait_time
-    attempts = config.attempts
-    if wait_strategy == WaitStrategy.exponential:
-        wait = wait_exponential(multiplier=wait_time)
-    else:
-        wait = wait_fixed(wait_time)
-    return dict(wait=wait, stop=stop_after_attempt(attempts))
-
-
-RETRY_CONFIG = fetchRetryConfig()
+RETRY_CONFIG = opal_client_config.POLICY_STORE_CONN_RETRY.toTenacityConfig()
 
 
 def fail_silently(fallback=None):

--- a/packages/opal-client/opal_client/policy_store/opa_client.py
+++ b/packages/opal-client/opal_client/policy_store/opa_client.py
@@ -11,18 +11,31 @@ from opal_client.policy_store.base_policy_store_client import (
     BasePolicyStoreClient,
     JsonableValue,
 )
+from opal_client.policy_store.options import WaitStrategy
 from opal_client.utils import proxy_response
 from opal_common.git.bundle_utils import BundleUtils
 from opal_common.opa.parsing import get_rego_package
 from opal_common.schemas.policy import DataModule, PolicyBundle
 from opal_common.schemas.store import JSONPatchAction, StoreTransaction, TransactionType
 from pydantic import BaseModel
-from tenacity import retry, stop_after_attempt, wait_fixed
+from tenacity import retry, stop_after_attempt, wait_exponential, wait_fixed
 
 JSONPatchDocument = List[JSONPatchAction]
 
-# 2 retries with 2 seconds apart
-RETRY_CONFIG = dict(wait=wait_fixed(2), stop=stop_after_attempt(2))
+
+def fetchRetryConfig():
+    config = opal_client_config.POLICY_STORE_CONN_RETRY
+    wait_strategy = config.wait_strategy
+    wait_time = config.wait_time
+    attempts = config.attempts
+    if wait_strategy == WaitStrategy.exponential:
+        wait = wait_exponential(multiplier=wait_time)
+    else:
+        wait = wait_fixed(wait_time)
+    return dict(wait=wait, stop=stop_after_attempt(attempts))
+
+
+RETRY_CONFIG = fetchRetryConfig()
 
 
 def fail_silently(fallback=None):

--- a/packages/opal-client/opal_client/policy_store/options.py
+++ b/packages/opal-client/opal_client/policy_store/options.py
@@ -1,0 +1,20 @@
+from enum import Enum
+
+from pydantic import BaseModel, Field
+
+
+class WaitStrategy(str, Enum):
+    fixed = "fixed"
+    exponential = "exponential"
+
+
+class PolicyStoreConnRetryOptions(BaseModel):
+    wait_strategy: WaitStrategy = Field(
+        WaitStrategy.fixed,
+        description="waiting strategy (e.g. fixed for fixed-time waiting, exponential for exponential backoff) (default fixed)",
+    )
+    wait_time: float = Field(
+        2,
+        description="waiting time in seconds (semantic depends on the waiting strategy) (default 2)",
+    )
+    attempts: int = Field(2, description="number of attempts (default 2)")


### PR DESCRIPTION
This PR is a basic attempt at resolving #281.

The default retry options are the currently existing ones before this PR (i.e. 2 attempts 2 s apart).

Example of a retry configuration:
```bash
OPAL_POLICY_STORE_CONN_RETRY='{"wait_time": 4, "wait_strategy": "exponential", "attempts": 10}'
```