### PR TITLE
Improve usability of topics in data updates

### DIFF
--- a/documentation/docs/FAQ.mdx
+++ b/documentation/docs/FAQ.mdx
@@ -6,12 +6,12 @@ title: FAQ
 ## Slack Community Questions
 
 :::note
-We often get **many questions come up in our Slack community**, which are relevant and might provide answer to others looking to work with OPAL.
-
-Please find them below. Each one will be marked with a specific topic it realates to.
+We often get **many questions in our Slack community**, which are relevant for a most OPAL users Please find a selection of them below.
 :::
 
-## Question
+---
+
+### If I'm using OPAL just for Kubernetes level authorization, what benefits do I get from using OPAL compared to [kube-mgmt](https://github.com/open-policy-agent/kube-mgmt)?
 
 <div
   style={{
@@ -24,18 +24,14 @@ Please find them below. Each one will be marked with a specific topic it realate
     justifyContent: "center",
     color: "white",
     fontWeight: "bolder",
+    fontSize: "0.8rem",
     borderRadius: "4px",
   }}
 >
   Kubernetes
 </div>
 
-### If I'm using OPAL just for Kubernetes level authorization, what benefits do I
-
-get from using OPAL compared to [kube-mgmt](https://github.com/open-policy-agent/kube-mgmt)
-?
-
-## Answer
+#### Answer:
 
 OPAL solves the most pain for application-level authorization; where things move a lot faster than the pace of deployments or infrastructure configurations. But it also shines for usage with Kubernetes. We'll highlight three main points:
 
@@ -50,8 +46,6 @@ OPAL solves the most pain for application-level authorization; where things move
 
    It may be possible to achieve a similar result with K8s Secrets, though there is no current way to do so with kube-mgmt. In addition this would tightly couple (potentially external) services into the k8s configuration.
 
-## Question
-
 ### Can I run the OPAL-server without `OPAL_BROADCAST_URI` ?
 
 <div
@@ -65,18 +59,17 @@ OPAL solves the most pain for application-level authorization; where things move
     justifyContent: "center",
     color: "white",
     fontWeight: "bolder",
+    fontSize: "0.8rem",
     borderRadius: "4px",
   }}
 >
   Networking
 </div>
 
-## Answer
+#### Answer:
 
 Yes, you can potentially choose to run it as a single instance with a single worker in which case you don’t need the broadcaster channel. The broadcaster, AKA the backbone pub-sub, is used to sync between opal-server instances, one instance doesn't require syncing of course.
 This is mainly useful for light-workloads (Where a single worker is enough) and development environments (where you just don't want the hassle of setting up a Kafka / Redis / Postgres service)
-
-## Question
 
 ### Does OPAL provide health-check routes ?
 
@@ -91,21 +84,20 @@ This is mainly useful for light-workloads (Where a single worker is enough) and 
     justifyContent: "center",
     color: "white",
     fontWeight: "bolder",
+    fontSize: "0.8rem",
     borderRadius: "4px",
   }}
 >
   Devops, maintenance and observability
 </div>
 
-## Answer
+#### Answer:
 
 Yes both OPAL-server and OPAL-client serve a health check route at `"/healthcheck"`
 
-## Question
-
 ### How does OPAL guarantee that the policy data is actually in sync with the actual application state. We get that OPAL server publishes updates to OPAL client but is there error correction in place.
 
-## Answer
+#### Answer:
 
 Thanks to the lightweight nature of the OPAL pub/sub channel - clients very quickly learn of changes in the data state even before they have
 the data itself - this allows the **OPAL-clients**, their **data-fetcher components**, their **managed OPA instances**
@@ -116,8 +108,6 @@ state. The simplest form of here is
 - The OPAL client will continue to try and fetch data the data until it gets it (with exponential backoff).
 
 You can read more about the mechanism **[here](/tutorials/healthcheck_policy_and_update_callbacks)**.
-
-## Question
 
 ### We are using the official OPAL postgres data fetcher. When the OPAL Client is being spun up, it will fetch the data from the postgres instance it is connected to. We are concerned that during that spin up phase, if any updates to the data source happen, how is it handled?
 
@@ -132,23 +122,22 @@ You can read more about the mechanism **[here](/tutorials/healthcheck_policy_and
     justifyContent: "center",
     color: "white",
     fontWeight: "bolder",
+    fontSize: "0.8rem",
     borderRadius: "4px",
   }}
 >
   Data Updates
 </div>
 
-## Answer
+#### Answer:
 
 Once connected, the OPAL-client will start tracking data update events that you send and handle them. It does so
 from the start even before getting the first base data - and will process the events in order - so you don't need
 to track them specifically.
 
-## Question
-
 ### Does the client fetch the update messages from the OPAL Server and re-run them after it builds the initial state?
 
-## Answer
+#### Answer:
 
 The client does not re-run, but more correctly spins tasks to update as events come, and processes them once possible.
 Usually loading the client is pretty fast, so we haven't encountered issues here. In general this is not a pure OPAL problem
@@ -157,9 +146,7 @@ but a general multi process read/write sync challenge. If it is an issue for you
 - Create a clone source where clients get their base data set, instead of working directly with the rapidly changing data source (this can be another OPA+OPAL instance for example - almost like a master node)
 - Temporarily lock access to the database for writing until the client is ready - (reader/writer lock pattern)
 
-## Question
-
-### I'm configuring OPAL to run with a kafka backbone. We have an existing kafka setup using SASL authentication. I can't see any examples for configuring this with authentication. What's the best way to achieve this?
+#### I'm configuring OPAL to run with a kafka backbone. We have an existing kafka setup using SASL authentication. I can't see any examples for configuring this with authentication. What's the best way to achieve this?
 
 <div
   style={{
@@ -172,13 +159,14 @@ but a general multi process read/write sync challenge. If it is an issue for you
     justifyContent: "center",
     color: "white",
     fontWeight: "bolder",
+    fontSize: "0.8rem",
     borderRadius: "4px",
   }}
 >
   Security
 </div>
 
-## Answer
+### Answer:
 
 At a glance it seems the current broadcaster Kafka backend doesn't support SASL. You can read more [here](https://github.com/permitio/broadcaster/blob/master/broadcaster/_backends/kafka.py).
 Unless there is a way to pass this configuration via URL to the underlying Kafka consumer.
@@ -191,33 +179,33 @@ I would suggest one of the following:
 - Use a Kafka proxy to add the needed params - e.g. [kafka-proxy](https://github.com/grepplabs/kafka-proxy).
 - Open an issue on our GitHub requesting we do item #1 for you; and we will do our best to prioritize it.
 
-## Question
-
 ### How can I plug data into OPAL?
 
-## Answer
+#### Answer:
 
 OPAL is extensible, its plugin mechanism is called fetchers. With them you can pipe data into OPA from 3rd party sources.
 You can learn more about OPAL fetchers here or simply try to use an [existing one](https://github.com/permitio/opal-fetcher-postgres).
 
-## Question
-
 ### Which is the better mechanism to use for realtime? OPA http.fetch() or OPAL Client fetch module?
 
-## Answer
+#### Answer:
 
 Unless the data source is a very stable ingrained service (part of the core system), and the queries to it are simple
 (low data volume and frequency) - We would always recommend the data fetcher option. It decouples the problem of loading
 data from querying the policy.
 
-## Question
-
 ### How can we trigger the OPAL data fetch from within Rego?
 
-## Answer
+#### Answer:
 
 First of all, you are not really supposed to trigger it from Rego - the idea is usually for it to be async and decoupled
 from the policy itself. Instead, the data source or the service mutating it are the ones sending the triggers to OPAL,
 handling the updates in the background - independent of any policy queries.
 
 That being said, you can technically use `http.send()` to trigger an update - as the API trigger is restful.
+
+### How does OPAL handle the situation when an OPA container is restarted or gets out-of-sync with source system ?
+
+#### Answer:
+
+[See discussion #385 on Github](https://github.com/permitio/opal/discussions/385)

--- a/documentation/docs/getting-started/quickstart/docker-compose-config/opal-server.mdx
+++ b/documentation/docs/getting-started/quickstart/docker-compose-config/opal-server.mdx
@@ -36,6 +36,10 @@ disconnection** from the server etc.
 The data sources specified in the server configuration must always return a complete and up-to-date picture.
 In our example `docker-compose.yml` file, the server is configured to return these data sources directives to the client.
 
+Each data source entry has `topics` to help control which clients should process it.
+The default topic is `"policy_data"` and is used as a default in both the client (for subscription) and the server (for publishing).
+(If publishing to another topic - make sure the client is subscribed to it by setting the `OPAL_DATA_TOPICS` envar)
+
 This is what it looks like:
 
 ```yml

--- a/documentation/docs/getting-started/quickstart/opal-playground/publishing-data-update.mdx
+++ b/documentation/docs/getting-started/quickstart/opal-playground/publishing-data-update.mdx
@@ -74,8 +74,9 @@ So what happened when we published our update with the CLI?
 
 Let's analyze the components of this update. **OPAL data updates** are built to support **your specific use case**.
 
-- You can specify a topic (in our example it was `policy_data`) to **target only specific OPAL clients**; and by extension **specific OPA agents**.
-  This is only logical if each microservice you have has an OPA sidecar of its own and thus different policy/data needs.
+- You can specify a topic (in our example it was `policy_data`, which) to **target only specific OPAL clients**; and by extension **specific OPA agents**.
+  In our example, we used the `policy_data` topic which clients listen to by default (it's also the default topic for updates published with no topics specification).
+  Changing this default is only logical if each microservice you have has an OPA sidecar of its own and thus different policy/data needs.
 
 - OPAL specifies **from where** to fetch the data that changed. In this example we used a free and open API ([`api.country.is`](https://api.country.is))
   that anyone can access, however, it can be **your specific API**, or a **3rd-party API**.

--- a/documentation/docs/getting-started/running-opal/run-opal-server/data-sources.mdx
+++ b/documentation/docs/getting-started/running-opal/run-opal-server/data-sources.mdx
@@ -7,9 +7,10 @@ The OPAL server serves the **base data source configuration** for OPAL client. T
 The data sources configured on the server will be fetched **by the client** every time it decides it needs to fetch the **entire** data configuration (e.g: when the client first loads, after a period of disconnection from the server, etc). This configuration must always point to a complete and up-to-date representation of the data (not a "delta").
 
 You'll need to configure this env var:
-Env Var Name | Function
-:--- | :---
-OPAL_DATA_CONFIG_SOURCES | Directives on **how to fetch** the data configuration we load into OPA cache when OPAL client starts, and **where to put it**.
+
+| Env Var Name             | Function                                                                                                                       |
+| :----------------------- | :----------------------------------------------------------------------------------------------------------------------------- |
+| OPAL_DATA_CONFIG_SOURCES | Directives on **how to fetch** the data configuration we load into OPA cache when OPAL client starts, and **where to put it**. |
 
 #### <a name="encode-data-sources"></a>Data sources config schema
 
@@ -72,6 +73,12 @@ export OPAL_DATA_CONFIG_SOURCES='{"config": {"entries": [{"url": "https://api.pe
 ```
 
 Please be advised, this will not work so great in docker-compose. Docker compose does not know how to deal with env vars that contain spaces, and it treats single quotes (i.e: `''`) as part of the value. But with `docker run` you should be fine.
+
+#### Delegating the sources config to an API server
+
+For more dynamic cases where you'd need different clients to load different sets of data at different times;
+you can have the OPAL-clients be redirected to another server to fetch the configuration.
+See the [details in this tutorial](tutorials/configure_external_data_sources#how-to-configure-an-external-data-source)
 
 #### Security
 

--- a/documentation/docs/getting-started/running-opal/run-opal-server/data-sources.mdx
+++ b/documentation/docs/getting-started/running-opal/run-opal-server/data-sources.mdx
@@ -25,7 +25,7 @@ The **value** of the data sources config variable is a json encoding of the [Ser
             {
                 "url": "https://api.permit.io/v1/policy-config",
                 "topics": [
-                    "policy_data"
+                    ...
                 ],
                 "config": {
                     "headers": {
@@ -45,6 +45,7 @@ Each object in `entries` (schema: [DataSourceEntry](https://github.com/permitio/
 - **From where to fetch:** we tell OPAL client to fetch data from the [Permit.io API](https://api.permit.io/redoc) (specifically, from the `policy-config` endpoint).
 - **how to fetch (optional):** we can direct the client to use a specific configuration when fetching the data, for example here we tell the client to use a specific HTTP Authorization header with a bearer token in order to authenticate to the API.
 - **Where to place the data in OPA cache:** although not specified, this entry uses the default of `/` which means at the root of OPA document hierarchy. You can specify another path with `dst_path` (check the [schema](https://github.com/permitio/opal/blob/master/packages/opal-common/opal_common/schemas/data.py#L8)).
+- **Which clients should fetch:** the entry would be processed only by clients subscribed to one of the specified topics. (If unspecified, the default `policy_data` topic would be used).
 
 #### Encoding this value in an environment variable:
 

--- a/packages/opal-client/opal_client/config.py
+++ b/packages/opal-client/opal_client/config.py
@@ -6,7 +6,7 @@ from opal_client.policy_store.schemas import PolicyStoreTypes
 from opal_common.confi import Confi, confi
 from opal_common.config import opal_common_config
 from opal_common.fetcher.providers.http_fetch_provider import HttpFetcherConfig
-from opal_common.schemas.data import UpdateCallback
+from opal_common.schemas.data import DEFAULT_DATA_TOPIC, UpdateCallback
 
 
 # Opal Client general configuration -------------------------------------------
@@ -149,7 +149,7 @@ class OpalClientConfig(Confi):
 
     DATA_TOPICS = confi.list(
         "DATA_TOPICS",
-        ["policy_data"],
+        [DEFAULT_DATA_TOPIC],
         description="Data topics to subscribe to",
     )
 

--- a/packages/opal-client/opal_client/data/updater.py
+++ b/packages/opal-client/opal_client/data/updater.py
@@ -329,8 +329,13 @@ class DataUpdater:
             ]
             urls = [(entry.url, entry.config, entry.data) for entry in entries]
 
-        # get the data for the update
-        logger.info("Fetching policy data", urls=repr(urls))
+        if len(entries) > 0:
+            logger.info("Fetching policy data", urls=repr(urls))
+        else:
+            logger.warning(
+                "None of the update's entries are designated to subscribed topics"
+            )
+
         # Urls may be None - handle_urls has a default for None
         policy_data_with_urls = await data_fetcher.handle_urls(urls)
         # Save the data from the update

--- a/packages/opal-common/opal_common/schemas/data.py
+++ b/packages/opal-common/opal_common/schemas/data.py
@@ -8,6 +8,8 @@ from pydantic import AnyHttpUrl, BaseModel, Field, root_validator
 
 JsonableValue = Union[Dict[str, Any], List[Any]]
 
+DEFAULT_DATA_TOPIC = "policy_data"
+
 
 class DataSourceEntry(BaseModel):
     """
@@ -26,7 +28,9 @@ class DataSourceEntry(BaseModel):
         description="Suggested fetcher configuration (e.g. auth or method) to fetch data with",
     )
     # How to catalog data
-    topics: List[str] = Field(None, description="topics the data applies to")
+    topics: List[str] = Field(
+        [DEFAULT_DATA_TOPIC], description="topics the data applies to"
+    )
     # How to save the data
     # see https://www.openpolicyagent.org/docs/latest/rest-api/#data-api path is the path nested under <OPA_SERVER>/<version>/data
     dst_path: str = Field("", description="OPA data api path to store the document at")
@@ -36,7 +40,6 @@ class DataSourceEntry(BaseModel):
 
 
 class DataSourceEntryWithPollingInterval(DataSourceEntry):
-
     # Periodic Update Interval
     # If set, tells OPAL server how frequently to send message to clients that they need to refresh their data store from a data source
     # Time in Seconds

--- a/packages/opal-server/opal_server/config.py
+++ b/packages/opal-server/opal_server/config.py
@@ -4,7 +4,7 @@ from enum import Enum
 
 from opal_common.authentication.types import EncryptionKeyFormat
 from opal_common.confi import Confi
-from opal_common.schemas.data import ServerDataSourceConfig
+from opal_common.schemas.data import DEFAULT_DATA_TOPIC, ServerDataSourceConfig
 from opal_common.schemas.webhook import GitWebhookRequestParams
 
 confi = Confi(prefix="OPAL_")
@@ -159,7 +159,7 @@ class OpalServerConfig(Confi):
 
     # Data updates
     ALL_DATA_TOPIC = confi.str(
-        "ALL_DATA_TOPIC", "policy_data", description="Top level topic for data"
+        "ALL_DATA_TOPIC", DEFAULT_DATA_TOPIC, description="Top level topic for data"
     )
     ALL_DATA_ROUTE = confi.str("ALL_DATA_ROUTE", "/policy-data")
     ALL_DATA_URL = confi.str(

--- a/packages/opal-server/opal_server/data/data_update_publisher.py
+++ b/packages/opal-server/opal_server/data/data_update_publisher.py
@@ -87,10 +87,17 @@ class DataUpdatePublisher:
         # Expand the topics for each event to include sub topic combos (e.g. publish 'a/b/c' as 'a' , 'a/b', and 'a/b/c')
         for entry in update.entries:
             topic_combos = []
-            for topic in entry.topics:
-                topic_combos.extend(DataUpdatePublisher.get_topic_combos(topic))
-            entry.topics = topic_combos  # Update entry with the exaustive list, so client won't have to expand it again
-            all_topic_combos.update(topic_combos)
+            if entry.topics:
+                for topic in entry.topics:
+                    topic_combos.extend(DataUpdatePublisher.get_topic_combos(topic))
+                entry.topics = topic_combos  # Update entry with the exaustive list, so client won't have to expand it again
+                all_topic_combos.update(topic_combos)
+            else:
+                logger.warning(
+                    "[{pid}] No topics were provided for the following entry: {entry}",
+                    pid=os.getpid(),
+                    entry=entry,
+                )
 
         # publish all topics with all their sub combinations
         logger.info(


### PR DESCRIPTION
1. Have the default topic (`policy_data`) as a default value for `DataSourceEntry.topics` - To prevent users who have left this empty before from experiencing breaking changes as a result of related bug fixes in 0.4.0
2. Warn at realtime when published entry doesn't have topics, or when client processes data update with no matching entries (this would cover what isn't covered by 1).
3. Fix documentation about topics in data updates.

also fixes #375 