### PR TITLE
Webhook: Fix not getting notifications from broacaster 

### DIFF
--- a/docker/docker-compose-git-webhook.yml
+++ b/docker/docker-compose-git-webhook.yml
@@ -1,0 +1,62 @@
+version: "3.8"
+services:
+  # When scaling the opal-server to multiple nodes and/or multiple workers, we use
+  # a *broadcast* channel to sync between all the instances of opal-server.
+  # Under the hood, this channel is implemented by encode/broadcaster (see link below).
+  # At the moment, the broadcast channel can be either: postgresdb, redis or kafka.
+  # The format of the broadcaster URI string (the one we pass to opal server as `OPAL_BROADCAST_URI`) is specified here:
+  # https://github.com/encode/broadcaster#available-backends
+  broadcast_channel:
+    image: postgres:alpine
+    environment:
+      - POSTGRES_DB=postgres
+      - POSTGRES_USER=postgres
+      - POSTGRES_PASSWORD=postgres
+  opal_server:
+    # by default we run opal-server from latest official image
+    image: permitio/opal-server:next
+    environment:
+      # the broadcast backbone uri used by opal server workers (see comments above for: broadcast_channel)
+      - OPAL_BROADCAST_URI=postgres://postgres:postgres@broadcast_channel:5432/postgres
+      # number of uvicorn workers to run inside the opal-server container
+      - UVICORN_NUM_WORKERS=4
+      # the git repo hosting our policy
+      # - if this repo is not public, you can pass an ssh key via `OPAL_POLICY_REPO_SSH_KEY`)
+      # - the repo we pass in this example is *public* and acts as an example repo with dummy rego policy
+      # - for more info, see: https://docs.opal.ac/tutorials/track_a_git_repo
+      - OPAL_POLICY_REPO_URL=https://github.com/permitio/opal-example-policy-repo
+      # configures from where the opal client should initially fetch data (when it first goes up, after disconnection, etc).
+      # the data sources represents from where the opal clients should get a "complete picture" of the data they need.
+      # after the initial sources are fetched, the client will subscribe only to update notifications sent by the server.
+      - OPAL_DATA_CONFIG_SOURCES={"config":{"entries":[{"url":"http://opal_server:7002/policy-data","topics":["policy_data"],"dst_path":"/static"}]}}
+      - OPAL_LOG_FORMAT_INCLUDE_PID=true
+      #
+      # Webhook configuration
+      # - To simulate webhook, run the following command:
+      #   curl --request POST 'http://localhost:7002/webhook' --header 'Content-Type: application/json' --header 'x-webhook-token: xxxxx' --data-raw '{"gitEvent":"git.push","repository":{"git_url":"https://github.com/permitio/opal-example-policy-repo"}}'
+      - OPAL_POLICY_REPO_WEBHOOK_SECRET=xxxxx
+      - OPAL_POLICY_REPO_WEBHOOK_PARAMS={"secret_header_name":"x-webhook-token","secret_type":"token","secret_parsing_regex":"(.*)","event_request_key":"gitEvent","push_event_value":"git.push"}
+    ports:
+      # exposes opal server on the host machine, you can access the server at: http://localhost:7002
+      - "7002:7002"
+    depends_on:
+      - broadcast_channel
+  opal_client:
+    # by default we run opal-client from latest official image
+    image: permitio/opal-client:next
+    environment:
+      - OPAL_SERVER_URL=http://opal_server:7002
+      - OPAL_LOG_FORMAT_INCLUDE_PID=true
+      - OPAL_INLINE_OPA_LOG_FORMAT=http
+    ports:
+      # exposes opal client on the host machine, you can access the client at: http://localhost:7000
+      - "7766:7000"
+      # exposes the OPA agent (being run by OPAL) on the host machine
+      # you can access the OPA api that you know and love at: http://localhost:8181
+      # OPA api docs are at: https://www.openpolicyagent.org/docs/latest/rest-api/
+      - "8181:8181"
+    depends_on:
+      - opal_server
+    # this command is not necessary when deploying OPAL for real, it is simply a trick for dev environments
+    # to make sure that opal-server is already up before starting the client.
+    command: sh -c "./wait-for.sh opal_server:7002 --timeout=20 -- ./start.sh"

--- a/packages/opal-server/opal_server/policy/watcher/__init__.py
+++ b/packages/opal-server/opal_server/policy/watcher/__init__.py
@@ -1,1 +1,1 @@
-from .factory import setup_watcher_task, trigger_repo_watcher_pull
+from .factory import setup_watcher_task

--- a/packages/opal-server/opal_server/policy/watcher/factory.py
+++ b/packages/opal-server/opal_server/policy/watcher/factory.py
@@ -1,7 +1,7 @@
 from functools import partial
 from typing import Any, List, Optional
 
-from fastapi_websocket_pubsub import Topic
+from fastapi_websocket_pubsub.pub_sub_server import PubSubEndpoint
 from opal_common.confi.confi import load_conf_if_none
 from opal_common.git.repo_cloner import RepoClonePathFinder
 from opal_common.logger import logger
@@ -15,6 +15,7 @@ from opal_server.policy.watcher.task import PolicyWatcherTask
 
 def setup_watcher_task(
     publisher: TopicPublisher,
+    pubsub_endpoint: PubSubEndpoint,
     source_type: str = None,
     remote_source_url: str = None,
     clone_path_finder: RepoClonePathFinder = None,
@@ -116,15 +117,4 @@ def setup_watcher_task(
             bundle_ignore=bundle_ignore,
         )
     )
-    return PolicyWatcherTask(watcher)
-
-
-async def trigger_repo_watcher_pull(
-    watcher: PolicyWatcherTask, topic: Topic, data: Any
-):
-    """triggers the policy watcher check for changes.
-
-    will trigger a task on the watcher's thread.
-    """
-    logger.info("webhook listener triggered")
-    watcher.trigger()
+    return PolicyWatcherTask(watcher, pubsub_endpoint)

--- a/packages/opal-server/opal_server/server.py
+++ b/packages/opal-server/opal_server/server.py
@@ -28,7 +28,7 @@ from opal_server.data.api import init_data_updates_router
 from opal_server.data.data_update_publisher import DataUpdatePublisher
 from opal_server.loadlimiting import init_loadlimit_router
 from opal_server.policy.bundles.api import router as bundles_router
-from opal_server.policy.watcher import setup_watcher_task, trigger_repo_watcher_pull
+from opal_server.policy.watcher import setup_watcher_task
 from opal_server.policy.watcher.task import PolicyWatcherTask
 from opal_server.policy.webhook.api import init_git_webhook_router
 from opal_server.publisher import setup_broadcaster_keepalive_task
@@ -349,10 +349,7 @@ class OpalServer:
                             "leadership lock acquired, leader pid: {pid}",
                             pid=os.getpid(),
                         )
-                        logger.info(
-                            "listening on webhook topic: '{topic}'",
-                            topic=opal_server_config.POLICY_REPO_WEBHOOK_TOPIC,
-                        )
+
                         # bind data updater publishers to the leader worker
                         asyncio.create_task(
                             DataUpdatePublisher.mount_and_start_polling_updates(
@@ -377,18 +374,13 @@ class OpalServer:
 
                             self.watcher = setup_watcher_task(
                                 self.publisher,
+                                self.pubsub.endpoint,
                                 remote_source_url=opal_server_config.POLICY_REPO_URL,
                                 ssh_key=opal_server_config.POLICY_REPO_SSH_KEY,
                                 branch_name=opal_server_config.POLICY_REPO_MAIN_BRANCH,
                                 clone_path_finder=clone_path_finder,
                             )
 
-                        # the leader listens to the webhook topic (webhook api route can be hit randomly in all workers)
-                        # and triggers the watcher to check for changes in the tracked upstream remote.
-                        await self.pubsub.endpoint.subscribe(
-                            [opal_server_config.POLICY_REPO_WEBHOOK_TOPIC],
-                            partial(trigger_repo_watcher_pull, self.watcher),
-                        )
                         # running the watcher, and waiting until it stops (until self.watcher.signal_stop() is called)
                         async with self.watcher:
                             if self.broadcast_keepalive is not None:


### PR DESCRIPTION
Broadcaster context's wasn't entered - so in case no other subscribers were listening in the leader worker (no connected clients), the webhook notification wasn't processes (thus repo not cloned).

The handling of the webhook topic subscription was moved from `OpalServer` into `PolicyWatcherTask` which is more proper in my estimation.
