### PR TITLE
Implement usage of save_method patch and delete (based on #312)

### DIFF
--- a/packages/opal-client/opal_client/data/updater.py
+++ b/packages/opal-client/opal_client/data/updater.py
@@ -33,7 +33,7 @@ from opal_common.schemas.data import (
     DataUpdateReport,
     HttpMethodsAllowed,
 )
-from opal_common.schemas.store import TransactionType, JSONPatchAction
+from opal_common.schemas.store import JSONPatchAction, TransactionType
 from opal_common.security.sslcontext import get_custom_ssl_context
 from opal_common.utils import get_authorization_header
 
@@ -398,7 +398,9 @@ class DataUpdater:
                     )
                     try:
                         if entry.save_method == HttpMethodsAllowed.PATCH:
-                            patch_data = [JSONPatchAction(**action) for action in policy_data]
+                            patch_data = [
+                                JSONPatchAction(**action) for action in policy_data
+                            ]
                             await store_transaction.patch_policy_data(
                                 patch_data, path=policy_store_path
                             )

--- a/packages/opal-client/opal_client/policy_store/base_policy_store_client.py
+++ b/packages/opal-client/opal_client/policy_store/base_policy_store_client.py
@@ -51,7 +51,7 @@ class AbstractPolicyStore:
     ):
         raise NotImplementedError()
 
-    async def patch_policy_data(
+    async def patch_data(
         self,
         patch_document: Dict[str, Any],
         path: str,

--- a/packages/opal-client/opal_client/policy_store/base_policy_store_client.py
+++ b/packages/opal-client/opal_client/policy_store/base_policy_store_client.py
@@ -51,10 +51,10 @@ class AbstractPolicyStore:
     ):
         raise NotImplementedError()
 
-    async def patch_data(
+    async def patch_policy_data(
         self,
-        path: str,
         patch_document: Dict[str, Any],
+        path: str,
         transaction_id: Optional[str] = None,
     ):
         raise NotImplementedError()

--- a/packages/opal-client/opal_client/policy_store/mock_policy_store_client.py
+++ b/packages/opal-client/opal_client/policy_store/mock_policy_store_client.py
@@ -70,10 +70,10 @@ class MockPolicyStoreClient(BasePolicyStoreClient):
         else:
             del self._data[path]
 
-    async def patch_data(
+    async def patch_policy_data(
         self,
-        path: str,
         patch_document: Dict[str, Any],
+        path: str,
         transaction_id: Optional[str] = None,
     ):
         pass

--- a/packages/opal-client/opal_client/policy_store/mock_policy_store_client.py
+++ b/packages/opal-client/opal_client/policy_store/mock_policy_store_client.py
@@ -70,7 +70,7 @@ class MockPolicyStoreClient(BasePolicyStoreClient):
         else:
             del self._data[path]
 
-    async def patch_policy_data(
+    async def patch_data(
         self,
         patch_document: Dict[str, Any],
         path: str,

--- a/packages/opal-client/opal_client/policy_store/opa_client.py
+++ b/packages/opal-client/opal_client/policy_store/opa_client.py
@@ -490,10 +490,10 @@ class OpaClient(BasePolicyStoreClient):
                 raise
 
     @affects_transaction
-    async def patch_data(
+    async def patch_policy_data(
         self,
-        path: str,
         patch_document: JSONPatchDocument,
+        path: str,
         transaction_id: Optional[str] = None,
     ):
         path = self._safe_data_module_path(path)

--- a/packages/opal-client/opal_client/policy_store/opa_client.py
+++ b/packages/opal-client/opal_client/policy_store/opa_client.py
@@ -490,7 +490,7 @@ class OpaClient(BasePolicyStoreClient):
                 raise
 
     @affects_transaction
-    async def patch_policy_data(
+    async def patch_data(
         self,
         patch_document: JSONPatchDocument,
         path: str,

--- a/packages/opal-common/opal_common/schemas/data.py
+++ b/packages/opal-common/opal_common/schemas/data.py
@@ -10,10 +10,11 @@ from pydantic import AnyHttpUrl, BaseModel, Field, root_validator
 JsonableValue = Union[Dict[str, Any], List[Any]]
 
 
-class HttpMethodsAllowed(Enum):
-    PUT = "put"
-    PATCH = "patch"
-    DELETE = "delete"
+class HttpMethodsAllowed(str, Enum):
+    PUT = "PUT"
+    PATCH = "PATCH"
+    DELETE = "DELETE"
+
 
 class DataSourceEntry(BaseModel):
     """

--- a/packages/opal-common/opal_common/schemas/data.py
+++ b/packages/opal-common/opal_common/schemas/data.py
@@ -1,3 +1,4 @@
+from enum import Enum
 from logging import basicConfig
 from pydoc import describe
 from typing import Any, Dict, List, Optional, Tuple, Union
@@ -8,6 +9,11 @@ from pydantic import AnyHttpUrl, BaseModel, Field, root_validator
 
 JsonableValue = Union[Dict[str, Any], List[Any]]
 
+
+class HttpMethodsAllowed(Enum):
+    PUT = "put"
+    PATCH = "patch"
+    DELETE= "delete"
 
 class DataSourceEntry(BaseModel):
     """
@@ -30,8 +36,8 @@ class DataSourceEntry(BaseModel):
     # How to save the data
     # see https://www.openpolicyagent.org/docs/latest/rest-api/#data-api path is the path nested under <OPA_SERVER>/<version>/data
     dst_path: str = Field("", description="OPA data api path to store the document at")
-    save_method: str = Field(
-        "PUT", description="Method used to write into OPA - PUT/PATCH"
+    save_method: HttpMethodsAllowed = Field(
+        HttpMethodsAllowed.PUT, description="Method used to write into OPA - PUT/PATCH"
     )
 
 

--- a/packages/opal-common/opal_common/schemas/data.py
+++ b/packages/opal-common/opal_common/schemas/data.py
@@ -13,7 +13,7 @@ JsonableValue = Union[Dict[str, Any], List[Any]]
 class HttpMethodsAllowed(Enum):
     PUT = "put"
     PATCH = "patch"
-    DELETE= "delete"
+    DELETE = "delete"
 
 class DataSourceEntry(BaseModel):
     """


### PR DESCRIPTION
(Base on PR by @loan75)

1. Renamed back method in PolicyStoreClient (we use it in other code)
2. Extracted code that calls the Policy Store to a method
3. Added a str base class to HttpMethodsAllowed enum