### PR TITLE
Use redis-py to replace asyncio-redis

### DIFF
--- a/packages/opal-common/opal_common/synchronization/expiring_redis_lock.py
+++ b/packages/opal-common/opal_common/synchronization/expiring_redis_lock.py
@@ -1,11 +1,12 @@
 import asyncio
 
 import redis.asyncio as redis
+
 from opal_common.logger import logger
 
 
 async def run_locked(
-        _redis: redis.Redis, lock_name: str, coro: asyncio.coroutine, timeout: int = 10
+    _redis: redis.Redis, lock_name: str, coro: asyncio.coroutine, timeout: int = 10
 ):
     """This function runs a coroutine wrapped in a redis lock, in a way that
     prevents hanging locks. Hanging locks can happen when a process crashes

--- a/packages/opal-common/opal_common/synchronization/expiring_redis_lock.py
+++ b/packages/opal-common/opal_common/synchronization/expiring_redis_lock.py
@@ -2,6 +2,7 @@ import asyncio
 
 import redis.asyncio as redis
 
+
 from opal_common.logger import logger
 
 

--- a/packages/opal-common/opal_common/synchronization/expiring_redis_lock.py
+++ b/packages/opal-common/opal_common/synchronization/expiring_redis_lock.py
@@ -1,8 +1,6 @@
 import asyncio
 
 import redis.asyncio as redis
-
-
 from opal_common.logger import logger
 
 

--- a/packages/opal-common/opal_common/synchronization/expiring_redis_lock.py
+++ b/packages/opal-common/opal_common/synchronization/expiring_redis_lock.py
@@ -1,11 +1,11 @@
 import asyncio
 
-import aioredis
+import redis.asyncio as redis
 from opal_common.logger import logger
 
 
 async def run_locked(
-    redis: aioredis.Redis, lock_name: str, coro: asyncio.coroutine, timeout: int = 10
+        _redis: redis.Redis, lock_name: str, coro: asyncio.coroutine, timeout: int = 10
 ):
     """This function runs a coroutine wrapped in a redis lock, in a way that
     prevents hanging locks. Hanging locks can happen when a process crashes
@@ -13,7 +13,7 @@ async def run_locked(
 
     This function sets a redis enforced timeout, and reacquires the lock every timeout * 0.8 (as long as it runs)
     """
-    lock = redis.lock(lock_name, timeout=timeout)
+    lock = _redis.lock(lock_name, timeout=timeout)
     try:
         logger.debug(f"Trying to acquire redis lock: {lock_name}")
         await lock.acquire()

--- a/packages/opal-server/opal_server/git_fetcher.py
+++ b/packages/opal-server/opal_server/git_fetcher.py
@@ -5,7 +5,6 @@ from pathlib import Path
 from typing import Optional, cast
 
 import aiofiles.os
-import aioredis
 import pygit2
 from git import Repo
 from opal_common.async_utils import run_sync

--- a/packages/opal-server/opal_server/git_fetcher.py
+++ b/packages/opal-server/opal_server/git_fetcher.py
@@ -1,4 +1,3 @@
-import asyncio
 import hashlib
 import shutil
 from pathlib import Path

--- a/packages/opal-server/opal_server/redis.py
+++ b/packages/opal-server/opal_server/redis.py
@@ -1,6 +1,6 @@
 from typing import Generator
 
-import aioredis
+import redis.asyncio as redis
 from opal_common.logger import logger
 from pydantic import BaseModel
 
@@ -12,10 +12,10 @@ class RedisDB:
         self._url = redis_url
         logger.debug("Connecting to Redis: {url}", url=self._url)
 
-        self._redis = aioredis.from_url(self._url)
+        self._redis = redis.Redis.from_url(self._url)
 
     @property
-    def redis_connection(self) -> aioredis.Redis:
+    def redis_connection(self) -> redis.Redis:
         return self._redis
 
     async def set(self, key: str, value: BaseModel):

--- a/packages/opal-server/requires.txt
+++ b/packages/opal-server/requires.txt
@@ -6,7 +6,6 @@ websockets>=10.3,<11
 ddtrace>=1.1.4,<2
 slowapi>=0.1.5,<1
 # slowapi is stuck on and old `redis`, so fix that and switch from aioredis to redis
-aioredis>=2.0.1,<3
 pygit2>=1.9.2,<2
 asgiref>=3.5.2,<4
 redis>=4.3.4,<5


### PR DESCRIPTION


## Fixes Issue
Close #497 

Use redis.asyncio from redis-py to replace asyncio-redis.
Since  package `asyncio-redis` had  already been  integrated to redis-py and abanded
