### PR TITLE
bump gitpython because of CVE-2023-40267 

### DIFF
--- a/packages/opal-common/requires.txt
+++ b/packages/opal-common/requires.txt
@@ -1,7 +1,7 @@
 aiohttp>=3.8.1,<4
 click>=8.1.3,<9
 cryptography>=38.0.3,<39
-gitpython>=3.1.27,<4
+gitpython>=3.1.32,<4
 loguru>=0.6.0,<1
 pyjwt[crypto]>=2.4.0,<3
 python-decouple>=3.6,<4

--- a/packages/opal-server/requires.txt
+++ b/packages/opal-server/requires.txt
@@ -1,6 +1,6 @@
 click>=8.1.3,<9
 permit-broadcaster[postgres,redis,kafka]>=0.2.0,<1
-gitpython>=3.1.27,<4
+gitpython>=3.1.32,<4
 pyjwt[crypto]>=2.1.0,<3
 websockets>=10.3,<11
 ddtrace>=1.1.4,<2


### PR DESCRIPTION
Gitpython has a vulnerability where it does not block insecure non-multi options in clone and clone_from. This popped up in our vulnerability scanner, so I thought it suggest to bump it. 

https://avd.aquasec.com/nvd/2023/cve-2023-40267/

I have a hard time seeing it should pose a real security issue for OPAL users, but who knows. At the very least, it's nice to not get any critical vulnerability reports in vulnerability scanners.


The minor version bump suggest it should be an easy one. Complete changelog here: https://github.com/gitpython-developers/GitPython/compare/3.1.27...3.1.32


## Check List (Check all the applicable boxes) <!-- Follow the above conventions to check the box -->

- [x] I sign off on contributing this submission to open-source
- [ ] ~My code follows the code style of this project.~
- [ ] ~My change requires changes to the documentation.~
- [ ] ~I have updated the documentation accordingly.~
- [ ] All new and existing tests passed.
- [x] This PR does not contain plagiarized content.
- [x] The title of my pull request is a short description of the requested changes.


## Note to reviewers

I am not sure exactly how to test this further than the automated tests. Let me know if you want further action from my side.

I did not get the tests running on my local machine - would need approval on the test run: https://github.com/permitio/opal/actions/runs/5956379336
