### PR TITLE
Revert "BasePolicyWatcherTask: Signal stop if broadcaster fails to connect"

### DIFF
--- a/packages/opal-server/opal_server/policy/watcher/task.py
+++ b/packages/opal-server/opal_server/policy/watcher/task.py
@@ -50,12 +50,11 @@ class BasePolicyWatcherTask:
             )
 
         if self._pubsub_endpoint.broadcaster is not None:
-            try:
-                async with self._pubsub_endpoint.broadcaster.get_listening_context():
-                    await _subscribe_internal()
-                    await self._pubsub_endpoint.broadcaster.get_reader_task()
-            finally:
-                # Stop the watcher if broadcaster disconnects / fails to connect
+            async with self._pubsub_endpoint.broadcaster.get_listening_context():
+                await _subscribe_internal()
+                await self._pubsub_endpoint.broadcaster.get_reader_task()
+
+                # Stop the watcher if broadcaster disconnects
                 self.signal_stop()
         else:
             # If no broadcaster is configured, just subscribe, no need to wait on anything

--- a/packages/requires.txt
+++ b/packages/requires.txt
@@ -1,7 +1,7 @@
 idna>=3.3,<4
 typer>=0.4.1,<1
 fastapi>=0.109.1,<1
-fastapi_websocket_pubsub==0.3.9
+fastapi_websocket_pubsub==0.3.7
 fastapi_websocket_rpc>=0.1.21,<1
 gunicorn>=22.0.0,<23
 pydantic[email]>=1.9.1,<2


### PR DESCRIPTION
This reverts commit 3fba32e54ecaa9b3b7b8797480519c2f336b8cfc.

That change probably caused the failure in `test-docker` step