### PR TITLE
add support for save_method PATCH

### DIFF
--- a/packages/opal-client/requires.txt
+++ b/packages/opal-client/requires.txt
@@ -4,3 +4,4 @@ psutil>=5.9.1,<6
 tenacity>=8.0.1,<9
 websockets>=10.3,<11
 dpath>=2.1.5,<3
+jsonpatch>=1.33,<2

--- a/packages/opal-server/opal_server/data/data_update_publisher.py
+++ b/packages/opal-server/opal_server/data/data_update_publisher.py
@@ -109,7 +109,9 @@ class DataUpdatePublisher:
         )
 
         async with self._publisher:
-            await self._publisher.publish(list(all_topic_combos), update)
+            await self._publisher.publish(
+                list(all_topic_combos), update.dict(by_alias=True)
+            )
 
     async def _periodic_update_callback(
         self, update: DataSourceEntryWithPollingInterval


### PR DESCRIPTION
## Changes proposed
Add support for `PATCH` as a `save_method`, currently only `PUT` is supported as a `save_method`
<!-- List all the proposed changes in your PR -->
- use `JSONPatchAction` to validate and read JSON patch operations
- add `patch_policy_data` to opal_client which does a PATCH API call to OPA 
    -  based on the save_method value, call either `set_policy_data` or `patch_policy_data` respectively
- added [jsonpatch](https://pypi.org/project/jsonpatch/) package to apply JSON patch operations on OPA data cache when offline mode is enabled
- added a function `custom_encoder`  for using it as the default encoder for doing `json.dumps` on the Union type `JsonableValue` to ignore default fields values and dump based on alias name

<!-- Mark all the applicable boxes. To mark the box as done follow the following conventions -->
<!--
[x] - Correct; marked as done
[X] - Correct; marked as done

[ ] - Not correct; marked as **not** done
-->

## Check List (Check all the applicable boxes) <!-- Follow the above conventions to check the box -->

- [x] My code follows the code style of this project.
- [ ] My change requires changes to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] This PR does not contain plagiarized content.
- [x] The title of my pull request is a short description of the requested changes.

<!-- Add all the screenshots which support your changes -->

## Note to reviewers
Need thoughts/help on if there is a better way to do `custom_encoder` implementation, haven't used pydantic before

the reason i used it was because FastAPI does by default print response using JSON alias names but we are not returning response from FastAPI server but rather feeding the model directly to OPA in which case the field name would be used when doing a `json.dumps` instead of alias name

and also to remove default `None` value populated fields from the dumped JSON for any request that matches the `JSONPatchAction` type

One more thing is, OPA does not support `move` operation as a JSON patch operation, [refer discussion](https://github.com/orgs/open-policy-agent/discussions/462#discussioncomment-6343050) and hence OPAL would also not support it
what would be a good place in the docs to mentions this as a NOTE ?