### PR TITLE
Split root data to individual keys

### DIFF
--- a/packages/opal-client/opal_client/config.py
+++ b/packages/opal-client/opal_client/config.py
@@ -257,6 +257,9 @@ class OpalClientConfig(Confi):
         False,
         description="If set, opal client will try to load policy store from backup file and operate even if server is unreachable. Ignored if INLINE_OPA_ENABLED=False",
     )
+    SPLIT_ROOT_DATA = confi.bool(
+        "SPLIT_ROOT_DATA", False, description="Split writing data updates to root path"
+    )
 
     def on_load(self):
         # LOGGER


### PR DESCRIPTION
When using multiple data source, if one of them has dst_path="/", it will override all other data that was written to subpaths.

To address this, when an update comes in with root path, split it to its keys and write each individually. Gate this with OPAL_SPLIT_ROOT_DATA.

<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing -->

## Fixes Issue

<!-- Remove this section if not applicable -->

<!-- Example: Closes #31 -->

## Changes proposed

<!-- List all the proposed changes in your PR -->

<!-- Mark all the applicable boxes. To mark the box as done follow the following conventions -->
<!--
[x] - Correct; marked as done
[X] - Correct; marked as done

[ ] - Not correct; marked as **not** done
-->

## Check List (Check all the applicable boxes) <!-- Follow the above conventions to check the box -->

- [x] My code follows the code style of this project.
- [x] My change requires changes to the documentation.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] This PR does not contain plagiarized content.
- [x] The title of my pull request is a short description of the requested changes.

## Screenshots

<!-- Add all the screenshots which support your changes -->

## Note to reviewers

<!-- Add notes to reviewers if applicable -->
