### PR TITLE
Add redis dependency to OPAL

### DIFF
--- a/packages/opal-server/requires.txt
+++ b/packages/opal-server/requires.txt
@@ -10,3 +10,4 @@ aioredis>=2.0.1,<3
 celery>=5.2.7,<6
 pygit2>=1.9.2,<2
 asgiref>=3.5.2,<4
+redis>=4.3.4,<5


### PR DESCRIPTION
I think it was installed implicitly before from celery, but not anymore?