### PR TITLE
Bugfix/hanging redis lock

### DIFF
--- a/packages/opal-common/opal_common/synchronization/expiring_redis_lock.py
+++ b/packages/opal-common/opal_common/synchronization/expiring_redis_lock.py
@@ -1,0 +1,39 @@
+import asyncio
+
+import aioredis
+from opal_common.logger import logger
+
+
+async def run_locked(
+    redis: aioredis.Redis, lock_name: str, coro: asyncio.coroutine, timeout: int = 10
+):
+    """This function runs a coroutine wrapped in a redis lock, in a way that
+    prevents hanging locks. Hanging locks can happen when a process crashes
+    while holding a lock.
+
+    This function sets a redis enforced timeout, and reacquires the lock every timeout * 0.8 (as long as it runs)
+    """
+    lock = redis.lock(lock_name, timeout=timeout)
+    try:
+        logger.debug(f"Trying to acquire redis lock: {lock_name}")
+        await lock.acquire()
+        logger.debug(f"Acquired lock: {lock_name}")
+
+        locked_task = asyncio.create_task(coro)
+
+        while True:
+            done, _ = await asyncio.wait(
+                (locked_task,),
+                timeout=timeout * 0.8,
+                return_when=asyncio.FIRST_COMPLETED,
+            )
+            if locked_task in done:
+                break
+            else:
+                # Extend lock timeout as long as the coroutine is still running
+                await lock.reacquire()
+                logger.debug(f"Reacquired lock: {lock_name}")
+
+    finally:
+        await lock.release()
+        logger.debug(f"Released lock: {lock_name}")

--- a/packages/opal-server/opal_server/git_fetcher.py
+++ b/packages/opal-server/opal_server/git_fetcher.py
@@ -1,3 +1,4 @@
+import asyncio
 import hashlib
 import shutil
 from pathlib import Path
@@ -16,6 +17,7 @@ from opal_common.schemas.policy_source import (
     GitPolicyScopeSource,
     SSHAuthData,
 )
+from opal_common.synchronization.expiring_redis_lock import run_locked
 from pygit2 import (
     KeypairFromMemory,
     RemoteCallbacks,
@@ -143,15 +145,7 @@ class GitPolicyFetcher(PolicyFetcher):
         locks.
         """
         lock_name = GitPolicyFetcher.source_id(self._source)
-        lock = redis.lock(lock_name)
-        try:
-            logger.info(f"Trying to acquire redis lock: {lock_name}")
-            await lock.acquire()
-            logger.info(f"Acquired lock: {lock_name}")
-            await self.fetch(*args, **kwargs)
-        finally:
-            await lock.release()
-            logger.info(f"Released lock: {lock_name}")
+        await run_locked(redis, lock_name, self.fetch(*args, **kwargs))
 
     async def fetch(self, hinted_hash: Optional[str] = None, force_fetch: bool = False):
         """makes sure the repo is already fetched and is up to date.


### PR DESCRIPTION
This solves the issue of the Redis lock (around the policy git clone) staying hanging forever (preventing new workers from cloning the repo). Probably because the app crashes with segfault before releasing the lock.

My solution is giving the lock an expiration time (enforced by Redis itself), keeping extending this timeout while we wait for fetch to finish. When the app crashes, the lock would expire and not hang forever.

I got this idea from [this library](https://github.com/ionelmc/python-redis-lock) which I had used before to solve a similar issue. But that library isn't async - So I've implemented the same idea myself (Not that complicated anyway).