### PR TITLE
Data source refresh

### DIFF
--- a/packages/opal-common/opal_common/schemas/data.py
+++ b/packages/opal-common/opal_common/schemas/data.py
@@ -1,4 +1,5 @@
 from logging import basicConfig
+from pydoc import describe
 from typing import Any, Dict, List, Optional, Tuple, Union
 
 from opal_common.fetcher.events import FetcherConfig
@@ -33,6 +34,15 @@ class DataSourceEntry(BaseModel):
         "PUT", description="Method used to write into OPA - PUT/PATCH"
     )
 
+class DataSourceEntryWithPollingInterval(DataSourceEntry):
+
+    # Periodic Update Interval
+    # If set, tells OPAL server how frequently to send message to clients that they need to refresh their data store from a data source
+    # Time in Seconds
+    periodic_update_interval: int = Field(
+        None,
+        description="Polling interval to refresh data from data source"
+    )
 
 class DataSourceConfig(BaseModel):
     """Static list of Data Source Entries returned to client.
@@ -42,7 +52,7 @@ class DataSourceConfig(BaseModel):
     updates)
     """
 
-    entries: List[DataSourceEntry] = Field(
+    entries: List[DataSourceEntryWithPollingInterval] = Field(
         ..., description="list of data sources and how to fetch from them"
     )
 

--- a/packages/opal-common/opal_common/schemas/data.py
+++ b/packages/opal-common/opal_common/schemas/data.py
@@ -39,7 +39,7 @@ class DataSourceEntryWithPollingInterval(DataSourceEntry):
     # Periodic Update Interval
     # If set, tells OPAL server how frequently to send message to clients that they need to refresh their data store from a data source
     # Time in Seconds
-    periodic_update_interval: int = Field(
+    periodic_update_interval: Optional[int] = Field(
         None,
         description="Polling interval to refresh data from data source"
     )

--- a/packages/opal-common/opal_common/schemas/data.py
+++ b/packages/opal-common/opal_common/schemas/data.py
@@ -34,15 +34,16 @@ class DataSourceEntry(BaseModel):
         "PUT", description="Method used to write into OPA - PUT/PATCH"
     )
 
+
 class DataSourceEntryWithPollingInterval(DataSourceEntry):
 
     # Periodic Update Interval
     # If set, tells OPAL server how frequently to send message to clients that they need to refresh their data store from a data source
     # Time in Seconds
     periodic_update_interval: Optional[float] = Field(
-        None,
-        description="Polling interval to refresh data from data source"
+        None, description="Polling interval to refresh data from data source"
     )
+
 
 class DataSourceConfig(BaseModel):
     """Static list of Data Source Entries returned to client.

--- a/packages/opal-common/opal_common/schemas/data.py
+++ b/packages/opal-common/opal_common/schemas/data.py
@@ -39,7 +39,7 @@ class DataSourceEntryWithPollingInterval(DataSourceEntry):
     # Periodic Update Interval
     # If set, tells OPAL server how frequently to send message to clients that they need to refresh their data store from a data source
     # Time in Seconds
-    periodic_update_interval: Optional[int] = Field(
+    periodic_update_interval: Optional[float] = Field(
         None,
         description="Polling interval to refresh data from data source"
     )

--- a/packages/opal-server/opal_server/data/data_update_publisher.py
+++ b/packages/opal-server/opal_server/data/data_update_publisher.py
@@ -127,3 +127,13 @@ class DataUpdatePublisher:
                     updaters.append(repeat_every(seconds=source.periodic_update_interval, wait_first=True, logger=logger)(bind_for_repeat))
 
             return updaters
+
+    @staticmethod
+    async def mount_and_start_polling_updates(publisher: TopicPublisher, sources: ServerDataSourceConfig):
+        logger.info(
+            "[{pid}] Starting Polling Updates",
+            pid=os.getpid()
+        )
+        data_publisher = DataUpdatePublisher(publisher)
+        for polling_update in data_publisher.create_polling_updates(sources):
+            await polling_update()

--- a/packages/opal-server/opal_server/data/data_update_publisher.py
+++ b/packages/opal-server/opal_server/data/data_update_publisher.py
@@ -98,13 +98,10 @@ class DataUpdatePublisher:
 
     def create_polling_updates(self, sources: ServerDataSourceConfig):
         #For every entry with a non zero period update interval, bind an inverval to it
-        updaters = []
         if hasattr(sources, "entries"):
-            for source in filter(lambda s: s.periodic_update_interval > 0, sources.entries):
-                # force PUT
-                source.save_method = "PUT"
-                updater = repeat_every(lambda :
-                    self.publish_data_updates(self, source)
-                , source.periodic_update_interval)
-                updaters.append(updater)
+            updaters = [
+                repeat_every(lambda :
+                    self.publish_data_updates(self, source),
+                source.periodic_update_interval, True, logger) for source in sources if hasattr(source, 'periodic_update_interval')
+            ]
             return updaters

--- a/packages/opal-server/opal_server/data/data_update_publisher.py
+++ b/packages/opal-server/opal_server/data/data_update_publisher.py
@@ -96,12 +96,16 @@ class DataUpdatePublisher:
         )
         self._publisher.publish(all_topic_combos, update)
 
+    def _periodic_update_callback(self, update: DataUpdate):
+        """Called for every periodic update based on repeat_every
+        """
+        self.publish_data_updates(update)
+
     def create_polling_updates(self, sources: ServerDataSourceConfig):
         #For every entry with a non zero period update interval, bind an inverval to it
         if hasattr(sources, "entries"):
             updaters = [
-                repeat_every(lambda :
-                    self.publish_data_updates(self, source),
+                repeat_every(self._periodic_update_callback(self, source),
                 source.periodic_update_interval, True, logger) for source in sources if hasattr(source, 'periodic_update_interval')
             ]
             return updaters

--- a/packages/opal-server/opal_server/server.py
+++ b/packages/opal-server/opal_server/server.py
@@ -361,7 +361,9 @@ class OpalServer:
                             pid=os.getpid(),
                         )
                         #bind data updater publishers to lead worker
-                        [await fn() for fn in DataUpdatePublisher(self.publisher).create_polling_updates(opal_server_config.DATA_CONFIG_SOURCES)]
+                        data_publisher = DataUpdatePublisher(self.publisher)
+                        for polling_update in data_publisher.create_polling_updates(opal_server_config.DATA_CONFIG_SOURCES):
+                            await polling_update()
 
                         # init policy watcher
                         if self.watcher is None:

--- a/packages/opal-server/opal_server/server.py
+++ b/packages/opal-server/opal_server/server.py
@@ -361,9 +361,7 @@ class OpalServer:
                             pid=os.getpid(),
                         )
                         #bind data updater publishers to lead worker
-                        data_publisher = DataUpdatePublisher(self.publisher)
-                        for polling_update in data_publisher.create_polling_updates(opal_server_config.DATA_CONFIG_SOURCES):
-                            await polling_update()
+                        await DataUpdatePublisher.mount_and_start_polling_updates(self.publisher, opal_server_config.DATA_CONFIG_SOURCES)
 
                         # init policy watcher
                         if self.watcher is None:

--- a/packages/opal-server/opal_server/server.py
+++ b/packages/opal-server/opal_server/server.py
@@ -6,6 +6,7 @@ from functools import partial
 from typing import List, Optional
 
 from fastapi import Depends, FastAPI
+from fastapi_utils.tasks import repeat_every
 from fastapi_websocket_pubsub.event_broadcaster import EventBroadcasterContextManager
 from opal_common.authentication.deps import JWTAuthenticator, StaticBearerAuthenticator
 from opal_common.authentication.signer import JWTSigner
@@ -40,8 +41,6 @@ from opal_server.security.api import init_security_router
 from opal_server.security.jwks import JwksStaticEndpoint
 from opal_server.statistics import OpalStatistics, init_statistics_router
 from opal_server.worker import schedule_sync_all_scopes
-from fastapi_utils.tasks import repeat_every
-
 
 
 class OpalServer:
@@ -275,7 +274,6 @@ class OpalServer:
         # top level routes (i.e: healthchecks)
         @app.get("/healthcheck", include_in_schema=False)
         @app.get("/", include_in_schema=False)
-
         def healthcheck():
             return {"status": "ok"}
 
@@ -355,13 +353,15 @@ class OpalServer:
                             "listening on webhook topic: '{topic}'",
                             topic=opal_server_config.POLICY_REPO_WEBHOOK_TOPIC,
                         )
-                          #the leader should be the only one to constantly push data config pushes to clients
+                        # the leader should be the only one to constantly push data config pushes to clients
                         logger.info(
                             "Binding data update publisher to: {pid}",
                             pid=os.getpid(),
                         )
-                        #bind data updater publishers to lead worker
-                        await DataUpdatePublisher.mount_and_start_polling_updates(self.publisher, opal_server_config.DATA_CONFIG_SOURCES)
+                        # bind data updater publishers to lead worker
+                        await DataUpdatePublisher.mount_and_start_polling_updates(
+                            self.publisher, opal_server_config.DATA_CONFIG_SOURCES
+                        )
 
                         # init policy watcher
                         if self.watcher is None:

--- a/packages/opal-server/opal_server/server.py
+++ b/packages/opal-server/opal_server/server.py
@@ -273,6 +273,8 @@ class OpalServer:
         # top level routes (i.e: healthchecks)
         @app.get("/healthcheck", include_in_schema=False)
         @app.get("/", include_in_schema=False)
+
+
         def healthcheck():
             return {"status": "ok"}
 
@@ -293,6 +295,8 @@ class OpalServer:
             try:
                 await self.start()
                 self._task = asyncio.create_task(self.start_server_background_tasks())
+                #start pulling tasks
+                DataUpdatePublisher.create_polling_updates(self.publisher, opal_server_config.DATA_CONFIG_SOURCES)
             except Exception:
                 logger.critical("Exception while starting OPAL")
                 traceback.print_exc()

--- a/packages/opal-server/opal_server/server.py
+++ b/packages/opal-server/opal_server/server.py
@@ -353,14 +353,11 @@ class OpalServer:
                             "listening on webhook topic: '{topic}'",
                             topic=opal_server_config.POLICY_REPO_WEBHOOK_TOPIC,
                         )
-                        # the leader should be the only one to constantly push data config pushes to clients
-                        logger.info(
-                            "Binding data update publisher to: {pid}",
-                            pid=os.getpid(),
-                        )
-                        # bind data updater publishers to lead worker
-                        await DataUpdatePublisher.mount_and_start_polling_updates(
-                            self.publisher, opal_server_config.DATA_CONFIG_SOURCES
+                        # bind data updater publishers to the leader worker
+                        asyncio.create_task(
+                            DataUpdatePublisher.mount_and_start_polling_updates(
+                                self.publisher, opal_server_config.DATA_CONFIG_SOURCES
+                            )
                         )
 
                         # init policy watcher

--- a/packages/opal-server/opal_server/server.py
+++ b/packages/opal-server/opal_server/server.py
@@ -274,7 +274,6 @@ class OpalServer:
         @app.get("/healthcheck", include_in_schema=False)
         @app.get("/", include_in_schema=False)
 
-
         def healthcheck():
             return {"status": "ok"}
 

--- a/packages/requires.txt
+++ b/packages/requires.txt
@@ -8,4 +8,4 @@ gunicorn>=20.1.0,<21
 pydantic[email]>=1.9.1,<2
 typing-extensions;python_version<'3.8'
 uvicorn[standard]>=0.17.6,<1
-fastapi-utils>=0.2.1
+fastapi-utils>=0.2.1,<1

--- a/packages/requires.txt
+++ b/packages/requires.txt
@@ -8,3 +8,4 @@ gunicorn>=20.1.0,<21
 pydantic[email]>=1.9.1,<2
 typing-extensions;python_version<'3.8'
 uvicorn[standard]>=0.17.6,<1
+fastapi-utils>=0.2.1


### PR DESCRIPTION
exposes periodic_update_interval on OPAL_DATA_SOURCE_CONFIG to allow for auto PUT data updates from a given source to be generated at a set interval (in seconds) 