### PR TITLE
introduce config variable to disable policy listening on OPAL client

### DIFF
--- a/documentation/docs/getting-started/configuration.mdx
+++ b/documentation/docs/getting-started/configuration.mdx
@@ -133,7 +133,8 @@ Please use this table as a reference.
 | KEEP_ALIVE_INTERVAL                   |                                                                                                                                                                                           |         |
 | OFFLINE_MODE_ENABLED                  | If set, opal client will try to load policy store from backup file and operate even if server is unreachable. Ignored if INLINE_OPA_ENABLED=False                                         |         |
 | STORE_BACKUP_PATH                     | Path to backup policy store's data to                                                                                                                                                     |         |
-| STORE_BACKUP_INTERVAL                 | Interval in seconds to backup policy store's data                                                                                                                                         |         |
+| STORE_BACKUP_INTERVAL                 | Interval in seconds to backup policy store's data   
+| POLICY_UPDATER_ENABLED                | If set to `FALSE`, OPAL Client will not fetch policies or listen to policy updates.                                                                                                                   |         |                                                                                                                                      |         |
 
 ## Policy Updater Configuration Variables
 

--- a/documentation/docs/getting-started/configuration.mdx
+++ b/documentation/docs/getting-started/configuration.mdx
@@ -133,7 +133,7 @@ Please use this table as a reference.
 | KEEP_ALIVE_INTERVAL                   |                                                                                                                                                                                           |         |
 | OFFLINE_MODE_ENABLED                  | If set, opal client will try to load policy store from backup file and operate even if server is unreachable. Ignored if INLINE_OPA_ENABLED=False                                         |         |
 | STORE_BACKUP_PATH                     | Path to backup policy store's data to                                                                                                                                                     |         |
-| STORE_BACKUP_INTERVAL                 | Interval in seconds to backup policy store's data   
+| STORE_BACKUP_INTERVAL                 | Interval in seconds to backup policy store's data
 | POLICY_UPDATER_ENABLED                | If set to `FALSE`, OPAL Client will not fetch policies or listen to policy updates.                                                                                                                   |         |                                                                                                                                      |         |
 
 ## Policy Updater Configuration Variables

--- a/packages/opal-client/opal_client/config.py
+++ b/packages/opal-client/opal_client/config.py
@@ -74,6 +74,13 @@ class OpalClientConfig(Confi):
         description="When loading policies manually or otherwise externally into the policy store, use this list of glob patterns to have OPAL ignore and not delete or override them, end paths (without any wildcards in the middle) with '\**' to indicate you want all nested under the path to be ignored",
     )
 
+    POLICY_UPDATER_ENABLED = confi.bool(
+        "POLICY_UPDATER_ENABLED",
+        True,
+        description="If set to False, opal client will not listen to dynamic policy updates."
+        "Policy update fetching will be completely disabled.",
+    )
+
     # create an instance of a policy store upon load
     def load_policy_store():
         from opal_client.policy_store.policy_store_client_factory import (

--- a/packages/opal-client/opal_client/policy_store/opa_client.py
+++ b/packages/opal-client/opal_client/policy_store/opa_client.py
@@ -120,9 +120,9 @@ class OpaTransactionLogState:
             self._last_data_transaction is not None
             and self._last_data_transaction.success
         )
-        is_healthy: bool = (self._policy_updater_disabled or policy_updater_is_healthy) and (
-            self._data_updater_disabled or data_updater_is_healthy
-        )
+        is_healthy: bool = (
+            self._policy_updater_disabled or policy_updater_is_healthy
+        ) and (self._data_updater_disabled or data_updater_is_healthy)
         logger.info(
             f"OPA client health: {is_healthy} (policy: {policy_updater_is_healthy}, data: {data_updater_is_healthy})"
         )
@@ -355,7 +355,10 @@ class OpaClient(BasePolicyStoreClient):
             else {}
         )
 
-        self._transaction_state = OpaTransactionLogState(data_updater_enabled=data_updater_enabled, policy_updater_enabled=policy_updater_enabled)
+        self._transaction_state = OpaTransactionLogState(
+            data_updater_enabled=data_updater_enabled,
+            policy_updater_enabled=policy_updater_enabled,
+        )
         # as long as this is null, persisting transaction log to OPA is disabled
         self._transaction_state_writer: Optional[OpaTransactionLogState] = None
 

--- a/packages/opal-client/opal_client/policy_store/opa_client.py
+++ b/packages/opal-client/opal_client/policy_store/opa_client.py
@@ -90,8 +90,10 @@ class OpaTransactionLogState:
     def __init__(
         self,
         data_updater_enabled: bool = True,
+        policy_updater_enabled: bool = True,
     ):
         self._data_updater_disabled = not data_updater_enabled
+        self._policy_updater_disabled = not policy_updater_enabled
         self._num_successful_policy_transactions = 0
         self._num_failed_policy_transactions = 0
         self._num_successful_data_transactions = 0
@@ -118,7 +120,7 @@ class OpaTransactionLogState:
             self._last_data_transaction is not None
             and self._last_data_transaction.success
         )
-        is_healthy: bool = policy_updater_is_healthy and (
+        is_healthy: bool = (self._policy_updater_disabled or policy_updater_is_healthy) and (
             self._data_updater_disabled or data_updater_is_healthy
         )
         logger.info(
@@ -284,6 +286,7 @@ class OpaClient(BasePolicyStoreClient):
         oauth_client_secret: Optional[str] = None,
         oauth_server: Optional[str] = None,
         data_updater_enabled: bool = True,
+        policy_updater_enabled: bool = True,
         cache_policy_data: bool = False,
         tls_client_cert: Optional[str] = None,
         tls_client_key: Optional[str] = None,
@@ -352,7 +355,7 @@ class OpaClient(BasePolicyStoreClient):
             else {}
         )
 
-        self._transaction_state = OpaTransactionLogState(data_updater_enabled)
+        self._transaction_state = OpaTransactionLogState(data_updater_enabled=data_updater_enabled, policy_updater_enabled=policy_updater_enabled)
         # as long as this is null, persisting transaction log to OPA is disabled
         self._transaction_state_writer: Optional[OpaTransactionLogState] = None
 

--- a/packages/opal-client/opal_client/policy_store/policy_store_client_factory.py
+++ b/packages/opal-client/opal_client/policy_store/policy_store_client_factory.py
@@ -70,6 +70,7 @@ class PolicyStoreClientFactory:
         oauth_client_secret: Optional[str] = None,
         oauth_server: Optional[str] = None,
         data_updater_enabled: Optional[bool] = None,
+        policy_updater_enabled: Optional[bool] = None,
         offline_mode_enabled: bool = False,
         tls_client_cert: Optional[str] = None,
         tls_client_key: Optional[str] = None,
@@ -108,6 +109,11 @@ class PolicyStoreClientFactory:
             if data_updater_enabled is not None
             else opal_client_config.DATA_UPDATER_ENABLED
         )
+        policy_updater_enabled = (
+            policy_updater_enabled
+            if policy_updater_enabled is not None
+            else opal_client_config.POLICY_UPDATER_ENABLED
+        )
 
         res: Optional[BasePolicyStoreClient] = None
         tls_client_cert = (
@@ -132,6 +138,7 @@ class PolicyStoreClientFactory:
                 oauth_client_secret=oauth_client_secret,
                 oauth_server=oauth_server,
                 data_updater_enabled=data_updater_enabled,
+                policy_updater_enabled=policy_updater_enabled,
                 cache_policy_data=offline_mode_enabled,
                 tls_client_cert=tls_client_cert,
                 tls_client_key=tls_client_key,


### PR DESCRIPTION
## Fixes Issue
Fixes issue #455 

## Changes proposed
- Added a new environment variable called `OPAL_POLICY_UPDATER_ENABLED` for OPAL client which would disable policy fetcher on the OPAL client
- The value of the env variable will optionally initialise the `PolicyUpdater` which is responsible for fetching policies from server
<!-- Mark all the applicable boxes. To mark the box as done follow the following conventions -->
<!--
[x] - Correct; marked as done
[X] - Correct; marked as done

[ ] - Not correct; marked as **not** done
-->

## Check List (Check all the applicable boxes) <!-- Follow the above conventions to check the box -->

- [x] My code follows the code style of this project.
- [x] My change requires changes to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [x] This PR does not contain plagiarized content.
- [x] The title of my pull request is a short description of the requested changes.

## Screenshots

## Note to reviewers
- Although this does address the issue i mentioned, there is a problem that the server will try to push policy updates to the client and will result in an error as the client will not listen to that event
- I haven't been able to figure out how to segregate policy update events from data update events, an alternative i have been thinking is to listen to policy updates on client but ignore them after receiving based on the `OPAL_POLICY_UPDATER_ENABLED` which would be smaller change than having to segregate the events itself
- I would really appreciate if someone can help me figure out how i can proceed on this issue by pointing me to relevant code i should look at as i am not so averse with python and web sockets
- regarding `All new and existing tests passed`, when i am running all test cases by doing `pytest ./` the test cases get stuck at `packages/opal-common/opal_common/git/tests/repo_cloner_test.py` and does not exit or continue