### PR TITLE
Server: Quit worker process if broadcaster disconnects

### DIFF
--- a/packages/opal-server/opal_server/policy/webhook/api.py
+++ b/packages/opal-server/opal_server/policy/webhook/api.py
@@ -70,7 +70,7 @@ def get_webhook_router(
         status_code=status.HTTP_200_OK,
         dependencies=route_dependencies,
     )
-    async def trigger_webhook(request: Request, git_changes: GitChanges = git_changes):            
+    async def trigger_webhook(request: Request, git_changes: GitChanges = git_changes):
 
         # TODO: breaking change: change "repo_url" to "remote_url" in next major
         if source_type == PolicySourceTypes.Git:

--- a/packages/opal-server/opal_server/server.py
+++ b/packages/opal-server/opal_server/server.py
@@ -321,6 +321,10 @@ class OpalServer:
                             "listening on broadcast channel for statistics events..."
                         )
                         await self.broadcast_listening_context.__aenter__()
+                        # if the broadcast channel is closed, we want to restart worker process because statistics can't be reliable anymore
+                        self.broadcast_listening_context._event_broadcaster.get_reader_task().add_done_callback(
+                            lambda _: self._graceful_shutdown()
+                        )
                     asyncio.create_task(self.opal_statistics.run())
                     self.pubsub.endpoint.notifier.register_unsubscribe_event(
                         self.opal_statistics.remove_client

--- a/packages/opal-server/opal_server/server.py
+++ b/packages/opal-server/opal_server/server.py
@@ -1,5 +1,6 @@
 import asyncio
 import os
+import signal
 import sys
 import traceback
 from functools import partial
@@ -363,6 +364,9 @@ class OpalServer:
                         async with self.watcher:
                             await self.watcher.wait_until_should_stop()
 
+                            # Worker should restart when watcher stops
+                            self._graceful_shutdown()
+
                 if (
                     self.opal_statistics is not None
                     and self.broadcast_listening_context is not None
@@ -388,3 +392,7 @@ class OpalServer:
             await asyncio.gather(*tasks)
         except Exception:
             logger.exception("exception while shutting down background tasks")
+
+    def _graceful_shutdown(self):
+        logger.info("Trigger worker graceful shutdown")
+        os.kill(os.getpid(), signal.SIGTERM)


### PR DESCRIPTION
1) When watcher task's broadcaster disconnects - so process would restart and try to reacquire leadership lock (otherwise, after UVICORN_NUM_WORKERS connections losses - there would be no leader and no repo watching).
2) When statistics is enabled - if broadcaster disconnects we can't rely on being synced with other workers and process better be disconnected.
2.1) also solves an issue of deadlock that happens when statistics are enabled, there are multiple Uvicorn processes with broadcaster, and broadcaster connection disconnects. in that case `await self.broadcast_listening_context.__aexit__()` would block forever, reader task won't be recreated and every new client connection would be rejected.

Note: Statistics sometimes aren't coherent after worker restart - I think that's because clients connect before the new worker completes its "statistics sync". I'll open a separate issue as this is less urgent than the DOS (2.1)