### PR TITLE
Opal Client offline mode (write OPA data to a backup file and load it on startup) #58

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -66,6 +66,9 @@ ENV OPAL_INLINE_OPA_ENABLED=false
 EXPOSE 7000
 USER opal
 
+RUN mkdir -p /opal/backup
+VOLUME /opal/backup
+
 
 FROM alpine:latest as opa-extractor
 USER root
@@ -100,7 +103,6 @@ ENV OPAL_INLINE_OPA_ENABLED=true
 # expose opa port
 EXPOSE 8181
 USER opal
-
 
 # SERVER IMAGE --------------------------------------
 # ---------------------------------------------------

--- a/docker/docker-compose-api-policy-source-example.yml
+++ b/docker/docker-compose-api-policy-source-example.yml
@@ -63,7 +63,7 @@ services:
       - opal_server
     # this command is not necessary when deploying OPAL for real, it is simply a trick for dev environments
     # to make sure that opal-server is already up before starting the client.
-    command: sh -c "./wait-for.sh opal_server:7002 --timeout=20 -- ./start.sh"
+    command: sh -c "exec ./wait-for.sh opal_server:7002 --timeout=20 -- ./start.sh"
 
   # Demo bundle server to serve the policy
   api_policy_source_server:

--- a/docker/docker-compose-example.yml
+++ b/docker/docker-compose-example.yml
@@ -63,7 +63,7 @@ services:
       - opal_server
     # this command is not necessary when deploying OPAL for real, it is simply a trick for dev environments
     # to make sure that opal-server is already up before starting the client.
-    command: sh -c "./wait-for.sh opal_server:7002 --timeout=20 -- ./start.sh"
+    command: sh -c "exec ./wait-for.sh opal_server:7002 --timeout=20 -- ./start.sh"
 
 volumes:
   opa_backup:

--- a/docker/docker-compose-example.yml
+++ b/docker/docker-compose-example.yml
@@ -46,6 +46,12 @@ services:
       - OPAL_SERVER_URL=http://opal_server:7002
       - OPAL_LOG_FORMAT_INCLUDE_PID=true
       - OPAL_INLINE_OPA_LOG_FORMAT=http
+
+      # Uncomment the following lines to enable storing & loading OPA data from a backup file:
+      # - OPAL_OFFLINE_MODE_ENABLED=true
+    # volumes:
+    #  - opa_backup:/opal/backup:rw
+
     ports:
       # exposes opal client on the host machine, you can access the client at: http://localhost:7000
       - "7766:7000"
@@ -58,3 +64,6 @@ services:
     # this command is not necessary when deploying OPAL for real, it is simply a trick for dev environments
     # to make sure that opal-server is already up before starting the client.
     command: sh -c "./wait-for.sh opal_server:7002 --timeout=20 -- ./start.sh"
+
+volumes:
+  opa_backup:

--- a/docker/docker-compose-git-webhook.yml
+++ b/docker/docker-compose-git-webhook.yml
@@ -59,4 +59,4 @@ services:
       - opal_server
     # this command is not necessary when deploying OPAL for real, it is simply a trick for dev environments
     # to make sure that opal-server is already up before starting the client.
-    command: sh -c "./wait-for.sh opal_server:7002 --timeout=20 -- ./start.sh"
+    command: sh -c "exec ./wait-for.sh opal_server:7002 --timeout=20 -- ./start.sh"

--- a/docker/docker-compose-scopes-example.yml
+++ b/docker/docker-compose-scopes-example.yml
@@ -57,4 +57,4 @@ services:
       - opal_server
     # this command is not necessary when deploying OPAL for real, it is simply a trick for dev environments
     # to make sure that opal-server is already up before starting the client.
-    command: sh -c "./wait-for.sh opal_server:7002 --timeout=20 -- ./start.sh"
+    command: sh -c "exec ./wait-for.sh opal_server:7002 --timeout=20 -- ./start.sh"

--- a/docker/docker-compose-with-callbacks.yml
+++ b/docker/docker-compose-with-callbacks.yml
@@ -74,4 +74,4 @@ services:
       - opal_server
     # this command is not necessary when deploying OPAL for real, it is simply a trick for dev environments
     # to make sure that opal-server is already up before starting the client.
-    command: sh -c "./wait-for.sh opal_server:7002 --timeout=20 -- ./start.sh"
+    command: sh -c "exec ./wait-for.sh opal_server:7002 --timeout=20 -- ./start.sh"

--- a/docker/docker-compose-with-kafka-example.yml
+++ b/docker/docker-compose-with-kafka-example.yml
@@ -77,7 +77,7 @@ services:
       - "7002:7002"
     depends_on:
       - kafka_broadcast_channel
-    command: sh -c "/usr/wait-for.sh kafka:9092 --timeout=30 -- /start.sh"
+    command: sh -c "exec /usr/wait-for.sh kafka:9092 --timeout=30 -- /start.sh"
 
   opal_client:
     # by default we run opal-client from latest official image
@@ -97,4 +97,4 @@ services:
       - opal_server
     # this command is not necessary when deploying OPAL for real, it is simply a trick for dev environments
     # to make sure that opal-server is already up before starting the client.
-    command: sh -c "/usr/wait-for.sh opal_server:7002 --timeout=20 -- /start.sh"
+    command: sh -c "exec /usr/wait-for.sh opal_server:7002 --timeout=20 -- /start.sh"

--- a/docker/docker-compose-with-oauth-initial.yml
+++ b/docker/docker-compose-with-oauth-initial.yml
@@ -70,4 +70,4 @@ services:
       - opal_server
     # this command is not necessary when deploying OPAL for real, it is simply a trick for dev environments
     # to make sure that opal-server is already up before starting the client.
-    command: sh -c "./wait-for.sh opal_server:7002 --timeout=20 -- ./start.sh"
+    command: sh -c "exec ./wait-for.sh opal_server:7002 --timeout=20 -- ./start.sh"

--- a/docker/docker-compose-with-rate-limiting.yml
+++ b/docker/docker-compose-with-rate-limiting.yml
@@ -61,7 +61,7 @@ services:
       - opal_server
     # this command is not necessary when deploying OPAL for real, it is simply a trick for dev environments
     # to make sure that opal-server is already up before starting the client.
-    command: sh -c "./wait-for.sh opal_server:7002 --timeout=20 -- ./start.sh"
+    command: sh -c "exec ./wait-for.sh opal_server:7002 --timeout=20 -- ./start.sh"
   opal_client2:
     # by default we run opal-client from latest official image
     image: permitio/opal-client:next
@@ -82,4 +82,4 @@ services:
       - opal_server
     # this command is not necessary when deploying OPAL for real, it is simply a trick for dev environments
     # to make sure that opal-server is already up before starting the client.
-    command: sh -c "./wait-for.sh opal_server:7002 --timeout=20 -- ./start.sh"
+    command: sh -c "exec ./wait-for.sh opal_server:7002 --timeout=20 -- ./start.sh"

--- a/docker/docker-compose-with-security.yml
+++ b/docker/docker-compose-with-security.yml
@@ -88,4 +88,4 @@ services:
       - opal_server
     # this command is not necessary when deploying OPAL for real, it is simply a trick for dev environments
     # to make sure that opal-server is already up before starting the client.
-    command: sh -c "./wait-for.sh opal_server:7002 --timeout=20 -- ./start.sh"
+    command: sh -c "exec ./wait-for.sh opal_server:7002 --timeout=20 -- ./start.sh"

--- a/docker/docker-compose-with-statistics.yml
+++ b/docker/docker-compose-with-statistics.yml
@@ -61,4 +61,4 @@ services:
       - opal_server
     # this command is not necessary when deploying OPAL for real, it is simply a trick for dev environments
     # to make sure that opal-server is already up before starting the client.
-    command: sh -c "./wait-for.sh opal_server:7002 --timeout=20 -- ./start.sh"
+    command: sh -c "exec ./wait-for.sh opal_server:7002 --timeout=20 -- ./start.sh"

--- a/documentation/docs/getting-started/configuration.mdx
+++ b/documentation/docs/getting-started/configuration.mdx
@@ -124,13 +124,16 @@ Please use this table as a reference.
 | POLICY_STORE_AUTH_OAUTH_SERVER        | The authentication server OPAL client will use to authenticate against for retrieving the access_token.                                                                                   |         |
 | POLICY_STORE_AUTH_OAUTH_CLIENT_ID     | The client id OPAL will use to authenticate against the OAuth server.                                                                                                                     |         |
 | POLICY_STORE_AUTH_OAUTH_CLIENT_SECRET | The client secret OPAL will use to authenticate against the OAuth server.                                                                                                                 |         |
-| POLICY_STORE_CONN_RETRY               | Retry options when connecting to the policy store (i.e. the agent that handles the policy, e.g. OPA).                                                                                     |
+| POLICY_STORE_CONN_RETRY               | Retry options when connecting to the policy store (i.e. the agent that handles the policy, e.g. OPA).                                                                                     |         |
 | POLICY_STORE_POLICY_PATHS_TO_IGNORE   | Which policy paths pushed to the client should be ignored. List of glob style paths, or paths without wildcards but ending with "/\*\*" indicating a parent path (ignoring all under it). |         |
 | POLICY_UPDATER_CONN_RETRY             | Retry options when connecting to the policy source (e.g. the policy bundle server).                                                                                                       |         |
 | INLINE_OPA_ENABLED                    | Whether or not OPAL should run OPA by itself in the same container.                                                                                                                       |         |
 | INLINE_OPA_CONFIG                     | If inline OPA is indeed enabled, user can pass cli options (configuration) that affects how OPA will run cli options used when running `opa run --server` inline.                         |         |
 | INLINE_OPA_LOG_FORMAT                 |                                                                                                                                                                                           |         |
 | KEEP_ALIVE_INTERVAL                   |                                                                                                                                                                                           |         |
+| OFFLINE_MODE_ENABLED                  | If set, opal client will try to load policy store from backup file and operate even if server is unreachable. Ignored if INLINE_OPA_ENABLED=False                                         |         |
+| STORE_BACKUP_PATH                     | Path to backup policy store's data to                                                                                                                                                     |         |
+| STORE_BACKUP_INTERVAL                 | Interval in seconds to backup policy store's data                                                                                                                                         |         |
 
 ## Policy Updater Configuration Variables
 

--- a/documentation/docs/getting-started/running-opal/run-opal-client/opa-runner-parameters.mdx
+++ b/documentation/docs/getting-started/running-opal/run-opal-client/opa-runner-parameters.mdx
@@ -15,3 +15,13 @@ In order to override default configuration, you'll need to set this env var:
 Use the `POLICY_STORE_*` [config options](/getting-started/configuration) to control how OPAL-client interacts the policy store (e.g. OPA)
 
 - Use `POLICY_STORE_POLICY_PATHS_TO_IGNORE` to have the client ignore instruction to overwrite or delete policies. Accepting a list of glob paths, or parent paths (without wildcards) ending with "/\*\*"
+
+#### Policy store backup
+
+Opal client can be configured to maintain a local backup file, enabling to restore the policy store to its last known state after a restart, even when server is unavailable.
+
+- Use `OPAL_OFFLINE_MODE_ENABLED=true` to enable storing and loading from backup file.
+- The backup file is stored to `OPAL_STORE_BACKUP_PATH` (default value is `/opal/backup/opa.json`) - make sure its directory is mapped to a meaningful mount point
+- The backup is exported on SIGTERM (on container graceful shutdown), and every `OPAL_STORE_BACKUP_INTERVAL` seconds (default is 60s).
+
+When the client successfully loads the backup, it would report being ready even if server connection isn't established (thus considered operating at "offline mode")

--- a/documentation/docs/tutorials/monitoring_opal.mdx
+++ b/documentation/docs/tutorials/monitoring_opal.mdx
@@ -21,12 +21,17 @@ Currently it returns `200 OK` as long as server is up.
 
 ### OPAL Client
 
-opal-client exposes http health check endpoints on `/` & `/healthcheck`. <br/>
-The health check returns `200 OK` when both policy and data were successfully loaded into OPA, otherwise `503 Unavailable` is returned
+opal-client exposes 2 types of http health checks:
+
+- **Readiness** - available on `/ready`. <br/>
+  Returns `200 OK` if the client have loaded policy & data to OPA at least once (from either server, or local backup file), otherwise `503 Unavailable` is returned.
+
+- **Liveness** - available on `/`, `/healthcheck` & `/healthy`. <br/>
+  Returns `200 OK` if the last attempts to load policy & data to OPA were successful, otherwise `503 Unavailable` is returned
 
 **Notice:** if you don't except your opal-client to load any data into OPA, set `OPAL_DATA_UPDATER_ENABLED: False`, so opal-client could report being healthy.
 
-You can also configure opal-client to store dynamic health status in OPA, [Learn more here](/tutorials/healthcheck_policy_and_update_callbacks)
+You can also configure opal-client to store dynamic health status as a document in OPA, [Learn more here](/tutorials/healthcheck_policy_and_update_callbacks)
 
 ## OPAL Statistics
 

--- a/packages/opal-client/opal_client/client.py
+++ b/packages/opal-client/opal_client/client.py
@@ -6,6 +6,8 @@ import uuid
 from logging import disable
 from typing import List, Optional
 
+import aiofiles
+import aiofiles.os
 import aiohttp
 import websockets
 from fastapi import FastAPI, status
@@ -45,6 +47,9 @@ class OpalClient:
         inline_opa_enabled: bool = None,
         inline_opa_options: OpaServerOptions = None,
         verifier: Optional[JWTVerifier] = None,
+        store_backup_path: Optional[str] = None,
+        store_backup_interval: Optional[int] = None,
+        offline_mode_enabled: bool = False,
     ) -> None:
         """
         Args:
@@ -168,6 +173,21 @@ class OpalClient:
             logger.info(
                 "API authentication disabled (public encryption key was not provided)"
             )
+        self.store_backup_path = (
+            store_backup_path or opal_client_config.STORE_BACKUP_PATH
+        )
+        self.store_backup_interval = (
+            store_backup_interval or opal_client_config.STORE_BACKUP_INTERVAL
+        )
+
+        self.offline_mode_enabled = (
+            offline_mode_enabled or opal_client_config.OFFLINE_MODE_ENABLED
+        )
+        if self.offline_mode_enabled and not inline_opa_enabled:
+            logger.warning(
+                "Offline mode was enabled, but isn't supported when using an external policy store (inline OPA is disabled)"
+            )
+            self.offline_mode_enabled = False
 
         # init fastapi app
         self.app: FastAPI = self._init_fast_api_app()
@@ -236,6 +256,9 @@ class OpalClient:
 
         @app.on_event("shutdown")
         async def shutdown_event():
+            if self.offline_mode_enabled:
+                await self.backup_store()
+
             await self.stop_client_background_tasks()
 
         return app
@@ -285,6 +308,45 @@ class OpalClient:
         except Exception:
             logger.exception("exception while shutting down updaters")
 
+    async def load_store_from_backup(self):
+        """Imports the backup file, if exists, to the policy store."""
+        try:
+            if os.path.isfile(self.store_backup_path):
+                async with aiofiles.open(self.store_backup_path, "r") as backup_file:
+                    logger.debug("importing policy store from backup file...")
+                    await self.policy_store.full_import(backup_file)
+                    logger.debug("import completed")
+            else:
+                logger.warning("policy store backup file wasn't found")
+        except Exception:
+            logger.exception("failed to load backup data to policy store")
+
+    async def backup_store(self):
+        """Exports the policy store's data to a backup file."""
+        try:
+            async with self._backup_lock:
+                await aiofiles.os.makedirs(
+                    os.path.dirname(self.store_backup_path), exist_ok=True
+                )
+                tmp_backup_path = self.store_backup_path + ".tmp"
+                async with aiofiles.open(tmp_backup_path, "w") as backup_file:
+                    logger.debug("exporting policy store to backup file...")
+                    await self.policy_store.full_export(backup_file)
+                    logger.debug("export completed")
+
+                # Atomically replace the previous backup (only after the new one is ready)
+                await aiofiles.os.replace(tmp_backup_path, self.store_backup_path)
+        except Exception:
+            logger.exception("failed to backup policy store")
+
+    async def periodically_backup_store(self):
+        self._backup_lock = asyncio.Lock()
+
+        # Backup store periodically
+        while True:
+            await asyncio.sleep(self.store_backup_interval)
+            await self.backup_store()
+
     async def launch_policy_store_dependent_tasks(self):
         try:
             await self.maybe_init_healthcheck_policy()
@@ -292,6 +354,11 @@ class OpalClient:
             logger.critical("healthcheck policy enabled but could not be initialized!")
             self._trigger_shutdown()
             return
+
+        if self.offline_mode_enabled:
+            # Immediately attempt loading from backup (waiting for failure loading from server would delay availability)
+            await self.load_store_from_backup()
+            asyncio.create_task(self.periodically_backup_store())
 
         try:
             for task in asyncio.as_completed(

--- a/packages/opal-client/opal_client/client.py
+++ b/packages/opal-client/opal_client/client.py
@@ -188,6 +188,7 @@ class OpalClient:
                 "Offline mode was enabled, but isn't supported when using an external policy store (inline OPA is disabled)"
             )
             self.offline_mode_enabled = False
+        self._backup_loaded = False
 
         # init fastapi app
         self.app: FastAPI = self._init_fast_api_app()
@@ -227,10 +228,28 @@ class OpalClient:
         # top level routes (i.e: healthchecks)
         @app.get("/healthcheck", include_in_schema=False)
         @app.get("/", include_in_schema=False)
-        async def healthcheck():
+        @app.get("/healthy", include_in_schema=False)
+        async def healthy():
+            """returns 200 if updates keep being successfully fetched from the
+            server and applied to the policy store."""
             healthy = await self.policy_store.is_healthy()
 
             if healthy:
+                return JSONResponse(
+                    status_code=status.HTTP_200_OK, content={"status": "ok"}
+                )
+            else:
+                return JSONResponse(
+                    status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+                    content={"status": "unavailable"},
+                )
+
+        @app.get("/ready", include_in_schema=False)
+        async def ready():
+            """returns 200 if the policy store is ready to serve requests."""
+            ready = self._backup_loaded or await self.policy_store.is_ready()
+
+            if ready:
                 return JSONResponse(
                     status_code=status.HTTP_200_OK, content={"status": "ok"}
                 )
@@ -316,6 +335,7 @@ class OpalClient:
                     logger.debug("importing policy store from backup file...")
                     await self.policy_store.full_import(backup_file)
                     logger.debug("import completed")
+                    self._backup_loaded = True
             else:
                 logger.warning("policy store backup file wasn't found")
         except Exception:

--- a/packages/opal-client/opal_client/config.py
+++ b/packages/opal-client/opal_client/config.py
@@ -242,6 +242,22 @@ class OpalClientConfig(Confi):
 
     SCOPE_ID = confi.str("SCOPE_ID", "default", description="OPAL Scope ID")
 
+    STORE_BACKUP_PATH = confi.str(
+        "STORE_BACKUP_PATH",
+        "/opal/backup/opa.json",
+        description="Path to backup policy store's data to",
+    )
+    STORE_BACKUP_INTERVAL = confi.int(
+        "STORE_BACKUP_INTERVAL",
+        60,
+        description="Interval in seconds to backup policy store's data",
+    )
+    OFFLINE_MODE_ENABLED = confi.bool(
+        "OFFLINE_MODE_ENABLED",
+        False,
+        description="If set, opal client will try to load policy store from backup file and operate even if server is unreachable. Ignored if INLINE_OPA_ENABLED=False",
+    )
+
     def on_load(self):
         # LOGGER
         if self.INLINE_OPA_LOG_FORMAT == OpaLogFormat.NONE:

--- a/packages/opal-client/opal_client/policy_store/base_policy_store_client.py
+++ b/packages/opal-client/opal_client/policy_store/base_policy_store_client.py
@@ -1,5 +1,6 @@
 import json
 import uuid
+from asyncio import StreamReader, StreamWriter
 from datetime import datetime
 from functools import partial
 from inspect import signature
@@ -72,6 +73,12 @@ class AbstractPolicyStore:
         raise NotImplementedError()
 
     async def is_healthy(self) -> bool:
+        raise NotImplementedError()
+
+    async def full_export(self, writer: StreamWriter) -> None:
+        raise NotImplementedError()
+
+    async def full_import(self, reader: StreamReader) -> None:
         raise NotImplementedError()
 
 

--- a/packages/opal-client/opal_client/policy_store/opa_client.py
+++ b/packages/opal-client/opal_client/policy_store/opa_client.py
@@ -2,6 +2,7 @@ import asyncio
 import functools
 import json
 import time
+from asyncio import StreamReader, StreamWriter
 from typing import Any, Awaitable, Callable, Dict, List, Optional, Set
 from urllib.parse import urlencode
 
@@ -18,7 +19,7 @@ from opal_client.utils import proxy_response
 from opal_common.git.bundle_utils import BundleUtils
 from opal_common.opa.parsing import get_rego_package
 from opal_common.paths import PathUtils
-from opal_common.schemas.policy import DataModule, PolicyBundle
+from opal_common.schemas.policy import DataModule, PolicyBundle, RegoModule
 from opal_common.schemas.store import JSONPatchAction, StoreTransaction, TransactionType
 from pydantic import BaseModel
 from tenacity import RetryError, retry
@@ -401,6 +402,22 @@ class OpaClient(BasePolicyStoreClient):
                 logger.warning("Opa connection error: {err}", err=repr(e))
                 raise
 
+    @fail_silently()
+    @retry(**RETRY_CONFIG)
+    async def get_policies(self) -> Optional[Dict[str, str]]:
+        async with aiohttp.ClientSession() as session:
+            try:
+                headers = await self._get_auth_headers()
+
+                async with session.get(
+                    f"{self._opa_url}/policies", headers=headers
+                ) as opa_response:
+                    result = await opa_response.json()
+                    return OpaClient._extract_modules_from_policies_json(result)
+            except aiohttp.ClientError as e:
+                logger.warning("Opa connection error: {err}", err=repr(e))
+                raise
+
     @affects_transaction
     @retry(**RETRY_CONFIG)
     async def delete_policy(self, policy_id: str, transaction_id: Optional[str] = None):
@@ -431,36 +448,25 @@ class OpaClient(BasePolicyStoreClient):
                 logger.warning("Opa connection error: {err}", err=repr(e))
                 raise
 
-    @fail_silently()
-    @retry(**RETRY_CONFIG)
     async def get_policy_module_ids(self) -> List[str]:
-        async with aiohttp.ClientSession() as session:
-            try:
-                headers = await self._get_auth_headers()
-
-                async with session.get(
-                    f"{self._opa_url}/policies", headers=headers
-                ) as opa_response:
-                    result = await opa_response.json()
-                    return OpaClient._extract_module_ids_from_policies_json(result)
-            except aiohttp.ClientError as e:
-                logger.warning("Opa connection error: {err}", err=repr(e))
-                raise
+        modules = await self.get_policies()
+        return modules.keys()
 
     @staticmethod
-    def _extract_module_ids_from_policies_json(result: Dict[str, Any]) -> List[str]:
+    def _extract_modules_from_policies_json(result: Dict[str, Any]) -> Dict[str, str]:
         """return all module ids in OPA cache who are not:
 
         - skipped module ids (i.e: our health check policy)
         - all modules with package name starting with "system" (special OPA policies)
         """
-        modules: List[Dict[str, Any]] = result.get("result", [])
+        policies: List[Dict[str, Any]] = result.get("result", [])
         builtin_modules = [opal_client_config.OPA_HEALTH_CHECK_POLICY_PATH]
 
-        module_ids = []
-        for module in modules:
-            module_id = module.get("id", None)
-            package_name = get_rego_package(module.get("raw", ""))
+        modules = {}
+        for policy in policies:
+            module_id = policy.get("id", None)
+            module_raw = policy.get("raw", "")
+            package_name = get_rego_package(module_raw)
 
             if module_id is None:
                 continue
@@ -471,9 +477,9 @@ class OpaClient(BasePolicyStoreClient):
             if module_id in builtin_modules:
                 continue
 
-            module_ids.append(module_id)
+            modules[module_id] = module_raw
 
-        return module_ids
+        return modules
 
     @affects_transaction
     async def set_policies(
@@ -717,14 +723,14 @@ class OpaClient(BasePolicyStoreClient):
         returns a dict (parsed json).
         """
         # function accepts paths that start with / and also path that do not start with /
-        if path.startswith("/"):
-            path = path[1:]
+        if path != "" and not path.startswith("/"):
+            path = "/" + path
         try:
             headers = await self._get_auth_headers()
 
             async with aiohttp.ClientSession() as session:
                 async with session.get(
-                    f"{self._opa_url}/data/{path}", headers=headers
+                    f"{self._opa_url}/data{path}", headers=headers
                 ) as opa_response:
                     return await opa_response.json()
         except aiohttp.ClientError as e:
@@ -793,3 +799,20 @@ class OpaClient(BasePolicyStoreClient):
 
     async def is_healthy(self) -> bool:
         return self._transaction_state.healthy
+
+    async def full_export(self, writer: StreamWriter) -> None:
+        policies = await self.get_policies()
+        data = await self.get_data("")
+        await writer.write(json.dumps({"policies": policies, "data": data}))
+
+    async def full_import(self, reader: StreamReader) -> None:
+        import_data = json.loads(await reader.read())
+
+        await OpaClient._attempt_operations_with_postponed_failure_retry(
+            [
+                functools.partial(self.set_policy, policy_id=id, policy_code=raw)
+                for id, raw in import_data["policies"].items()
+            ]
+        )
+
+        await self.set_policy_data(import_data["data"])

--- a/packages/opal-client/opal_client/policy_store/opa_client.py
+++ b/packages/opal-client/opal_client/policy_store/opa_client.py
@@ -797,6 +797,9 @@ class OpaClient(BasePolicyStoreClient):
                     data=transaction_data,
                 )
 
+    async def is_ready(self) -> bool:
+        return self._transaction_state.ready
+
     async def is_healthy(self) -> bool:
         return self._transaction_state.healthy
 


### PR DESCRIPTION
Importing the backup data to OPA on client startup (if server connection would succeed, backup data would be overridden with new data).
Trying to backup the store periodically, and also on SIGTERM.

Also adds readiness endpoint ("/ready")