### PR TITLE
Add missing `x-amz-content-sha256` header when generating headers for…

### DIFF
--- a/documentation/docs/tutorials/track_an_api_bundle_server.mdx
+++ b/documentation/docs/tutorials/track_an_api_bundle_server.mdx
@@ -40,7 +40,6 @@ You can configure how the OPAL-server will authenticate itself with the bundle s
 | POLICY_BUNDLE_SERVER_TYPE      | `HTTP` (authenticated with bearer token,or nothing), `AWS-S3`(Authenticated with [AWS REST Auth](https://docs.aws.amazon.com/AmazonS3/latest/userguide/RESTAuthentication.html) | AWS-S3                                   |
 | POLICY_BUNDLE_SERVER_TOKEN_ID  | The Secret Token Id (AKA user id, AKA access-key) sent to the API bundle server.                                                                                                | AKIAIOSFODNN7EXAMPLE                     |
 | POLICY_BUNDLE_SERVER_TOKEN     | The Secret Token (AKA password, AKA secret-key) sent to the API bundle server.                                                                                                  | wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY |
-| POLICY_BUNDLE_SERVER_TOKEN     | The Secret Token (AKA password, AKA secret-key) sent to the API bundle server.                                                                                                  | wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY |
 | POLICY_BUNDLE_SERVER_AWS_REGION| The AWS Region if using `AWS-S3`  Defaults to `us-east-1`                                                                                                                       | us-east-1                                |
 
 ## <a name="compose-example"></a>Docker compose example

--- a/documentation/docs/tutorials/track_an_api_bundle_server.mdx
+++ b/documentation/docs/tutorials/track_an_api_bundle_server.mdx
@@ -37,9 +37,11 @@ You can configure how the OPAL-server will authenticate itself with the bundle s
 
 | Variables                     | Description                                                                                                                                                                     | Example                                  |
 | ----------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------- |
-| POLICY_BUNDLE_SERVER_TYPE     | `HTTP` (authenticated with bearer token,or nothing), `AWS-S3`(Authenticated with [AWS REST Auth](https://docs.aws.amazon.com/AmazonS3/latest/userguide/RESTAuthentication.html) | AWS-S3                                   |
-| POLICY_BUNDLE_SERVER_TOKEN_ID | The Secret Token Id (AKA user id, AKA access-key) sent to the API bundle server.                                                                                                | AKIAIOSFODNN7EXAMPLE                     |
-| POLICY_BUNDLE_SERVER_TOKEN    | The Secret Token (AKA password, AKA secret-key) sent to the API bundle server.                                                                                                  | wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY |
+| POLICY_BUNDLE_SERVER_TYPE      | `HTTP` (authenticated with bearer token,or nothing), `AWS-S3`(Authenticated with [AWS REST Auth](https://docs.aws.amazon.com/AmazonS3/latest/userguide/RESTAuthentication.html) | AWS-S3                                   |
+| POLICY_BUNDLE_SERVER_TOKEN_ID  | The Secret Token Id (AKA user id, AKA access-key) sent to the API bundle server.                                                                                                | AKIAIOSFODNN7EXAMPLE                     |
+| POLICY_BUNDLE_SERVER_TOKEN     | The Secret Token (AKA password, AKA secret-key) sent to the API bundle server.                                                                                                  | wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY |
+| POLICY_BUNDLE_SERVER_TOKEN     | The Secret Token (AKA password, AKA secret-key) sent to the API bundle server.                                                                                                  | wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY |
+| POLICY_BUNDLE_SERVER_AWS_REGION| The AWS Region if using `AWS-S3`  Defaults to `us-east-1`                                                                                                                       | us-east-1                                |
 
 ## <a name="compose-example"></a>Docker compose example
 

--- a/packages/opal-common/opal_common/sources/api_policy_source.py
+++ b/packages/opal-common/opal_common/sources/api_policy_source.py
@@ -138,7 +138,9 @@ class ApiPolicySource(BasePolicySource):
             host = split_url.netloc
             path = split_url.path + "/" + path
 
-            return build_aws_rest_auth_headers(self.token_id, token, host, path, self.region)
+            return build_aws_rest_auth_headers(
+                self.token_id, token, host, path, self.region
+            )
         else:
             return {}
 

--- a/packages/opal-common/opal_common/sources/api_policy_source.py
+++ b/packages/opal-common/opal_common/sources/api_policy_source.py
@@ -50,6 +50,7 @@ class ApiPolicySource(BasePolicySource):
         polling_interval: int = 0,
         token: Optional[str] = None,
         token_id: Optional[str] = None,
+        region: Optional[str] = None,
         bundle_server_type: Optional[PolicyBundleServerType] = None,
         policy_bundle_path=".",
         policy_bundle_git_add_pattern="*",
@@ -62,6 +63,7 @@ class ApiPolicySource(BasePolicySource):
         self.token = token
         self.token_id = token_id
         self.server_type = bundle_server_type
+        self.region = region
         self.bundle_hash = None
         self.etag = None
         self.tmp_bundle_path = Path(policy_bundle_path)
@@ -136,7 +138,7 @@ class ApiPolicySource(BasePolicySource):
             host = split_url.netloc
             path = split_url.path + "/" + path
 
-            return build_aws_rest_auth_headers(self.token_id, token, host, path)
+            return build_aws_rest_auth_headers(self.token_id, token, host, path, self.region)
         else:
             return {}
 

--- a/packages/opal-common/opal_common/utils.py
+++ b/packages/opal-common/opal_common/utils.py
@@ -136,6 +136,7 @@ def build_aws_rest_auth_headers(key_id: str, secret_key: str, host: str, path: s
 
     return {
         "x-amz-date": amzdate,
+        "x-amz-content-sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
         "Authorization": authorization_header,
     }
 

--- a/packages/opal-common/opal_common/utils.py
+++ b/packages/opal-common/opal_common/utils.py
@@ -56,7 +56,7 @@ def get_authorization_header(token: str) -> Tuple[str, str]:
     return "Authorization", f"Bearer {token}"
 
 
-def build_aws_rest_auth_headers(key_id: str, secret_key: str, host: str, path: str):
+def build_aws_rest_auth_headers(key_id: str, secret_key: str, host: str, path: str, region: str):
     """Use the AWS signature algorithm (https://docs.aws.amazon.com/AmazonS3/la
     test/userguide/RESTAuthentication.html) to generate the hTTP headers.
 
@@ -101,7 +101,9 @@ def build_aws_rest_auth_headers(key_id: str, secret_key: str, host: str, path: s
         + payload_hash
     )
 
-    region = "us-east-1"
+    if not region:
+        region = "us-east-1"
+
     algorithm = "AWS4-HMAC-SHA256"
     credential_scope = datestamp + "/" + region + "/" + "s3" + "/" + "aws4_request"
 

--- a/packages/opal-common/opal_common/utils.py
+++ b/packages/opal-common/opal_common/utils.py
@@ -79,6 +79,9 @@ def build_aws_rest_auth_headers(key_id: str, secret_key: str, host: str, path: s
         kSigning = sign(kService, "aws4_request")
         return kSigning
 
+    # SHA256 of empty string.  This is needed when S3 request payload is empty.
+    SHA256_EMPTY = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+
     t = datetime.utcnow()
     amzdate = t.strftime("%Y%m%dT%H%M%SZ")
     datestamp = t.strftime("%Y%m%d")
@@ -138,7 +141,7 @@ def build_aws_rest_auth_headers(key_id: str, secret_key: str, host: str, path: s
 
     return {
         "x-amz-date": amzdate,
-        "x-amz-content-sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "x-amz-content-sha256": SHA256_EMPTY,
         "Authorization": authorization_header,
     }
 

--- a/packages/opal-common/opal_common/utils.py
+++ b/packages/opal-common/opal_common/utils.py
@@ -104,8 +104,6 @@ def build_aws_rest_auth_headers(key_id: str, secret_key: str, host: str, path: s
         + payload_hash
     )
 
-    if not region:
-        region = "us-east-1"
 
     algorithm = "AWS4-HMAC-SHA256"
     credential_scope = datestamp + "/" + region + "/" + "s3" + "/" + "aws4_request"

--- a/packages/opal-common/opal_common/utils.py
+++ b/packages/opal-common/opal_common/utils.py
@@ -56,7 +56,9 @@ def get_authorization_header(token: str) -> Tuple[str, str]:
     return "Authorization", f"Bearer {token}"
 
 
-def build_aws_rest_auth_headers(key_id: str, secret_key: str, host: str, path: str, region: str):
+def build_aws_rest_auth_headers(
+    key_id: str, secret_key: str, host: str, path: str, region: str
+):
     """Use the AWS signature algorithm (https://docs.aws.amazon.com/AmazonS3/la
     test/userguide/RESTAuthentication.html) to generate the hTTP headers.
 
@@ -103,7 +105,6 @@ def build_aws_rest_auth_headers(key_id: str, secret_key: str, host: str, path: s
         + "\n"
         + payload_hash
     )
-
 
     algorithm = "AWS4-HMAC-SHA256"
     credential_scope = datestamp + "/" + region + "/" + "s3" + "/" + "aws4_request"

--- a/packages/opal-server/opal_server/config.py
+++ b/packages/opal-server/opal_server/config.py
@@ -130,7 +130,7 @@ class OpalServerConfig(Confi):
     )
     POLICY_BUNDLE_SERVER_AWS_REGION = confi.str(
         "POLICY_BUNDLE_SERVER_AWS_REGION",
-        None,
+        "us-east-1",
         description="The AWS region of the S3 bucket",
     )
     POLICY_BUNDLE_TMP_PATH = confi.str(

--- a/packages/opal-server/opal_server/config.py
+++ b/packages/opal-server/opal_server/config.py
@@ -128,6 +128,11 @@ class OpalServerConfig(Confi):
         None,
         description="The id of the secret token to be sent to API bundle server",
     )
+    POLICY_BUNDLE_SERVER_AWS_REGION = confi.str(
+        "POLICY_BUNDLE_SERVER_AWS_REGION",
+        None,
+        description="The AWS region of the S3 bucket",
+    )
     POLICY_BUNDLE_TMP_PATH = confi.str(
         "POLICY_BUNDLE_TMP_PATH",
         "/tmp/bundle.tar.gz",

--- a/packages/opal-server/opal_server/policy/watcher/factory.py
+++ b/packages/opal-server/opal_server/policy/watcher/factory.py
@@ -128,7 +128,7 @@ def setup_watcher_task(
             bundle_server_type=policy_bundle_server_type,
             policy_bundle_path=opal_server_config.POLICY_BUNDLE_TMP_PATH,
             policy_bundle_git_add_pattern=opal_server_config.POLICY_BUNDLE_GIT_ADD_PATTERN,
-            region=policy_bundle_aws_region
+            region=policy_bundle_aws_region,
         )
     else:
         raise ValueError("Unknown value for OPAL_POLICY_SOURCE_TYPE")

--- a/packages/opal-server/opal_server/policy/watcher/factory.py
+++ b/packages/opal-server/opal_server/policy/watcher/factory.py
@@ -27,6 +27,7 @@ def setup_watcher_task(
     policy_bundle_token: str = None,
     policy_bundle_token_id: str = None,
     policy_bundle_server_type: str = None,
+    policy_bundle_aws_region: str = None,
     extensions: Optional[List[str]] = None,
     bundle_ignore: Optional[List[str]] = None,
 ) -> BasePolicyWatcherTask:
@@ -115,6 +116,9 @@ def setup_watcher_task(
         policy_bundle_server_type = load_conf_if_none(
             policy_bundle_server_type, opal_server_config.POLICY_BUNDLE_SERVER_TYPE
         )
+        policy_bundle_aws_region = load_conf_if_none(
+            policy_bundle_aws_region, opal_server_config.POLICY_BUNDLE_SERVER_AWS_REGION
+        )
         watcher = ApiPolicySource(
             remote_source_url=remote_source_url,
             local_clone_path=clone_path,
@@ -124,6 +128,7 @@ def setup_watcher_task(
             bundle_server_type=policy_bundle_server_type,
             policy_bundle_path=opal_server_config.POLICY_BUNDLE_TMP_PATH,
             policy_bundle_git_add_pattern=opal_server_config.POLICY_BUNDLE_GIT_ADD_PATTERN,
+            region=policy_bundle_aws_region
         )
     else:
         raise ValueError("Unknown value for OPAL_POLICY_SOURCE_TYPE")


### PR DESCRIPTION
… s3 authorization.

Also adds the ability to configure the AWS region when pulling from S3.   For back-compat, the code defaults to the original hardcoded `us-east-1` value.   

Closes #518

<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing -->

## Fixes Issue

Fixes #518



## Check List (Check all the applicable boxes) <!-- Follow the above conventions to check the box -->

- [x] I sign off on contributing this submission to open-source
- [x] My code follows the code style of this project.
- [x] My change requires changes to the documentation.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] This PR does not contain plagiarized content.
- [x] The title of my pull request is a short description of the requested changes.

