### PR TITLE
Fix policy paths to ignore

### DIFF
--- a/packages/opal-client/opal_client/config.py
+++ b/packages/opal-client/opal_client/config.py
@@ -69,7 +69,7 @@ class OpalClientConfig(Confi):
     )
 
     POLICY_STORE_POLICY_PATHS_TO_IGNORE = confi.list(
-        "POLICY_STORE_EXTERNAL_POLICY_PATHS_TO_IGNORE",
+        "POLICY_STORE_POLICY_PATHS_TO_IGNORE",
         [],
         description="When loading policies manually or otherwise externally into the policy store, use this list of glob patterns to have OPAL ignore and not delete or override them, end paths (without any wildcards in the middle) with '\**' to indicate you want all nested under the path to be ignored",
     )

--- a/packages/opal-client/opal_client/policy_store/opa_client.py
+++ b/packages/opal-client/opal_client/policy_store/opa_client.py
@@ -506,7 +506,7 @@ class OpaClient(BasePolicyStoreClient):
             for op in ops:
                 # Only expected errors are retried (such as 400), so exceptions are not caught
                 response = await op()
-                if response.status_code != status.HTTP_200_OK:
+                if response and response.status_code != status.HTTP_200_OK:
                     logger.warning(
                         f"Failed policy operation, would retry again after the rest. status: {response.status_code}, body: {response.body.decode()}"
                     )


### PR DESCRIPTION
1. Expected environment variable name was inconsistent with config var name and docs
2. Fix broken integration with another new feature "reattempting failed policy store ops" - which should handle None as return value of operation when it's blocked by the ignore list.