### PR TITLE
add support for omitting files from bundle

### DIFF
--- a/documentation/docs/getting-started/running-opal/run-opal-server/policy-repo-location.mdx
+++ b/documentation/docs/getting-started/running-opal/run-opal-server/policy-repo-location.mdx
@@ -92,3 +92,21 @@ For these config vars, in most cases you are good with the default values:
     </tr>
   </tbody>
 </table>
+
+#### (Optional) Bundle settings
+
+<table>
+  <tbody>
+    <tr>
+      <th align="left">Env Var Name</th>
+      <th align="left">Function</th>
+    </tr>
+    <tr>
+      <td valign="top">OPAL_BUNDLE_IGNORE</td>
+      <td>
+        Comma separated list of glob paths to omit from policy bundle.
+        Note that double asterisks ** do not recursively match.
+      </td>
+    </tr>
+  </tbody>
+</table>

--- a/packages/opal-common/opal_common/git/commit_viewer.py
+++ b/packages/opal-common/opal_common/git/commit_viewer.py
@@ -110,6 +110,18 @@ def has_extension(f: VersionedFile, extensions: Optional[List[str]] = None) -> b
         return f.path.suffix in extensions
 
 
+def find_ignore_match(path: Path, bundle_ignore: Optional[List[str]]) -> Optional[str]:
+    """Determines the ignore glob path, if any, which matches the given file's path.
+    Returns the matched glob path rather than a binary decision of whether
+    there is a match to enable better logging in the case of matched paths in manifests.
+    """
+    if bundle_ignore != None:
+        for ignore in bundle_ignore:
+            if path.match(ignore):
+                return ignore
+    return None
+
+
 def is_under_directories(f: VersionedFile, directories: Set[Path]) -> bool:
     """a filter on versioned files, filters only files under certain
     directories in the repo."""

--- a/packages/opal-common/opal_common/git/commit_viewer.py
+++ b/packages/opal-common/opal_common/git/commit_viewer.py
@@ -110,12 +110,13 @@ def has_extension(f: VersionedFile, extensions: Optional[List[str]] = None) -> b
         return f.path.suffix in extensions
 
 
-def find_ignore_match(path: Path, bundle_ignore: Optional[List[str]]) -> Optional[str]:
+def find_ignore_match(maybe_path: Path, bundle_ignore: Optional[List[str]]) -> Optional[str]:
     """Determines the ignore glob path, if any, which matches the given file's path.
     Returns the matched glob path rather than a binary decision of whether
     there is a match to enable better logging in the case of matched paths in manifests.
     """
     if bundle_ignore != None:
+        path = Path(maybe_path)
         for ignore in bundle_ignore:
             if path.match(ignore):
                 return ignore

--- a/packages/opal-common/opal_common/git/tests/bundle_maker_test.py
+++ b/packages/opal-common/opal_common/git/tests/bundle_maker_test.py
@@ -362,7 +362,7 @@ def test_bundle_maker_can_ignore_files_using_a_glob_path(local_repo: Repo, helpe
     commit: Commit = repo.head.commit
 
     maker = BundleMaker(
-        repo, in_directories=set([Path(".")]), extensions=OPA_FILE_EXTENSIONS, ignore=["other/**"]
+        repo, in_directories=set([Path(".")]), extensions=OPA_FILE_EXTENSIONS, bundle_ignore=["other/**"]
     )
     bundle: PolicyBundle = maker.make_bundle(commit)
     # assert the bundle is a complete bundle (no old hash, etc)
@@ -390,7 +390,7 @@ def test_bundle_maker_can_ignore_files_using_a_glob_path(local_repo: Repo, helpe
     assert policy_modules[1].package_name == "envoy.http.public"
 
     maker = BundleMaker(
-        repo, in_directories=set([Path(".")]), extensions=OPA_FILE_EXTENSIONS, ignore=["some/*/*/file.rego"]
+        repo, in_directories=set([Path(".")]), extensions=OPA_FILE_EXTENSIONS, bundle_ignore=["some/*/*/file.rego"]
     )
     bundle: PolicyBundle = maker.make_bundle(commit)
     # assert the bundle is a complete bundle (no old hash, etc)
@@ -421,7 +421,7 @@ def test_bundle_maker_can_ignore_files_using_a_glob_path(local_repo: Repo, helpe
     assert policy_modules[1].package_name == "app.rbac"
 
     maker = BundleMaker(
-        repo, in_directories=set([Path(".")]), extensions=OPA_FILE_EXTENSIONS, ignore=["*bac*"]
+        repo, in_directories=set([Path(".")]), extensions=OPA_FILE_EXTENSIONS, bundle_ignore=["*bac*"]
     )
     bundle: PolicyBundle = maker.make_bundle(commit)
     # assert the bundle is a complete bundle (no old hash, etc)

--- a/packages/opal-common/opal_common/schemas/policy_source.py
+++ b/packages/opal-common/opal_common/schemas/policy_source.py
@@ -42,6 +42,7 @@ class BasePolicyScopeSource(BaseSchema):
     extensions: List[str] = Field(
         [".rego", ".json"], description="File extensions to use"
     )
+    bundle_ignore: Optional[List[str]] = Field(None, description="glob paths to omit from bundle")
     manifest: str = Field(".manifest", description="path to manifest file")
     poll_updates: bool = Field(
         False, description="Whether OPAL should check for updates periodically"

--- a/packages/opal-server/opal_server/config.py
+++ b/packages/opal-server/opal_server/config.py
@@ -223,7 +223,7 @@ class OpalServerConfig(Confi):
 
     ALLOWED_ORIGINS = confi.list("ALLOWED_ORIGINS", ["*"])
     OPA_FILE_EXTENSIONS = (".rego", ".json")
-    BUNDLE_IGNORE = None
+    BUNDLE_IGNORE = confi.list("BUNDLE_IGNORE", [])
 
     NO_RPC_LOGS = confi.bool("NO_RPC_LOGS", True)
 

--- a/packages/opal-server/opal_server/config.py
+++ b/packages/opal-server/opal_server/config.py
@@ -223,7 +223,7 @@ class OpalServerConfig(Confi):
 
     ALLOWED_ORIGINS = confi.list("ALLOWED_ORIGINS", ["*"])
     OPA_FILE_EXTENSIONS = (".rego", ".json")
-    OPA_BUNDLE_IGNORE = None
+    BUNDLE_IGNORE = None
 
     NO_RPC_LOGS = confi.bool("NO_RPC_LOGS", True)
 

--- a/packages/opal-server/opal_server/config.py
+++ b/packages/opal-server/opal_server/config.py
@@ -223,6 +223,7 @@ class OpalServerConfig(Confi):
 
     ALLOWED_ORIGINS = confi.list("ALLOWED_ORIGINS", ["*"])
     OPA_FILE_EXTENSIONS = (".rego", ".json")
+    OPA_BUNDLE_IGNORE = None
 
     NO_RPC_LOGS = confi.bool("NO_RPC_LOGS", True)
 

--- a/packages/opal-server/opal_server/git_fetcher.py
+++ b/packages/opal-server/opal_server/git_fetcher.py
@@ -278,6 +278,7 @@ class GitPolicyFetcher(PolicyFetcher):
             {Path(p) for p in self._source.directories},
             extensions=self._source.extensions,
             root_manifest_path=self._source.manifest,
+            bundle_ignore=self._source.bundle_ignore,
         )
         current_head_commit = repo.commit(self._get_current_branch_head())
 

--- a/packages/opal-server/opal_server/policy/bundles/api.py
+++ b/packages/opal-server/opal_server/policy/bundles/api.py
@@ -105,7 +105,7 @@ async def get_policy(
         in_directories=set(input_paths),
         extensions=opal_server_config.OPA_FILE_EXTENSIONS,
         root_manifest_path=opal_server_config.POLICY_REPO_MANIFEST_PATH,
-        ignore=opal_server_config.BUNDLE_IGNORE,
+        bundle_ignore=opal_server_config.BUNDLE_IGNORE,
     )
     # check if commit exist in the repo
     revision = None

--- a/packages/opal-server/opal_server/policy/bundles/api.py
+++ b/packages/opal-server/opal_server/policy/bundles/api.py
@@ -105,7 +105,7 @@ async def get_policy(
         in_directories=set(input_paths),
         extensions=opal_server_config.OPA_FILE_EXTENSIONS,
         root_manifest_path=opal_server_config.POLICY_REPO_MANIFEST_PATH,
-        ignore=opal_server_config.OPA_BUNDLE_IGNORE,
+        ignore=opal_server_config.BUNDLE_IGNORE,
     )
     # check if commit exist in the repo
     revision = None

--- a/packages/opal-server/opal_server/policy/bundles/api.py
+++ b/packages/opal-server/opal_server/policy/bundles/api.py
@@ -105,6 +105,7 @@ async def get_policy(
         in_directories=set(input_paths),
         extensions=opal_server_config.OPA_FILE_EXTENSIONS,
         root_manifest_path=opal_server_config.POLICY_REPO_MANIFEST_PATH,
+        ignore=opal_server_config.OPA_BUNDLE_IGNORE,
     )
     # check if commit exist in the repo
     revision = None

--- a/packages/opal-server/opal_server/policy/watcher/factory.py
+++ b/packages/opal-server/opal_server/policy/watcher/factory.py
@@ -24,6 +24,7 @@ def setup_watcher_task(
     request_timeout: int = None,
     policy_bundle_token: str = None,
     extensions: Optional[List[str]] = None,
+    bundle_ignore: Optional[List[str]] = None,
 ) -> PolicyWatcherTask:
     """Create a PolicyWatcherTask with Git / API policy source defined by env
     vars Load all the defaults from config if called without params.
@@ -39,6 +40,7 @@ def setup_watcher_task(
         request_timeout(int):  how many seconds need to wait until timout
         policy_bundle_token(int):  auth token to include in connections to OPAL server. Defaults to POLICY_BUNDLE_SERVER_TOKEN.
         extensions(list(str), optional):  list of extantions to check when new policy arrive default is OPA_FILE_EXTENSIONS
+        bundle_ignore(list(str), optional):  list of glob paths to use for excluding files from bundle default is OPA_BUNDLE_IGNORE
     """
     # load defaults
     source_type = load_conf_if_none(source_type, opal_server_config.POLICY_SOURCE_TYPE)
@@ -71,6 +73,7 @@ def setup_watcher_task(
         policy_bundle_token, opal_server_config.POLICY_BUNDLE_SERVER_TOKEN
     )
     extensions = load_conf_if_none(extensions, opal_server_config.OPA_FILE_EXTENSIONS)
+    bundle_ignore = load_conf_if_none(extensions, opal_server_config.BUNDLE_IGNORE)
     if source_type == PolicySourceTypes.Git:
         remote_source_url = load_conf_if_none(
             remote_source_url, opal_server_config.POLICY_REPO_URL
@@ -107,7 +110,7 @@ def setup_watcher_task(
         raise ValueError("Unknown value for OPAL_POLICY_SOURCE_TYPE")
     watcher.add_on_new_policy_callback(
         partial(
-            publish_changed_directories, publisher=publisher, file_extensions=extensions
+            publish_changed_directories, publisher=publisher, file_extensions=extensions, bundle_ignore=bundle_ignore
         )
     )
     return PolicyWatcherTask(watcher)


### PR DESCRIPTION
## Changes proposed

Adds support for omitting files in the bundle produced by opal-server. Use the `OPAL_BUNDLE_IGNORE` environment variable to specify a list of comma separated glob paths which if matched will ignore a file from being included in the policy bundle.

## Check List (Check all the applicable boxes)

- [ ] My code follows the code style of this project.
- [X] My change requires changes to the documentation.
- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
- [X] This PR does not contain plagiarized content.
- [X] The title of my pull request is a short description of the requested changes.

## Note to reviewers

Note that due to the current implementation of Path matching globs in the standard library, double asterisks `**` will not be expanded recursively as expected.
