### PR TITLE
Improve Statistics and introduce server (and client) counts

### DIFF
--- a/packages/opal-server/opal_server/config.py
+++ b/packages/opal-server/opal_server/config.py
@@ -177,6 +177,11 @@ class OpalServerConfig(Confi):
         "__opal_stats_state_sync",
         description="The topic other servers with statistics provide their state to a waking-up server",
     )
+    STATISTICS_SERVER_HELLO_CHANNEL = confi.str(
+        "STATISTICS_SERVER_HELLO_CHANNEL",
+        "__opal_stats_server_hello",
+        description="The topic workers use to signal they exist and are alive",
+    )
 
     # Data updates
     ALL_DATA_TOPIC = confi.str(

--- a/packages/opal-server/opal_server/config.py
+++ b/packages/opal-server/opal_server/config.py
@@ -177,10 +177,15 @@ class OpalServerConfig(Confi):
         "__opal_stats_state_sync",
         description="The topic other servers with statistics provide their state to a waking-up server",
     )
-    STATISTICS_SERVER_HELLO_CHANNEL = confi.str(
-        "STATISTICS_SERVER_HELLO_CHANNEL",
+    STATISTICS_SERVER_KEEPALIVE_CHANNEL = confi.str(
+        "STATISTICS_SERVER_KEEPALIVE_CHANNEL",
         "__opal_stats_server_hello",
         description="The topic workers use to signal they exist and are alive",
+    )
+    STATISTICS_SERVER_KEEPALIVE_TIMEOUT = confi.str(
+        "STATISTICS_SERVER_KEEPALIVE_TIMEOUT",
+        20,
+        description="Timeout for forgetting a server from which a keep-alive haven't been seen (keep-alive frequency would be half of this value)",
     )
 
     # Data updates

--- a/packages/opal-server/opal_server/config.py
+++ b/packages/opal-server/opal_server/config.py
@@ -179,7 +179,7 @@ class OpalServerConfig(Confi):
     )
     STATISTICS_SERVER_KEEPALIVE_CHANNEL = confi.str(
         "STATISTICS_SERVER_KEEPALIVE_CHANNEL",
-        "__opal_stats_server_hello",
+        "__opal_stats_server_keepalive",
         description="The topic workers use to signal they exist and are alive",
     )
     STATISTICS_SERVER_KEEPALIVE_TIMEOUT = confi.str(

--- a/packages/opal-server/opal_server/server.py
+++ b/packages/opal-server/opal_server/server.py
@@ -390,6 +390,8 @@ class OpalServer:
             tasks.append(asyncio.create_task(self.publisher.stop()))
         if self.broadcast_keepalive is not None:
             tasks.append(asyncio.create_task(self.broadcast_keepalive.stop()))
+        if self.opal_statistics is not None:
+            tasks.append(asyncio.create_task(self.opal_statistics.stop()))
 
         try:
             await asyncio.gather(*tasks)


### PR DESCRIPTION
1. Introduce ability to track count of server instances currently alive. (both as a new field under `/statistics` that lists their uuids, and in a new endpoint `/stats` that retrieves amount of opal servers and opal clients connected to the same broadcast channel.
2. Fix tasks leaking by using `TasksPool`
3. Added opal version in both `/stats` & `/statistics`

Examples:
```
> curl http://localhost:7002/stats     
{"uptime":"2024-05-26T16:21:52.895075","version":"0.7.6","client_count":3,"server_count":2}%                       
```
```
> curl http://localhost:7002/statistics 
{"uptime":"2024-05-23T14:52:14.461300","version":"0.7.6","clients":{"CLIENT_9e9023bba9ee4a53b13e4f02ae0fafe1":[{"rpc_id":"699b34bcfb6246cea01d9f519d64a549","client_id":"CLIENT_9e9023bba9ee4a53b13e4f02ae0fafe1","topics":["policy:."]},{"rpc_id":"f047f5bdc12f442b9a361392de691fd6","client_id":"CLIENT_9e9023bba9ee4a53b13e4f02ae0fafe1","topics":["policy_data"]}],"CLIENT_b8a52614b8434a298bd30fa43875ff13":[{"rpc_id":"70e21d276bc74e4d93a511d6ad6aa7b2","client_id":"CLIENT_b8a52614b8434a298bd30fa43875ff13","topics":["policy:."]},{"rpc_id":"ebe6a48a74b44833b44de251c85c752f","client_id":"CLIENT_b8a52614b8434a298bd30fa43875ff13","topics":["policy_data"]}],"CLIENT_64ba93657aab4ba3bd2fe780f2cdd569":[{"rpc_id":"fabd61db82f949c9aeb0f049eec6ecf8","client_id":"CLIENT_64ba93657aab4ba3bd2fe780f2cdd569","topics":["policy_data"]},{"rpc_id":"239ac052772c45de93524e6c03ed808b","client_id":"CLIENT_64ba93657aab4ba3bd2fe780f2cdd569","topics":["policy:."]}]},"servers":["110a98f18bee45ce85e470da43450a70","8e22985f497846f89d1783c7dd7221f1"]}%     
```