### PR TITLE
Fix build and push workflow (Correctly support multi arch)

### DIFF
--- a/.github/workflows/on_release.yml
+++ b/.github/workflows/on_release.yml
@@ -44,7 +44,7 @@ jobs:
 
       - name: Login to DockerHub
         if: ${{ !(github.event_name == 'workflow_dispatch' && github.event.inputs.dry_run == 'true') }}
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}


### PR DESCRIPTION
buildx doesn't support multi arch when using "load=true". 
So first the workflow builds the image for x86, then it tests it, only then it builds & pushes with multi-arch.