### PR TITLE
Health check: Fix error in opal-client's health check (Enable tracking OPA transactions without persisting)

### DIFF
--- a/documentation/docs/tutorials/monitoring_opal.mdx
+++ b/documentation/docs/tutorials/monitoring_opal.mdx
@@ -8,9 +8,25 @@ title: Monitoring OPAL
 There are multiple ways you can monitor your OPAL deployment:
 
 - **Logs** - Using the structured logs outputted to stderr by both the OPAL-servers and OPAL-clients
-- [**Health-checks**](/tutorials/healthcheck_policy_and_update_callbacks) - Using the health-checks feature (You can query each OPAL client health-check / or even create a specific Rego policy to query which uses that health-check state)
+- **Health-checks** - OPAL exposes HTTP health check endpoints ([See below](##health-checks))
 - [**Callbacks**](/tutorials/healthcheck_policy_and_update_callbacks#-data-update-callbacks) - Using the callback webhooks feature - having OPAL-clients report their updates
-- **Statistics** - Using the built-in statistics feature in OPAL (See below)
+- **Statistics** - Using the built-in statistics feature in OPAL ([See below](##opal-statistics))
+
+## Health checks
+
+### OPAL Server
+
+opal-server exposes http health check endpoints on `/` & `/healthcheck`. <br/>
+Currently it returns `200 OK` as long as server is up.
+
+### OPAL Client
+
+opal-client exposes http health check endpoints on `/` & `/healthcheck`. <br/>
+The health check returns `200 OK` when both policy and data were successfully loaded into OPA, otherwise `503 Unavailable` is returned
+
+**Notice:** if you don't except your opal-client to load any data into OPA, set `OPAL_DATA_UPDATER_ENABLED: False`, so opal-client could report being healthy.
+
+You can also configure opal-client to store dynamic health status in OPA, [Learn more here](/tutorials/healthcheck_policy_and_update_callbacks)
 
 ## OPAL Statistics
 

--- a/packages/opal-client/opal_client/client.py
+++ b/packages/opal-client/opal_client/client.py
@@ -208,8 +208,7 @@ class OpalClient:
         @app.get("/healthcheck", include_in_schema=False)
         @app.get("/", include_in_schema=False)
         async def healthcheck():
-            resp = await self.policy_store.get_data("/system/opal/healthy")
-            healthy = resp["result"]
+            healthy = await self.policy_store.is_healthy()
 
             if healthy:
                 return JSONResponse(
@@ -336,7 +335,6 @@ class OpalClient:
             await self.policy_store.init_healthcheck_policy(
                 policy_id=healthcheck_policy_relpath,
                 policy_code=healthcheck_policy_code,
-                data_updater_enabled=opal_client_config.DATA_UPDATER_ENABLED,
             )
         except aiohttp.ClientError as err:
             logger.error(

--- a/packages/opal-client/opal_client/policy_store/mock_policy_store_client.py
+++ b/packages/opal-client/opal_client/policy_store/mock_policy_store_client.py
@@ -87,5 +87,5 @@ class MockPolicyStoreClient(BasePolicyStoreClient):
     ):
         pass
 
-    async def persist_transaction(self, transaction: StoreTransaction):
+    async def log_transaction(self, transaction: StoreTransaction):
         pass

--- a/packages/opal-client/opal_client/policy_store/policy_store_client_factory.py
+++ b/packages/opal-client/opal_client/policy_store/policy_store_client_factory.py
@@ -14,7 +14,6 @@ class InvalidPolicyStoreTypeException(Exception):
 
 
 class PolicyStoreClientFactory:
-
     CACHE: Dict[str, BasePolicyStoreClient] = {}
 
     @classmethod
@@ -70,6 +69,7 @@ class PolicyStoreClientFactory:
         oauth_client_id: Optional[str] = None,
         oauth_client_secret: Optional[str] = None,
         oauth_server: Optional[str] = None,
+        data_updater_enabled: Optional[bool] = None,
     ) -> BasePolicyStoreClient:
         """
         Factory method - create a new policy store by type.
@@ -99,6 +99,11 @@ class PolicyStoreClientFactory:
             or opal_client_config.POLICY_STORE_AUTH_OAUTH_CLIENT_SECRET
         )
         oauth_server = oauth_server or opal_client_config.POLICY_STORE_AUTH_OAUTH_SERVER
+        data_updater_enabled = (
+            data_updater_enabled
+            if data_updater_enabled is not None
+            else opal_client_config.DATA_UPDATER_ENABLED
+        )
 
         # OPA
         if PolicyStoreTypes.OPA == store_type:
@@ -111,6 +116,7 @@ class PolicyStoreClientFactory:
                 oauth_client_id=oauth_client_id,
                 oauth_client_secret=oauth_client_secret,
                 oauth_server=oauth_server,
+                data_updater_enabled=data_updater_enabled,
             )
         # MOCK
         elif PolicyStoreTypes.MOCK == store_type:


### PR DESCRIPTION
Currently `opal-client`'s http health check endpoint raises an error whenever `OPAL_OPA_HEALTH_CHECK_POLICY_ENABLED=false`. 

`OPA_HEALTH_CHECK_POLICY` is the name for the feature that makes `opal-client` configure OPA with a policy that reflects its own health status.
We want to make `opal-client`'s health check always available, regardless of the flag.

For that, tracking the status of transactions being made to OPA (thus knowing if opal is actually updating OPA's state) should be separated from storing/persisting that state to OPA as a policy (which should only happen when setting `OPAL_OPA_HEALTH_CHECK_POLICY_ENABLED=true`. )