### PR TITLE
Docs: Make it clear Bundle Server does not serve OPA bundles

### DIFF
--- a/documentation/docs/tutorials/track_an_api_bundle_server.mdx
+++ b/documentation/docs/tutorials/track_an_api_bundle_server.mdx
@@ -5,7 +5,9 @@ title: Track an API Bundle Server
 
 # Policy syncing from API
 
-This document describes how to change policy syncing feature of OPAL (policy-code and static data) from the default git to an API server that exposes tar bundles.
+This document describes how to use OPAL for syncing policy (code & static data) sourced from an API server that exposes tar bundles (rather than from a git repo, which is the default policy source).
+
+Bundle in this context are nothing more than a compressed tarball file archiving your policy filles, **not to be confused with an `OPA Bundle`**
 
 We have a [docker compose example file](https://github.com/permitio/opal/blob/master/docker/docker-compose-api-policy-source-example.yml) configured with an api policy source that we will explore in detail [later in this guide](#compose-example).
 

--- a/documentation/docs/tutorials/track_an_api_bundle_server.mdx
+++ b/documentation/docs/tutorials/track_an_api_bundle_server.mdx
@@ -7,7 +7,7 @@ title: Track an API Bundle Server
 
 This document describes how to use OPAL for syncing policy (code & static data) sourced from an API server that exposes tar bundles (rather than from a git repo, which is the default policy source).
 
-Bundle in this context are nothing more than a compressed tarball file archiving your policy filles, **not to be confused with an `OPA Bundle`**
+Bundle in this context are nothing more than a compressed tarball file archiving your policy files, **not to be confused with an `OPA Bundle`**
 
 We have a [docker compose example file](https://github.com/permitio/opal/blob/master/docker/docker-compose-api-policy-source-example.yml) configured with an api policy source that we will explore in detail [later in this guide](#compose-example).
 


### PR DESCRIPTION
Docs: Make it clear Bundle Server (aka API policy source) does not serve OPA bundles.

That follows 2 accidents in which users were confused by that.
