### PR TITLE
Add Azure Blob Storage as a PolicyBundleServerType

### DIFF
--- a/documentation/docs/tutorials/azure_blob_storage_as_api_bundle_server.mdx
+++ b/documentation/docs/tutorials/azure_blob_storage_as_api_bundle_server.mdx
@@ -1,0 +1,46 @@
+---
+sidebar_position: 11
+title: Azure Blob Storage as Policy Bundle Server
+---
+
+# Azure Blob Storage as Policy Bundle Server
+
+Due to azure blob storage appending the SAS token to the end of the url, the url creation needs to be handled different for Azure Blob Storage connection. 
+
+Setting PolicyBundleServerType.AZURE_BLOB will handle this case and create the correct connection when given the required parameters as environment variables. 
+
+
+You can configure how the OPAL-server will authenticate itself with the bundle server with the following env-var:
+
+| Variables                     | Description                                                                                                                                                                     | Example                                                                                  |
+| ----------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------- |
+| OPAL_BUNDLE_SERVER_TYPE       | Setting to AZURE_BLOB rather than HTTP or AWS_S3, requires extra env-var (below)                                                                                                | AZURE_BLOB                                                                               |
+| OPAL_MI_CLIENT_ID             | Used to create BlobServiceClient using DefaultAzureCredentials                                                                                                                  | xxxxxxxx-xxxx-xxxx-xxxxxxxxxxxx (ms authenticated uuid service principle app id)         |
+| OPAL_BUNDLE_CONTAINER         | Container name for the azure blob storage that is being targeted                                                                                                                | opalpolicybundle                                                                         |
+| OPAL_BLOB_ACCOUNT_URL         | Url to the blob account on azure                                                                                                                                                | https://opalpolicybundleserver43dke.blob.core.windows.net                                |
+
+
+The env-var OPAL_POLICE_BUNDLE_URL should now follow the below pattern:
+
+
+```python
+f"{OPAL_BLOB_ACCOUNT_URL}/{OPAL_BUNDLE_CONTAINER}/bundle.tar.gz"
+```
+
+
+Similar to AWS and HTTP the following should also be set:
+
+OPAL_POLICY_SOURCE_TYPE = "API"
+
+OPAL_POLICY_REPO_CLONE_PATH = /local/path/to/policyfiles   (example : "~/opal")
+
+
+You can also set polling interval 
+
+OPAL_POLICY_REPO_POLLING_INTERVAL = 60 (seconds)
+
+
+Notes:
+
+The URL package from yarl is used to encode the URL as SAS tokens can contain special characters that break the url encoding from environment variables. 
+

--- a/packages/opal-server/opal_server/config.py
+++ b/packages/opal-server/opal_server/config.py
@@ -18,6 +18,7 @@ class PolicySourceTypes(str, Enum):
 class PolicyBundleServerType(str, Enum):
     HTTP = "HTTP"
     AWS_S3 = "AWS-S3"
+    AZURE_BLOB = "AZURE_BLOB"
 
 
 class ServerRole(str, Enum):

--- a/packages/opal-server/requires.txt
+++ b/packages/opal-server/requires.txt
@@ -9,3 +9,6 @@ slowapi>=0.1.5,<1
 pygit2>=1.9.2,<2
 asgiref>=3.5.2,<4
 redis>=4.3.4,<5
+azure-core==1.29.6
+azure-identity==1.15.0
+azure-storage-blob==12.19.0


### PR DESCRIPTION
## Fixes Issue

Fix issue #529

## Changes proposed

Ability to connect to Azure Blob Storage as the PolicyBundleServerType. 

Ability to generate SAS tokens dynamically via ManagedIdentity.

Add URL encoding to the api_policy_source, fetch_policy_bundle_from_api_source method due to special characters in the SAS tokens required to connect to Azure Blob Storage.

## Check List (Check all the applicable boxes) <!-- Follow the above conventions to check the box -->

- [x] I sign off on contributing this submission to open-source
- [x] My code follows the code style of this project.
- [x] My change requires changes to the documentation.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] This PR does not contain plagiarized content.
- [x] The title of my pull request is a short description of the requested changes.


