### PR TITLE
Docker: Fix wait-for.sh kafka

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -142,7 +142,7 @@ USER opal
 # ---------------------------------------------------
 FROM common as server
 
-RUN apt-get update && apt-get install -y openssh-client git curl jq && apt-get clean
+RUN apt-get update && apt-get install -y openssh-client git curl jq netcat && apt-get clean
 
 USER opal
 

--- a/docker/docker-compose-with-kafka-example.yml
+++ b/docker/docker-compose-with-kafka-example.yml
@@ -77,7 +77,7 @@ services:
       - "7002:7002"
     depends_on:
       - kafka_broadcast_channel
-    command: sh -c "exec /usr/wait-for.sh kafka:9092 --timeout=30 -- /start.sh"
+    command: sh -c "exec /usr/wait-for.sh kafka:9092 --timeout=60 -- /start.sh"
 
   opal_client:
     # by default we run opal-client from latest official image


### PR DESCRIPTION
Add netcat to opal-server's netcat
Increase wait-for.sh timeout on kafka docker-compose example

