### PR TITLE
Support Local Health Checks for OPAL Server

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -89,7 +89,7 @@ USER opal
 # ---------------------------------------------------
 FROM common as server
 
-RUN apt-get update && apt-get install -y openssh-client git && apt-get clean
+RUN apt-get update && apt-get install -y openssh-client git curl && apt-get clean
 
 USER opal
 


### PR DESCRIPTION
**The issue:**
When deploying permitio/opal-server container in ECS Fargate as a service, the task definition provides the abillity to set up a health check. The simplist way to do this would be: `curl -f http://localhost:7002/healthcheck || exit 1`.  When I run this command in the container I get: `/bin/sh: 1: curl: Permission denied.`  When I do the exact same setup for the permitio/opal-client container (with the change in port to 7000) and run it, the curl command works as expected. 

**The proposed solution:**
Add the `curl` package to the permitio/opal-server image.  

**Testing**
1. made the change to the docker file
2. ran `make docker-build-server`
3. ran `make docker-run-server`
4. In the shell for the container run `curl http://localhost:7002/healthcheck` and verify a 200 status code is returned