### PR TITLE
Install netcat and jq in the common stage

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -109,8 +109,6 @@ FROM client-standalone as client
 # Temporarily move back to root for additional setup
 USER root
 
-RUN apt-get update && apt-get install -y netcat jq && apt-get clean
-
 # copy opa from opa-extractor
 COPY --from=opa-extractor /opal/opa ./opa
 
@@ -144,7 +142,7 @@ USER opal
 # ---------------------------------------------------
 FROM common as server
 
-RUN apt-get update && apt-get install -y openssh-client git curl jq netcat && apt-get clean
+RUN apt-get update && apt-get install -y openssh-client git curl && apt-get clean
 
 USER opal
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -37,6 +37,10 @@ WORKDIR /opal
 COPY scripts/wait-for.sh .
 RUN chmod +x ./wait-for.sh
 RUN ln -s /opal/wait-for.sh /usr/wait-for.sh
+
+# netcat (nc) is used by the wait-for.sh script
+RUN apt-get update && apt-get install -y netcat jq && apt-get clean
+
 # copy startup script (create link at old path to maintain backward compatibility)
 COPY ./scripts/start.sh .
 RUN chmod +x ./start.sh
@@ -123,8 +127,6 @@ FROM client-standalone as client-cedar
 
 # Temporarily move back to root for additional setup
 USER root
-
-RUN apt-get update && apt-get install -y netcat jq && apt-get clean
 
 # Copy cedar from its build stage
 COPY --from=cedar-builder /cedar-agent /bin/cedar-agent


### PR DESCRIPTION
The wait-for.sh script requires netcat and currently the `client-standalone` image fails if trying to use the `wait-for.sh` script, since netcat happens to not be installed in that specific image.

## Changes proposed

Move the installation of `netcat` and `jq` to the common stage, since `netcat` is required by the `wait-for.sh` script

<!-- List all the proposed changes in your PR -->

<!-- Mark all the applicable boxes. To mark the box as done follow the following conventions -->
<!--
[x] - Correct; marked as done
[X] - Correct; marked as done

[ ] - Not correct; marked as **not** done
-->

## Check List (Check all the applicable boxes) <!-- Follow the above conventions to check the box -->

- [x] I sign off on contributing this submission to open-source
- [x] My code follows the code style of this project.
- [ ] My change requires changes to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [x] This PR does not contain plagiarized content.
- [x] The title of my pull request is a short description of the requested changes.
