### PR TITLE
docker-compose: Fix image tags in webhook example

### DIFF
--- a/docker/docker-compose-git-webhook.yml
+++ b/docker/docker-compose-git-webhook.yml
@@ -14,7 +14,7 @@ services:
       - POSTGRES_PASSWORD=postgres
   opal_server:
     # by default we run opal-server from latest official image
-    image: permitio/opal-server:next
+    image: permitio/opal-server:latest
     environment:
       # the broadcast backbone uri used by opal server workers (see comments above for: broadcast_channel)
       - OPAL_BROADCAST_URI=postgres://postgres:postgres@broadcast_channel:5432/postgres
@@ -43,7 +43,7 @@ services:
       - broadcast_channel
   opal_client:
     # by default we run opal-client from latest official image
-    image: permitio/opal-client:next
+    image: permitio/opal-client:latest
     environment:
       - OPAL_SERVER_URL=http://opal_server:7002
       - OPAL_LOG_FORMAT_INCLUDE_PID=true


### PR DESCRIPTION
Just fixing Opal's image tags in docker/docker-compose-git-webhook.yaml