### PR TITLE
Compatibility Fix: Support not setting topics in DATA_CONFIG_SOURCES's entries

### DIFF
--- a/documentation/docs/getting-started/running-opal/run-opal-client/data-topics.mdx
+++ b/documentation/docs/getting-started/running-opal/run-opal-client/data-topics.mdx
@@ -15,6 +15,8 @@ Use this env var to control which topics the client will subscribe to:
 | :--------------- | :---------------------------------------- |
 | OPAL_DATA_TOPICS | data topics delimited by comma (i,e: `,`) |
 
+Topic less data updates from `DATA_CONFIG_SOURCES` (`/data/config`) would be processed by all clients, regardless of this env var.
+
 Example value:
 
 ```sh

--- a/packages/opal-client/opal_client/data/updater.py
+++ b/packages/opal-client/opal_client/data/updater.py
@@ -324,8 +324,8 @@ class DataUpdater:
             entries = [
                 entry
                 for entry in update.entries
-                if entry.topics
-                and not set(entry.topics).isdisjoint(set(self._data_topics))
+                if not entry.topics  # Always process entries with no topics
+                or not set(entry.topics).isdisjoint(set(self._data_topics))
             ]
             urls = [(entry.url, entry.config, entry.data) for entry in entries]
 


### PR DESCRIPTION
This is achieved by making client always process entries with no topics.

I believe the intention was using `ALL_DATA_TOPICS` (=`"policy-data"`) to function as a wildcard topic,
All clients listen to it by default (if `DATA_TOPICS` is not overridden), and the default `DATA_CONFIG_SOURCES` uses it.

But it seems like some users got used to just omitting the `topics` key from their `DATA_CONFIG_SOURCES` - which also worked since there was no enforcement on it being non empty.
[My recent PR](https://github.com/permitio/opal/pull/339) blocked this option as it introduced more enforcement on data entries processing (to solve another bug).
To restore backward compatibility - this PR adds support for processing topic-less data entries.

## Note to reviewers

This solution seems to work, but is not coherent - as PubSub currently doesn't publish updates without topics (and never did AFAIK), so publishing dynamic data updates to server with no topics wouldn't work.  (which means [that PR](https://github.com/permitio/opal/issues/375) would solve the exception but clients still wouldn't get the update)
@orweis What do you think?
