### PR TITLE
Rename `DATA_STORE_CONN_RETRY` to `DATA_UPDATER_CONN_RETRY`

### DIFF
--- a/documentation/docs/getting-started/configuration.mdx
+++ b/documentation/docs/getting-started/configuration.mdx
@@ -156,7 +156,9 @@ Please use this table as a reference.
 | SHOULD_REPORT_ON_DATA_UPDATES   | Should the client report on updates to callbacks defined in DEFAULT_UPDATE_CALLBACKS or within the given updates. |         |
 | DEFAULT_UPDATE_CALLBACK_CONFIG  |                                                                                                                   |         |
 | DEFAULT_UPDATE_CALLBACKS        | Where/How the client should report on the completion of data updates.                                             |         |
-| DATA_STORE_CONN_RETRY           | Retry options when connecting to the base data source (e.g. an external API server which returns data snapshot).  |         |
+| DATA_UPDATER_CONN_RETRY         | Retry options when connecting to the base data source (e.g. an external API server which returns data snapshot).  |         |
+| DATA_STORE_CONN_RETRY           | DEPTRECATED - The old confusing name for DATA_UPDATER_CONN_RETRY, kept for backwards compatibilit (for now)       |         |
+
 
 ## OPA Transaction Log / Healthcheck Configuration Variables
 

--- a/packages/opal-client/opal_client/config.py
+++ b/packages/opal-client/opal_client/config.py
@@ -52,7 +52,7 @@ class OpalClientConfig(Confi):
     POLICY_STORE_CONN_RETRY: ConnRetryOptions = confi.model(
         "POLICY_STORE_CONN_RETRY",
         ConnRetryOptions,
-        # defaults are being set according to PolicyStoreConnRetryOptions pydantic definitions (see class)
+        # defaults are being set according to ConnRetryOptions pydantic definitions (see class)
         {},
         description="retry options when connecting to the policy store (i.e. the agent that handles the policy, e.g. OPA)",
     )
@@ -70,6 +70,13 @@ class OpalClientConfig(Confi):
 
     DATA_STORE_CONN_RETRY: ConnRetryOptions = confi.model(
         "DATA_STORE_CONN_RETRY",
+        ConnRetryOptions,
+        None,
+        description="DEPTRECATED - The old confusing name for DATA_UPDATER_CONN_RETRY, kept for backwards compatibilit (for now)",
+    )
+
+    DATA_UPDATER_CONN_RETRY: ConnRetryOptions = confi.model(
+        "DATA_UPDATER_CONN_RETRY",
         ConnRetryOptions,
         {
             "wait_strategy": "random_exponential",
@@ -321,6 +328,10 @@ class OpalClientConfig(Confi):
             opal_common_config.LOG_MODULE_EXCLUDE_LIST = (
                 opal_common_config.LOG_MODULE_EXCLUDE_LIST
             )
+
+        if self.DATA_STORE_CONN_RETRY is not None:
+            # You should use `DATA_UPDATER_CONN_RETRY`, but that's for backwards compatibility
+            self.DATA_UPDATER_CONN_RETRY = self.DATA_STORE_CONN_RETRY
 
 
 opal_client_config = OpalClientConfig(prefix="OPAL_")

--- a/packages/opal-client/opal_client/data/fetcher.py
+++ b/packages/opal-client/opal_client/data/fetcher.py
@@ -14,9 +14,9 @@ from opal_common.utils import get_authorization_header, tuple_to_dict
 class DataFetcher:
     """fetches policy data from backend."""
 
-    # Use as default config the configuration provider by opal_client_config.DATA_STORE_CONN_RETRY
+    # Use as default config the configuration provider by opal_client_config.DATA_UPDATER_CONN_RETRY
     # Add reraise as true (an option not available for control from the higher-level config)
-    DEFAULT_RETRY_CONFIG = opal_client_config.DATA_STORE_CONN_RETRY.toTenacityConfig()
+    DEFAULT_RETRY_CONFIG = opal_client_config.DATA_UPDATER_CONN_RETRY.toTenacityConfig()
     DEFAULT_RETRY_CONFIG["reraise"] = True
 
     def __init__(

--- a/packages/opal-server/opal_server/config.py
+++ b/packages/opal-server/opal_server/config.py
@@ -296,9 +296,7 @@ class OpalServerConfig(Confi):
         description="Policy polling refresh interval",
     )
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-
+    def on_load(self):
         if self.SERVER_PORT is not None and self.SERVER_PORT.isdigit():
             # Backward compatibility - if SERVER_PORT is set with a valid value, use it as SERVER_BIND_PORT
             self.SERVER_BIND_PORT = int(self.SERVER_PORT)


### PR DESCRIPTION
This configuration variable sets the retry params for the data updater that fetches data from server.
The new name is more inline with the name of the similar variable for the policy updater (that fetches policy from server) - `POLICY_UPDATER_CONN_RETRY`

The older name (`DATA_STORE_CONN_RETRY`) was confusingly matching the retry configuration of the policy store client (OPA) - which actually sets both policy & data.

Backwards compatibility is kept - there would be no breakage for whomever is already using the deprecated name `DATA_STORE_CONN_RETRY`.