### PR TITLE
Fix worker behavior on broadcaster connection loss 

### DIFF
--- a/packages/opal-server/opal_server/policy/watcher/task.py
+++ b/packages/opal-server/opal_server/policy/watcher/task.py
@@ -59,7 +59,7 @@ class BasePolicyWatcherTask:
         """stops all policy watcher tasks."""
         logger.info("Stopping policy watcher")
         for task in self._tasks:
-            if not task.done():
+            if not task.done() and not task.cancelled():
                 task.cancel()
         await asyncio.gather(*self._tasks, return_exceptions=True)
 


### PR DESCRIPTION
1) When statistics are enabled, there was a deadlock preventing releasing broadcaster's listening context - thus it couldn't recreate and clients fail to reconnect.
2) Watcher and statistics task weren't restarted (on broadcaster connection loss)