### PR TITLE
[enh] Add opa_image Dockerfile build argument

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -74,8 +74,9 @@ RUN apk update && apk add skopeo tar
 WORKDIR /opal
 
 # copy opa from official docker image
-ARG opa_image=openpolicyagent/opa:latest-static
-RUN skopeo copy "docker://${opa_image}" docker-archive:./image.tar && \
+ARG opa_image=openpolicyagent/opa
+ARG opa_tag=latest-static
+RUN skopeo copy "docker://${opa_image}:${opa_tag}" docker-archive:./image.tar && \
   mkdir image && tar xf image.tar -C ./image && cat image/*.tar | tar xf - -C ./image -i && \
   find image/ -name "opa*" -type f -executable -print0 | xargs -0 -I "{}" cp {} ./opa && chmod 755 ./opa && \
   rm -r image image.tar

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -74,8 +74,8 @@ RUN apk update && apk add skopeo tar
 WORKDIR /opal
 
 # copy opa from official docker image
-ARG opa_tag=latest-static
-RUN skopeo copy "docker://openpolicyagent/opa:${opa_tag}" docker-archive:./image.tar && \
+ARG opa_image=openpolicyagent/opa:latest-static
+RUN skopeo copy "docker://${opa_image}" docker-archive:./image.tar && \
   mkdir image && tar xf image.tar -C ./image && cat image/*.tar | tar xf - -C ./image -i && \
   find image/ -name "opa*" -type f -executable -print0 | xargs -0 -I "{}" cp {} ./opa && chmod 755 ./opa && \
   rm -r image image.tar


### PR DESCRIPTION
This is an improvement on top of #316 .

This PR changes the `opa_tag` Docker build argument to the `opa_image` Docker build argument.

The `opa_image` build argument allows for arbitrary docker images to be included in the opal standalone client as opposed to only an arbitrary tag. This makes it easier to integrate custom builds of opa within the opal-client by allowing to specify a different docker image repository other than the official `openpolicyagent/opa` repository. Custom opa builds may be needed for custom opa plugin integration.