### PR TITLE
add support for opa configure with tls authentication

### DIFF
--- a/packages/opal-client/opal_client/config.py
+++ b/packages/opal-client/opal_client/config.py
@@ -77,17 +77,17 @@ class OpalClientConfig(Confi):
     POLICY_STORE_TLS_CLIENT_CERT = confi.str(
         "POLICY_STORE_TLS_CLIENT_CERT",
         None,
-        description="path to the client certificate used for tls authentication with the policy store"
+        description="path to the client certificate used for tls authentication with the policy store",
     )
     POLICY_STORE_TLS_CLIENT_KEY = confi.str(
         "POLICY_STORE_TLS_CLIENT_KEY",
         None,
-        description="path to the client key used for tls authentication with the policy store"
+        description="path to the client key used for tls authentication with the policy store",
     )
     POLICY_STORE_TLS_CA = confi.str(
         "POLICY_STORE_TLS_CA",
         None,
-        description="path to the file containing the ca certificate(s) used for tls authentication with the policy store"
+        description="path to the file containing the ca certificate(s) used for tls authentication with the policy store",
     )
 
     # create an instance of a policy store upon load

--- a/packages/opal-client/opal_client/config.py
+++ b/packages/opal-client/opal_client/config.py
@@ -74,6 +74,22 @@ class OpalClientConfig(Confi):
         description="When loading policies manually or otherwise externally into the policy store, use this list of glob patterns to have OPAL ignore and not delete or override them, end paths (without any wildcards in the middle) with '\**' to indicate you want all nested under the path to be ignored",
     )
 
+    POLICY_STORE_TLS_CLIENT_CERT = confi.str(
+        "POLICY_STORE_TLS_CLIENT_CERT",
+        None,
+        description="path to the client certificate used for tls authentication with the policy store"
+    )
+    POLICY_STORE_TLS_CLIENT_KEY = confi.str(
+        "POLICY_STORE_TLS_CLIENT_KEY",
+        None,
+        description="path to the client key used for tls authentication with the policy store"
+    )
+    POLICY_STORE_TLS_CA = confi.str(
+        "POLICY_STORE_TLS_CA",
+        None,
+        description="path to the file containing the ca certificate(s) used for tls authentication with the policy store"
+    )
+
     # create an instance of a policy store upon load
     def load_policy_store():
         from opal_client.policy_store.policy_store_client_factory import (

--- a/packages/opal-client/opal_client/policy_store/opa_client.py
+++ b/packages/opal-client/opal_client/policy_store/opa_client.py
@@ -1,8 +1,8 @@
 import asyncio
 import functools
 import json
-import time
 import ssl
+import time
 from typing import Any, Awaitable, Callable, Dict, List, Optional, Set
 from urllib.parse import urlencode
 
@@ -287,7 +287,7 @@ class OpaClient(BasePolicyStoreClient):
         cache_policy_data: bool = False,
         tls_client_cert: Optional[str] = None,
         tls_client_key: Optional[str] = None,
-        tls_ca: Optional[str] = None
+        tls_ca: Optional[str] = None,
     ):
         base_url = opa_server_url or opal_client_config.POLICY_STORE_URL
         self._opa_url = f"{base_url}/v1"
@@ -306,20 +306,17 @@ class OpaClient(BasePolicyStoreClient):
         if auth_type == PolicyStoreAuth.TOKEN:
             if self._token is None:
                 logger.error("POLICY_STORE_AUTH_TOKEN can not be empty")
-                raise Exception(
-                    "required variables for token auth are not set")
+                raise Exception("required variables for token auth are not set")
 
         if auth_type == PolicyStoreAuth.OAUTH:
             isError = False
             if self._oauth_client_id is None:
                 isError = True
-                logger.error(
-                    "POLICY_STORE_AUTH_OAUTH_CLIENT_ID can not be empty")
+                logger.error("POLICY_STORE_AUTH_OAUTH_CLIENT_ID can not be empty")
 
             if self._oauth_client_secret is None:
                 isError = True
-                logger.error(
-                    "POLICY_STORE_AUTH_OAUTH_CLIENT_SECRET can not be empty")
+                logger.error("POLICY_STORE_AUTH_OAUTH_CLIENT_SECRET can not be empty")
 
             if self._oauth_server is None:
                 isError = True
@@ -368,12 +365,14 @@ class OpaClient(BasePolicyStoreClient):
         if not self._tls_ca:
             return None
 
-        ssl_context = ssl.create_default_context(purpose=ssl.Purpose.SERVER_AUTH,
-                                                 cafile=self._tls_ca)
+        ssl_context = ssl.create_default_context(
+            purpose=ssl.Purpose.SERVER_AUTH, cafile=self._tls_ca
+        )
 
         if self._tls_client_key and self._tls_client_cert:
-            ssl_context.load_cert_chain(certfile=self._tls_client_cert,
-                                        keyfile=self._tls_client_key)
+            ssl_context.load_cert_chain(
+                certfile=self._tls_client_cert, keyfile=self._tls_client_key
+            )
 
         return ssl_context
 
@@ -410,8 +409,7 @@ class OpaClient(BasePolicyStoreClient):
                         "token": response["access_token"],
                     }
             except aiohttp.ClientError as e:
-                logger.warning(
-                    "OAuth server connection error: {err}", err=repr(e))
+                logger.warning("OAuth server connection error: {err}", err=repr(e))
                 raise
 
     async def _get_auth_headers(self) -> {}:
@@ -479,7 +477,8 @@ class OpaClient(BasePolicyStoreClient):
                 headers = await self._get_auth_headers()
 
                 async with session.get(
-                    f"{self._opa_url}/policies/{policy_id}", headers=headers,
+                    f"{self._opa_url}/policies/{policy_id}",
+                    headers=headers,
                     **self._ssl_context_kwargs,
                 ) as opa_response:
                     result = await opa_response.json()
@@ -496,7 +495,8 @@ class OpaClient(BasePolicyStoreClient):
                 headers = await self._get_auth_headers()
 
                 async with session.get(
-                    f"{self._opa_url}/policies", headers=headers,
+                    f"{self._opa_url}/policies",
+                    headers=headers,
                     **self._ssl_context_kwargs,
                 ) as opa_response:
                     result = await opa_response.json()
@@ -522,7 +522,8 @@ class OpaClient(BasePolicyStoreClient):
                 headers = await self._get_auth_headers()
 
                 async with session.delete(
-                    f"{self._opa_url}/policies/{policy_id}", headers=headers,
+                    f"{self._opa_url}/policies/{policy_id}",
+                    headers=headers,
                     **self._ssl_context_kwargs,
                 ) as opa_response:
                     return await proxy_response_unless_invalid(
@@ -612,8 +613,7 @@ class OpaClient(BasePolicyStoreClient):
                 for failure_msg in failure_msgs:
                     logger.error(failure_msg)
 
-                raise RuntimeError(
-                    "Giving up setting / deleting failed modules to OPA")
+                raise RuntimeError("Giving up setting / deleting failed modules to OPA")
 
             ops = failed_ops  # retry failed ops
 
@@ -770,7 +770,8 @@ class OpaClient(BasePolicyStoreClient):
                 headers = await self._get_auth_headers()
 
                 async with session.delete(
-                    f"{self._opa_url}/data{path}", headers=headers,
+                    f"{self._opa_url}/data{path}",
+                    headers=headers,
                     **self._ssl_context_kwargs,
                 ) as opa_response:
                     response = await proxy_response_unless_invalid(
@@ -804,7 +805,8 @@ class OpaClient(BasePolicyStoreClient):
 
             async with aiohttp.ClientSession() as session:
                 async with session.get(
-                    f"{self._opa_url}/data{path}", headers=headers,
+                    f"{self._opa_url}/data{path}",
+                    headers=headers,
                     **self._ssl_context_kwargs,
                 ) as opa_response:
                     json_response = await opa_response.json()
@@ -892,8 +894,7 @@ class OpaClient(BasePolicyStoreClient):
 
         await OpaClient._attempt_operations_with_postponed_failure_retry(
             [
-                functools.partial(
-                    self.set_policy, policy_id=id, policy_code=raw)
+                functools.partial(self.set_policy, policy_id=id, policy_code=raw)
                 for id, raw in import_data["policies"].items()
             ]
         )

--- a/packages/opal-client/opal_client/policy_store/policy_store_client_factory.py
+++ b/packages/opal-client/opal_client/policy_store/policy_store_client_factory.py
@@ -71,6 +71,9 @@ class PolicyStoreClientFactory:
         oauth_server: Optional[str] = None,
         data_updater_enabled: Optional[bool] = None,
         offline_mode_enabled: bool = False,
+        tls_client_cert: Optional[str] = None,
+        tls_client_key: Optional[str] = None,
+        tls_ca: Optional[str] = None
     ) -> BasePolicyStoreClient:
         """
         Factory method - create a new policy store by type.
@@ -107,6 +110,20 @@ class PolicyStoreClientFactory:
         )
 
         res: Optional[BasePolicyStoreClient] = None
+        tls_client_cert = (
+            tls_client_cert
+            or opal_client_config.POLICY_STORE_TLS_CLIENT_CERT
+        )
+
+        tls_client_key = (
+            tls_client_key
+            or opal_client_config.POLICY_STORE_TLS_CLIENT_KEY
+        )
+
+        tls_ca = (
+            tls_ca
+            or opal_client_config.POLICY_STORE_TLS_CA
+        )
 
         # OPA
         if PolicyStoreTypes.OPA == store_type:
@@ -121,6 +138,9 @@ class PolicyStoreClientFactory:
                 oauth_server=oauth_server,
                 data_updater_enabled=data_updater_enabled,
                 cache_policy_data=offline_mode_enabled,
+                tls_client_cert=tls_client_cert,
+                tls_client_key=tls_client_key,
+                tls_ca=tls_ca
             )
         elif PolicyStoreTypes.CEDAR == store_type:
             from opal_client.policy_store.cedar_client import CedarClient

--- a/packages/opal-client/opal_client/policy_store/policy_store_client_factory.py
+++ b/packages/opal-client/opal_client/policy_store/policy_store_client_factory.py
@@ -73,7 +73,7 @@ class PolicyStoreClientFactory:
         offline_mode_enabled: bool = False,
         tls_client_cert: Optional[str] = None,
         tls_client_key: Optional[str] = None,
-        tls_ca: Optional[str] = None
+        tls_ca: Optional[str] = None,
     ) -> BasePolicyStoreClient:
         """
         Factory method - create a new policy store by type.
@@ -111,19 +111,14 @@ class PolicyStoreClientFactory:
 
         res: Optional[BasePolicyStoreClient] = None
         tls_client_cert = (
-            tls_client_cert
-            or opal_client_config.POLICY_STORE_TLS_CLIENT_CERT
+            tls_client_cert or opal_client_config.POLICY_STORE_TLS_CLIENT_CERT
         )
 
         tls_client_key = (
-            tls_client_key
-            or opal_client_config.POLICY_STORE_TLS_CLIENT_KEY
+            tls_client_key or opal_client_config.POLICY_STORE_TLS_CLIENT_KEY
         )
 
-        tls_ca = (
-            tls_ca
-            or opal_client_config.POLICY_STORE_TLS_CA
-        )
+        tls_ca = tls_ca or opal_client_config.POLICY_STORE_TLS_CA
 
         # OPA
         if PolicyStoreTypes.OPA == store_type:
@@ -140,7 +135,7 @@ class PolicyStoreClientFactory:
                 cache_policy_data=offline_mode_enabled,
                 tls_client_cert=tls_client_cert,
                 tls_client_key=tls_client_key,
-                tls_ca=tls_ca
+                tls_ca=tls_ca,
             )
         elif PolicyStoreTypes.CEDAR == store_type:
             from opal_client.policy_store.cedar_client import CedarClient

--- a/packages/opal-client/opal_client/policy_store/schemas.py
+++ b/packages/opal-client/opal_client/policy_store/schemas.py
@@ -14,6 +14,7 @@ class PolicyStoreAuth(Enum):
     NONE = "none"
     TOKEN = "token"
     OAUTH = "oauth"
+    TLS = "tls"
 
 
 class PolicyStoreDetails(BaseModel):

--- a/packages/opal-client/opal_client/tests/opa_client_test.py
+++ b/packages/opal-client/opal_client/tests/opa_client_test.py
@@ -1,6 +1,6 @@
 import functools
-import random
 import os
+import random
 
 import pytest
 from fastapi import Response, status
@@ -25,20 +25,22 @@ def parse_nested_tuple(tuple, key):
     p = [parse_nested_tuple(item, key) for item in tuple]
     return p[1]
 
+
 def test_constuctor_should_panic_tls_configured_without_all_parts():
     with pytest.raises(Exception, match="required variables for tls are not set"):
         OpaClient(
-                "http://example.com",
-                opa_auth_token=None,
-                auth_type=PolicyStoreAuth.TLS,
-                oauth_client_id=None,
-                oauth_client_secret=None,
-                oauth_server=None,
-                data_updater_enabled=None,
-                tls_client_cert=None,
-                tls_client_key=None,
-                tls_ca=None
-            )
+            "http://example.com",
+            opa_auth_token=None,
+            auth_type=PolicyStoreAuth.TLS,
+            oauth_client_id=None,
+            oauth_client_secret=None,
+            oauth_server=None,
+            data_updater_enabled=None,
+            tls_client_cert=None,
+            tls_client_key=None,
+            tls_ca=None,
+        )
+
 
 def test_constructor_should_set_up_ca_certificate_even_without_tls_auth_type(tmpdir):
 
@@ -47,19 +49,19 @@ def test_constructor_should_set_up_ca_certificate_even_without_tls_auth_type(tmp
         ca.write(TEST_CA_CERT)
 
     c = OpaClient(
-                "http://example.com",
-                opa_auth_token=None,
-                auth_type=PolicyStoreAuth.NONE,
-                oauth_client_id=None,
-                oauth_client_secret=None,
-                oauth_server=None,
-                data_updater_enabled=None,
-                tls_client_cert=None,
-                tls_client_key=None,
-                tls_ca=ca_path
-            )
+        "http://example.com",
+        opa_auth_token=None,
+        auth_type=PolicyStoreAuth.NONE,
+        oauth_client_id=None,
+        oauth_client_secret=None,
+        oauth_server=None,
+        data_updater_enabled=None,
+        tls_client_cert=None,
+        tls_client_key=None,
+        tls_ca=ca_path,
+    )
     assert c._custom_ssl_context != None
-    certs = c._custom_ssl_context.get_ca_certs(binary_form= False)
+    certs = c._custom_ssl_context.get_ca_certs(binary_form=False)
     assert len(certs) == 1
 
 

--- a/packages/opal-client/opal_client/tests/opa_client_test.py
+++ b/packages/opal-client/opal_client/tests/opa_client_test.py
@@ -1,9 +1,66 @@
 import functools
 import random
+import os
 
 import pytest
 from fastapi import Response, status
 from opal_client.policy_store.opa_client import OpaClient
+from opal_client.policy_store.schemas import PolicyStoreAuth
+
+TEST_CA_CERT = """-----BEGIN CERTIFICATE-----
+MIIBdjCCAR2gAwIBAgIUaQ/M1qL0GzsTMChEAJsLLFgz7a4wCgYIKoZIzj0EAwIw
+EDEOMAwGA1UEAwwFbXktY2EwIBcNMjMwNTE1MDkzMDI2WhgPMjg0NDA5MjcwOTMw
+MjZaMBAxDjAMBgNVBAMMBW15LWNhMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE
+NKA1Q8QEl9/jA1/e4EZmrJpX3qprKOQ26H6aoFkqLF4UN43R/hG+sLnqlxWK5Eis
+iqm4AY7UIUMbL+UmzccXt6NTMFEwHQYDVR0OBBYEFHLLeNFR/WQCn/t7gDa8jC/A
+UHmAMB8GA1UdIwQYMBaAFHLLeNFR/WQCn/t7gDa8jC/AUHmAMA8GA1UdEwEB/wQF
+MAMBAf8wCgYIKoZIzj0EAwIDRwAwRAIgNAP8VQsRoEeiUzLUr3I3+AiRWesnLnPg
+okEOHA1r6hQCIH4jaSUrDN51u9uTvYw0UPmGk5TqaBtWpEuzgCKzOjy+
+-----END CERTIFICATE-----"""
+
+
+def parse_nested_tuple(tuple, key):
+    if tuple[0] == key:
+        return tuple[1]
+    p = [parse_nested_tuple(item, key) for item in tuple]
+    return p[1]
+
+def test_constuctor_should_panic_tls_configured_without_all_parts():
+    with pytest.raises(Exception, match="required variables for tls are not set"):
+        OpaClient(
+                "http://example.com",
+                opa_auth_token=None,
+                auth_type=PolicyStoreAuth.TLS,
+                oauth_client_id=None,
+                oauth_client_secret=None,
+                oauth_server=None,
+                data_updater_enabled=None,
+                tls_client_cert=None,
+                tls_client_key=None,
+                tls_ca=None
+            )
+
+def test_constructor_should_set_up_ca_certificate_even_without_tls_auth_type(tmpdir):
+
+    ca_path = os.path.join(tmpdir, "ca.pem")
+    with open(ca_path, "w") as ca:
+        ca.write(TEST_CA_CERT)
+
+    c = OpaClient(
+                "http://example.com",
+                opa_auth_token=None,
+                auth_type=PolicyStoreAuth.NONE,
+                oauth_client_id=None,
+                oauth_client_secret=None,
+                oauth_server=None,
+                data_updater_enabled=None,
+                tls_client_cert=None,
+                tls_client_key=None,
+                tls_ca=ca_path
+            )
+    assert c._custom_ssl_context != None
+    certs = c._custom_ssl_context.get_ca_certs(binary_form= False)
+    assert len(certs) == 1
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Fixes Issue

Closes #456 

<!-- Remove this section if not applicable -->

<!-- Example: Closes #31 -->

## Changes proposed

Add environment variables:
- POLICY_STORE_TLS_CLIENT_CERT: the certificate of the client
- POLICY_STORE_TLS_CLIENT_KEY: the private key of the client
- POLICY_STORE_TLS_CA: the ca (and any intermediate) to verify the certificates

Use new mtls context if all above environment variables been configured to communicate with opa.

## Check List (Check all the applicable boxes) <!-- Follow the above conventions to check the box -->

- [x] My code follows the code style of this project.
- [x] My change requires changes to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] This PR does not contain plagiarized content.
- [x] The title of my pull request is a short description of the requested changes.

## Screenshots

<!-- Add all the screenshots which support your changes -->

## Note to reviewers


~Draft PR for now; will add unit test coverage and method to test before finalizing PR~

### Testing:
Generate certificates following OPA documentation:
https://www.openpolicyagent.org/docs/latest/security/#tls-based-authentication-example

```sh

mkdir certs && cd certs

# CA
openssl ecparam -out ca-key.pem -name prime256v1 -genkey
openssl req -x509 -new -nodes -key ca-key.pem -days 30 -out ca.pem -subj "/CN=my-ca"

# Client (opal-client)
cat <<EOF >req.cnf
[req]
req_extensions = v3_req
distinguished_name = req_distinguished_name

[req_distinguished_name]

[v3_req]
basicConstraints = CA:FALSE
subjectAltName = @alt_names

[alt_names]
URI.1 = spiffe://example.com/client-1
EOF

openssl ecparam -out client-key-1.pem -name prime256v1 -genkey
openssl req -new -key client-key-1.pem -out csr.pem -subj "/CN=client-1" -config req.cnf 
openssl x509 -req -in csr.pem -CA ca.pem -CAkey ca-key.pem -CAcreateserial -out client-cert-1.pem -days 10 -extensions v3_req -extfile req.cnf -sha256

# Client (external not-in-acl)
cat <<EOF >req.cnf
[req]
req_extensions = v3_req
distinguished_name = req_distinguished_name

[req_distinguished_name]

[v3_req]
basicConstraints = CA:FALSE
subjectAltName = @alt_names

[alt_names]
URI.1 = spiffe://example.com/client-2
EOF

openssl ecparam -out client-key-2.pem -name prime256v1 -genkey 
openssl req -new -key client-key-2.pem -out csr.pem -subj "/CN=client-2" -config req.cnf
openssl x509 -req -in csr.pem -CA ca.pem -CAkey ca-key.pem -CAcreateserial -out client-cert-2.pem -days 10 -extensions v3_req -extfile req.cnf -sha256


# Server (opa)
cat <<EOF >req.cnf
[req]
req_extensions = v3_req
distinguished_name = req_distinguished_name

[req_distinguished_name]

[v3_req]
basicConstraints = CA:FALSE
keyUsage = nonRepudiation, digitalSignature, keyEncipherment
subjectAltName = @alt_names

[alt_names]
DNS.1 = opa.example.com
IP.1 = 127.0.0.1
URI.1 = spiffe://example.com/server
EOF

openssl ecparam -out server-key.pem -name prime256v1 -genkey
openssl req -new -key server-key.pem -out csr.pem -subj "/CN=server" -config req.cnf
openssl x509 -req -in csr.pem -CA ca.pem -CAkey ca-key.pem -CAcreateserial -out server-cert.pem -days 10 -extensions v3_req -extfile req.cnf -sha256

cd .. && mkdir startup-data && cd startup-data
cat <<EOF >auth.rego
package system.authz

import future.keywords.if
import future.keywords.in

id_uri := input.client_certificates[0].URIs[0]
id_string := sprintf("%s://%s%s", [id_uri.Scheme, id_uri.Host, id_uri.Path])

clients := [
  "spiffe://example.com/client-1"
]

default allow := {"allowed": false, "reason": "Access denied"}

allow := { "allowed": true } if {
  id_string in clients
} else := {
  "allowed": false,
  "reason": "Access denied"
}
EOF
```

Start opal-server
```
docker run -d -e "OPAL_LOG_LEVEL=DEBUG" -e "OPAL_POLICY_REPO_URL=https://github.com/permitio/opal-example-policy-repo.git"  -p 7002:7002 permitio/opal-server
```

Build opal from branch source and start opal-client:
```
docker run -it -e "OPAL_SERVER_URL=http://<opal-server-ip>:7002" -e 'OPAL_INLINE_OPA_CONFIG={"authorization":"basic","authentication":"tls","files":["/opt/opa/startup-data/auth.rego"],"tls_ca_cert_file":"/opt/opa/certs/ca.pem","tls_cert_file":"/opt/opa/certs/server-cert.pem","tls_private_key_file":"/opt/opa/certs/server-key.pem"}' -e "OPAL_POLICY_STORE_TLS_CA=/opt/opa/certs/ca.pem" -e "OPAL_POLICY_STORE_TLS_CLIENT_CERT=/opt/opa/certs/client-cert-1.pem" -e "OPAL_POLICY_STORE_TLS_CLIENT_KEY=/opt/opa/certs/client-key-1.pem" -e "OPAL_POLICY_STORE_AUTH_TYPE=tls" -e "OPAL_POLICY_STORE_URL=https://127.0.0.1:8181" -p 7000:7000 -p 8181:8181 -v $(pwd)/certs:/opt/opa/certs -v $(pwd)/startup-data/:/opt/opa/startup-data permitio/opal-client
```

Verify mutual tls requirement
```
# Verify https requirement
curl http://127.0.0.1:8181/v1/policies

# Verify client certificate requirement 
curl --ca certs/ca.pem http://127.0.0.1:8181/v1/policies

# Verify not working with client certificate not in acl (should return Access Denied message from rego)
curl --cert client-cert-2.pem --key client-key-2.pem  --cacert ca.pem -vvvvv https://127.0.0.1:8181/v1/policies

# Verify working communication using client cert and key (fetches policies put there by opal-client)
curl --cert client-cert-1.pem --key client-key-1.pem  --cacert ca.pem -vvvvv https://127.0.0.1:8181/v1/policies

# Verify logs in pod opal-client
```

