### PR TITLE
Auto-handle bundle ordering issues when updating OPA (.manifest workaround + handle moving rego files)

### DIFF
--- a/packages/opal-client/opal_client/tests/opa_client_test.py
+++ b/packages/opal-client/opal_client/tests/opa_client_test.py
@@ -1,0 +1,54 @@
+import functools
+import random
+
+import pytest
+from fastapi import Response, status
+from opal_client.policy_store.opa_client import OpaClient
+
+
+@pytest.mark.asyncio
+async def test_attempt_operations_with_postponed_failure_retry():
+    class OrderStrictOps:
+        def __init__(self, loadable=True):
+            self.next_allowed_module = 0
+            self.badly_ordered_bundle = list(range(random.randint(5, 25)))
+            random.shuffle(self.badly_ordered_bundle)
+
+            if not loadable:
+                # Remove a random module from the bundle, so dependent modules won't be able to ever load
+                self.badly_ordered_bundle.pop(
+                    random.randint(0, len(self.badly_ordered_bundle) - 1)
+                )
+
+        async def _policy_op(self, module: int) -> Response:
+            if self.next_allowed_module == module:
+                self.next_allowed_module += 1
+                return Response(status_code=status.HTTP_200_OK)
+            else:
+                return Response(
+                    status_code=random.choice(
+                        [status.HTTP_400_BAD_REQUEST, status.HTTP_404_NOT_FOUND]
+                    ),
+                    content=f"Module {module} is in bad order, can't load before {self.next_allowed_module}",
+                )
+
+        def get_badly_ordered_ops(self):
+            return [
+                functools.partial(self._policy_op, module)
+                for module in self.badly_ordered_bundle
+            ]
+
+    order_strict_ops = OrderStrictOps()
+
+    # Shouldn't raise
+    await OpaClient._attempt_operations_with_postponed_failure_retry(
+        order_strict_ops.get_badly_ordered_ops()
+    )
+
+    order_strict_ops = OrderStrictOps(loadable=False)
+
+    # Should raise, can't complete all operations
+    with pytest.raises(RuntimeError):
+        await OpaClient._attempt_operations_with_postponed_failure_retry(
+            order_strict_ops.get_badly_ordered_ops()
+        )

--- a/packages/opal-common/opal_common/git/bundle_utils.py
+++ b/packages/opal-common/opal_common/git/bundle_utils.py
@@ -43,10 +43,14 @@ class BundleUtils:
 
     @staticmethod
     def sorted_policy_modules_to_delete(bundle: PolicyBundle) -> List[Path]:
+        if bundle.deleted_files is None:
+            return []
         # already sorted
         return bundle.deleted_files.policy_modules
 
     @staticmethod
     def sorted_data_modules_to_delete(bundle: PolicyBundle) -> List[Path]:
+        if bundle.deleted_files is None:
+            return []
         # already sorted
         return bundle.deleted_files.data_modules

--- a/packages/opal-common/opal_common/git/commit_viewer.py
+++ b/packages/opal-common/opal_common/git/commit_viewer.py
@@ -122,7 +122,7 @@ def find_ignore_match(
     """
     if bundle_ignore is not None:
         return PathUtils.glob_style_match_path_to_list(
-            maybe_path.as_posix(), bundle_ignore
+            Path(maybe_path).as_posix(), bundle_ignore
         )
     return None
 


### PR DESCRIPTION
This fix makes `opa_client.py` retry failed `set_policy` / `delete_policy` operations again after completing rest of the bundle's operations.
When multiple operations fail - this will happen recursively (until full success or until none of the failed ops succeeds).

This basically solves any issue of bundle ordering we might have, because any operation X that is dependent on another Y would eventually execute after Y.  

Hopefully this would drastically reduce user friction (not having to get the error, google it, learn & implement `.manifest` files)
Moreover - it handles the issue of a moved Rego file (the new name is applied before the old one is deleted - causing duplicated definitions) which `.manifest` files don't cover.

Can we think of any undesired / unexpected behavior this can produce?