### PR TITLE
Fix broken pre commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,7 +10,7 @@ repos:
     hooks:
       - id: black
   - repo: https://github.com/pycqa/isort
-    rev: 5.10.1
+    rev: 5.12.0
     hooks:
       - id: isort
   - repo: https://github.com/myint/docformatter


### PR DESCRIPTION
## Fixes Issue

Looks like isort is broken, and upgrading to a new version ensures pre-commit hooks are passing.