### PR TITLE
Fix opa backup

### DIFF
--- a/packages/opal-client/opal_client/client.py
+++ b/packages/opal-client/opal_client/client.py
@@ -332,7 +332,7 @@ class OpalClient:
         try:
             if os.path.isfile(self.store_backup_path):
                 async with aiofiles.open(self.store_backup_path, "r") as backup_file:
-                    logger.debug("importing policy store from backup file...")
+                    logger.info("importing policy store from backup file...")
                     await self.policy_store.full_import(backup_file)
                     logger.debug("import completed")
                     self._backup_loaded = True

--- a/packages/opal-client/opal_client/client.py
+++ b/packages/opal-client/opal_client/client.py
@@ -75,10 +75,23 @@ class OpalClient:
         )
         # set logs
         configure_logs()
+
+        self.offline_mode_enabled = (
+            offline_mode_enabled or opal_client_config.OFFLINE_MODE_ENABLED
+        )
+        if self.offline_mode_enabled and not inline_opa_enabled:
+            logger.warning(
+                "Offline mode was enabled, but isn't supported when using an external policy store (inline OPA is disabled)"
+            )
+            self.offline_mode_enabled = False
+
         # Init policy store client
         self.policy_store_type: PolicyStoreTypes = policy_store_type
         self.policy_store: BasePolicyStoreClient = (
-            policy_store or PolicyStoreClientFactory.create(policy_store_type)
+            policy_store
+            or PolicyStoreClientFactory.create(
+                policy_store_type, offline_mode_enabled=self.offline_mode_enabled
+            )
         )
         # data fetcher
         self.data_fetcher = DataFetcher()
@@ -179,15 +192,6 @@ class OpalClient:
         self.store_backup_interval = (
             store_backup_interval or opal_client_config.STORE_BACKUP_INTERVAL
         )
-
-        self.offline_mode_enabled = (
-            offline_mode_enabled or opal_client_config.OFFLINE_MODE_ENABLED
-        )
-        if self.offline_mode_enabled and not inline_opa_enabled:
-            logger.warning(
-                "Offline mode was enabled, but isn't supported when using an external policy store (inline OPA is disabled)"
-            )
-            self.offline_mode_enabled = False
         self._backup_loaded = False
 
         # init fastapi app

--- a/packages/opal-client/opal_client/policy_store/base_policy_store_client.py
+++ b/packages/opal-client/opal_client/policy_store/base_policy_store_client.py
@@ -52,14 +52,6 @@ class AbstractPolicyStore:
     ):
         raise NotImplementedError()
 
-    async def patch_data(
-        self,
-        path: str,
-        patch_document: Dict[str, Any],
-        transaction_id: Optional[str] = None,
-    ):
-        raise NotImplementedError()
-
     async def get_data(self, path: str) -> Dict:
         raise NotImplementedError()
 

--- a/packages/opal-client/opal_client/policy_store/mock_policy_store_client.py
+++ b/packages/opal-client/opal_client/policy_store/mock_policy_store_client.py
@@ -70,14 +70,6 @@ class MockPolicyStoreClient(BasePolicyStoreClient):
         else:
             del self._data[path]
 
-    async def patch_data(
-        self,
-        path: str,
-        patch_document: Dict[str, Any],
-        transaction_id: Optional[str] = None,
-    ):
-        pass
-
     async def wait_for_data(self):
         """Wait until the store has data set in it."""
         await self.has_data_event.wait()

--- a/packages/opal-client/opal_client/policy_store/opa_client.py
+++ b/packages/opal-client/opal_client/policy_store/opa_client.py
@@ -737,7 +737,8 @@ class OpaClient(BasePolicyStoreClient):
                 async with session.get(
                     f"{self._opa_url}/data{path}", headers=headers
                 ) as opa_response:
-                    return await opa_response.json()
+                    json_response = await opa_response.json()
+                    return json_response.get("result", {})
         except aiohttp.ClientError as e:
             logger.warning("Opa connection error: {err}", err=repr(e))
             raise

--- a/packages/opal-client/opal_client/policy_store/opa_client.py
+++ b/packages/opal-client/opal_client/policy_store/opa_client.py
@@ -7,6 +7,7 @@ from typing import Any, Awaitable, Callable, Dict, List, Optional, Set
 from urllib.parse import urlencode
 
 import aiohttp
+import dpath
 from fastapi import Response, status
 from opal_client.config import opal_client_config
 from opal_client.logger import logger
@@ -239,6 +240,35 @@ class OpaTransactionLogPolicyWriter:
         )
 
 
+class OpaStaticDataCache:
+    """Caching OPA's static data, so we can back it up without querying.
+
+    /v1/data which also includes virtual documents.
+    """
+
+    def __init__(self):
+        self._root_data = {}
+
+    def set(self, path, data):
+        if not path or path == "/":
+            assert isinstance(data, dict), ValueError(
+                "Setting root document must be a dict"
+            )
+            self._root_data = data.copy()
+        else:
+            # This would overwrite already existing paths
+            dpath.new(self._root_data, path, data)
+
+    def delete(self, path):
+        if not path or path == "/":
+            self._root_data = {}
+        else:
+            dpath.delete(self._root_data, path)
+
+    def get_data(self):
+        return self._root_data
+
+
 class OpaClient(BasePolicyStoreClient):
     """communicates with OPA via its REST API."""
 
@@ -253,6 +283,7 @@ class OpaClient(BasePolicyStoreClient):
         oauth_client_secret: Optional[str] = None,
         oauth_server: Optional[str] = None,
         data_updater_enabled: bool = True,
+        cache_policy_data: bool = False,
     ):
         base_url = opa_server_url or opal_client_config.POLICY_STORE_URL
         self._opa_url = f"{base_url}/v1"
@@ -292,6 +323,10 @@ class OpaClient(BasePolicyStoreClient):
         self._transaction_state = OpaTransactionLogState(data_updater_enabled)
         # as long as this is null, persisting transaction log to OPA is disabled
         self._transaction_state_writer: Optional[OpaTransactionLogState] = None
+
+        self._policy_data_cache: Optional[OpaStaticDataCache] = None
+        if cache_policy_data:
+            self._policy_data_cache = OpaStaticDataCache()
 
     async def get_policy_version(self) -> Optional[str]:
         return self._policy_version
@@ -649,13 +684,16 @@ class OpaClient(BasePolicyStoreClient):
                     data=json.dumps(policy_data, default=str),
                     headers=headers,
                 ) as opa_response:
-                    return await proxy_response_unless_invalid(
+                    response = await proxy_response_unless_invalid(
                         opa_response,
                         accepted_status_codes=[
                             status.HTTP_204_NO_CONTENT,
                             status.HTTP_304_NOT_MODIFIED,
                         ],
                     )
+                    if self._policy_data_cache:
+                        self._policy_data_cache.set(path, policy_data)
+                    return response
             except aiohttp.ClientError as e:
                 logger.warning("Opa connection error: {err}", err=repr(e))
                 raise
@@ -676,13 +714,16 @@ class OpaClient(BasePolicyStoreClient):
                 async with session.delete(
                     f"{self._opa_url}/data{path}", headers=headers
                 ) as opa_response:
-                    return await proxy_response_unless_invalid(
+                    response = await proxy_response_unless_invalid(
                         opa_response,
                         accepted_status_codes=[
                             status.HTTP_204_NO_CONTENT,
                             status.HTTP_404_NOT_FOUND,
                         ],
                     )
+                    if self._policy_data_cache:
+                        self._policy_data_cache.delete(path)
+                    return response
             except aiohttp.ClientError as e:
                 logger.warning("Opa connection error: {err}", err=repr(e))
                 raise
@@ -780,8 +821,10 @@ class OpaClient(BasePolicyStoreClient):
 
     async def full_export(self, writer: StreamWriter) -> None:
         policies = await self.get_policies()
-        data = await self.get_data("")
-        await writer.write(json.dumps({"policies": policies, "data": data}))
+        data = self._policy_data_cache.get_data()
+        await writer.write(
+            json.dumps({"policies": policies, "data": data}, default=str)
+        )
 
     async def full_import(self, reader: StreamReader) -> None:
         import_data = json.loads(await reader.read())

--- a/packages/opal-client/opal_client/policy_store/opa_client.py
+++ b/packages/opal-client/opal_client/policy_store/opa_client.py
@@ -689,35 +689,6 @@ class OpaClient(BasePolicyStoreClient):
                 logger.warning("Opa connection error: {err}", err=repr(e))
                 raise
 
-    @affects_transaction
-    async def patch_data(
-        self,
-        path: str,
-        patch_document: JSONPatchDocument,
-        transaction_id: Optional[str] = None,
-    ):
-        path = self._safe_data_module_path(path)
-        # a patch document is a list of actions
-        # we render each action with pydantic, and then dump the doc into json
-        json_document = json.dumps([action.dict() for action in patch_document])
-
-        async with aiohttp.ClientSession() as session:
-            try:
-                headers = await self._get_auth_headers()
-
-                async with session.patch(
-                    f"{self._opa_url}/data{path}",
-                    data=json_document,
-                    headers=headers,
-                ) as opa_response:
-                    return await proxy_response_unless_invalid(
-                        opa_response,
-                        accepted_status_codes=[status.HTTP_204_NO_CONTENT],
-                    )
-            except aiohttp.ClientError as e:
-                logger.warning("Opa connection error: {err}", err=repr(e))
-                raise
-
     @fail_silently()
     @retry(**RETRY_CONFIG)
     async def get_data(self, path: str) -> Dict:

--- a/packages/opal-client/opal_client/policy_store/opa_client.py
+++ b/packages/opal-client/opal_client/policy_store/opa_client.py
@@ -256,7 +256,6 @@ class OpaClient(BasePolicyStoreClient):
     ):
         base_url = opa_server_url or opal_client_config.POLICY_STORE_URL
         self._opa_url = f"{base_url}/v1"
-        self._cached_policies: Dict[str, str] = {}
         self._policy_version: Optional[str] = None
         self._lock = asyncio.Lock()
         self._token = opa_auth_token
@@ -365,7 +364,6 @@ class OpaClient(BasePolicyStoreClient):
                 f"Ignoring setting policy - {policy_id}, set in POLICY_PATHS_TO_IGNORE."
             )
             return
-        self._cached_policies[policy_id] = policy_code
         async with aiohttp.ClientSession() as session:
             try:
                 headers = await self._get_auth_headers()

--- a/packages/opal-client/opal_client/policy_store/policy_store_client_factory.py
+++ b/packages/opal-client/opal_client/policy_store/policy_store_client_factory.py
@@ -70,6 +70,7 @@ class PolicyStoreClientFactory:
         oauth_client_secret: Optional[str] = None,
         oauth_server: Optional[str] = None,
         data_updater_enabled: Optional[bool] = None,
+        offline_mode_enabled: bool = False,
     ) -> BasePolicyStoreClient:
         """
         Factory method - create a new policy store by type.
@@ -117,6 +118,7 @@ class PolicyStoreClientFactory:
                 oauth_client_secret=oauth_client_secret,
                 oauth_server=oauth_server,
                 data_updater_enabled=data_updater_enabled,
+                cache_policy_data=offline_mode_enabled,
             )
         # MOCK
         elif PolicyStoreTypes.MOCK == store_type:

--- a/packages/opal-client/requires.txt
+++ b/packages/opal-client/requires.txt
@@ -3,3 +3,4 @@ aiohttp>=3.8.1,<4
 psutil>=5.9.1,<6
 tenacity>=8.0.1,<9
 websockets>=10.3,<11
+dpath>=2.1.5,<3


### PR DESCRIPTION
Static data export was buggy and included the HTTP response's "result" nesting.
When that was fixed - started having conflicts with virtual documents (generated by policy modules) because `/v1/data` returns both base and virtual documents.

Overall `/v1/data` for exporting static data doesn't work, it's slow and creates redundant decision logs (potentially with a lot of data).

The new backup is done by keeping an in memory cache for all static data.