### PR TITLE
Fix example docker-compose data sources configuration

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -105,7 +105,8 @@ jobs:
       - name: Output container logs
         run: docker-compose -f docker/docker-compose-test.yml logs
 
-      - name: check if opal-client was brought up
+      - name: check if opal-client was brought up successfully
         run: |
           docker-compose -f docker/docker-compose-test.yml logs opal_client | grep "Connected to PubSub server"
           docker-compose -f docker/docker-compose-test.yml logs opal_client | grep "Got policy bundle"
+          docker-compose -f docker/docker-compose-test.yml logs opal_client | grep 'PUT /v1/data/static -> 204'

--- a/docker/docker-compose-api-policy-source-example.yml
+++ b/docker/docker-compose-api-policy-source-example.yml
@@ -1,4 +1,3 @@
-version: "3.8"
 services:
   # When scaling the opal-server to multiple nodes and/or multiple workers, we use
   # a *broadcast* channel to sync between all the instances of opal-server.

--- a/docker/docker-compose-api-policy-source-example.yml
+++ b/docker/docker-compose-api-policy-source-example.yml
@@ -37,7 +37,7 @@ services:
       # configures from where the opal client should initially fetch data (when it first goes up, after disconnection, etc).
       # the data sources represents from where the opal clients should get a "complete picture" of the data they need.
       # after the initial sources are fetched, the client will subscribe only to update notifications sent by the server.
-      - OPAL_DATA_CONFIG_SOURCES={"config":{"entries":[{"url":"http://host.docker.internal:7002/policy-data","topics":["policy_data"],"dst_path":"/static"}]}}
+      - OPAL_DATA_CONFIG_SOURCES={"config":{"entries":[{"url":"http://opal-server:7002/policy-data","topics":["policy_data"],"dst_path":"/static"}]}}
       - OPAL_LOG_FORMAT_INCLUDE_PID=true
     ports:
       # exposes opal server on the host machine, you can access the server at: http://localhost:7002

--- a/docker/docker-compose-example-cedar.yml
+++ b/docker/docker-compose-example-cedar.yml
@@ -1,4 +1,3 @@
-version: "3.8"
 services:
   # When scaling the opal-server to multiple nodes and/or multiple workers, we use
   # a *broadcast* channel to sync between all the instances of opal-server.

--- a/docker/docker-compose-example.yml
+++ b/docker/docker-compose-example.yml
@@ -1,4 +1,3 @@
-version: "3.8"
 services:
   # When scaling the opal-server to multiple nodes and/or multiple workers, we use
   # a *broadcast* channel to sync between all the instances of opal-server.

--- a/docker/docker-compose-git-webhook.yml
+++ b/docker/docker-compose-git-webhook.yml
@@ -1,4 +1,3 @@
-version: "3.8"
 services:
   # When scaling the opal-server to multiple nodes and/or multiple workers, we use
   # a *broadcast* channel to sync between all the instances of opal-server.

--- a/docker/docker-compose-scopes-example.yml
+++ b/docker/docker-compose-scopes-example.yml
@@ -1,4 +1,3 @@
-version: "3.8"
 services:
   redis:
     image: redis

--- a/docker/docker-compose-with-callbacks.yml
+++ b/docker/docker-compose-with-callbacks.yml
@@ -1,4 +1,3 @@
-version: "3.8"
 services:
   # When scaling the opal-server to multiple nodes and/or multiple workers, we use
   # a *broadcast* channel to sync between all the instances of opal-server.

--- a/docker/docker-compose-with-callbacks.yml
+++ b/docker/docker-compose-with-callbacks.yml
@@ -32,7 +32,7 @@ services:
       # configures from where the opal client should initially fetch data (when it first goes up, after disconnection, etc).
       # the data sources represents from where the opal clients should get a "complete picture" of the data they need.
       # after the initial sources are fetched, the client will subscribe only to update notifications sent by the server.
-      - OPAL_DATA_CONFIG_SOURCES={"config":{"entries":[{"url":"http://host.docker.internal:7002/policy-data","topics":["policy_data"],"dst_path":"/static"}]}}
+      - OPAL_DATA_CONFIG_SOURCES={"config":{"entries":[{"url":"http://opal_server:7002/policy-data","topics":["policy_data"],"dst_path":"/static"}]}}
       - OPAL_LOG_FORMAT_INCLUDE_PID=true
     ports:
       # exposes opal server on the host machine, you can access the server at: http://localhost:7002

--- a/docker/docker-compose-with-kafka-example.yml
+++ b/docker/docker-compose-with-kafka-example.yml
@@ -1,4 +1,3 @@
-version: "3.8"
 
 services:
   # Based on: https://developer.confluent.io/quickstart/kafka-docker/

--- a/docker/docker-compose-with-kafka-example.yml
+++ b/docker/docker-compose-with-kafka-example.yml
@@ -70,7 +70,7 @@ services:
       # configures from where the opal client should initially fetch data (when it first goes up, after disconnection, etc).
       # the data sources represents from where the opal clients should get a "complete picture" of the data they need.
       # after the initial sources are fetched, the client will subscribe only to update notifications sent by the server.
-      - OPAL_DATA_CONFIG_SOURCES={"config":{"entries":[{"url":"http://host.docker.internal:7002/policy-data","topics":["policy_data"],"dst_path":"/static"}]}}
+      - OPAL_DATA_CONFIG_SOURCES={"config":{"entries":[{"url":"http://opal-server:7002/policy-data","topics":["policy_data"],"dst_path":"/static"}]}}
       - OPAL_LOG_FORMAT_INCLUDE_PID=true
     ports:
       # exposes opal server on the host machine, you can access the server at: http://localhost:7002

--- a/docker/docker-compose-with-oauth-initial.yml
+++ b/docker/docker-compose-with-oauth-initial.yml
@@ -1,4 +1,3 @@
-version: "3.8"
 services:
   # When scaling the opal-server to multiple nodes and/or multiple workers, we use
   # a *broadcast* channel to sync between all the instances of opal-server.

--- a/docker/docker-compose-with-rate-limiting.yml
+++ b/docker/docker-compose-with-rate-limiting.yml
@@ -1,5 +1,4 @@
 # This docker compose example shows how to configure OPAL's rate limiting feature
-version: "3.8"
 services:
   # When scaling the opal-server to multiple nodes and/or multiple workers, we use
   # a *broadcast* channel to sync between all the instances of opal-server.

--- a/docker/docker-compose-with-rate-limiting.yml
+++ b/docker/docker-compose-with-rate-limiting.yml
@@ -31,7 +31,7 @@ services:
       # configures from where the opal client should initially fetch data (when it first goes up, after disconnection, etc).
       # the data sources represents from where the opal clients should get a "complete picture" of the data they need.
       # after the initial sources are fetched, the client will subscribe only to update notifications sent by the server.
-      - OPAL_DATA_CONFIG_SOURCES={"config":{"entries":[{"url":"http://host.docker.internal:7002/policy-data","topics":["policy_data"],"dst_path":"/static"}]}}
+      - OPAL_DATA_CONFIG_SOURCES={"config":{"entries":[{"url":"http://opal-server:7002/policy-data","topics":["policy_data"],"dst_path":"/static"}]}}
       - OPAL_LOG_FORMAT_INCLUDE_PID=true
       # Turns on rate limiting in the server
       # supported formats documented here: https://limits.readthedocs.io/en/stable/quickstart.html#rate-limit-string-notation

--- a/docker/docker-compose-with-security.yml
+++ b/docker/docker-compose-with-security.yml
@@ -1,6 +1,5 @@
 # this docker compose file is relying on external environment variables!
 # run it by running the script: ./run-example-with-security.sh
-version: "3.8"
 services:
   # When scaling the opal-server to multiple nodes and/or multiple workers, we use
   # a *broadcast* channel to sync between all the instances of opal-server.

--- a/docker/docker-compose-with-security.yml
+++ b/docker/docker-compose-with-security.yml
@@ -46,7 +46,7 @@ services:
       # after the initial sources are fetched, the client will subscribe only to update notifications sent by the server.
       # please notice - since we fetch data entries from the OPAL server itself, we need to authenticate to that endpoint
       # with the client's token (JWT).
-      - OPAL_DATA_CONFIG_SOURCES={"config":{"entries":[{"url":"http://host.docker.internal:7002/policy-data","config":{"headers":{"Authorization":"Bearer ${OPAL_CLIENT_TOKEN}"}},"topics":["policy_data"],"dst_path":"/static"}]}}
+      - OPAL_DATA_CONFIG_SOURCES={"config":{"entries":[{"url":"http://opal-server:7002/policy-data","config":{"headers":{"Authorization":"Bearer ${OPAL_CLIENT_TOKEN}"}},"topics":["policy_data"],"dst_path":"/static"}]}}
       - OPAL_LOG_FORMAT_INCLUDE_PID=true
       # --------------------------------------------------------------------------------
       # the jwt audience and jwt issuer are not typically necessary in real setups

--- a/docker/docker-compose-with-statistics.yml
+++ b/docker/docker-compose-with-statistics.yml
@@ -1,4 +1,3 @@
-version: "3.8"
 services:
   # When scaling the opal-server to multiple nodes and/or multiple workers, we use
   # a *broadcast* channel to sync between all the instances of opal-server.

--- a/docker/docker-compose-with-statistics.yml
+++ b/docker/docker-compose-with-statistics.yml
@@ -32,7 +32,7 @@ services:
       # configures from where the opal client should initially fetch data (when it first goes up, after disconnection, etc).
       # the data sources represents from where the opal clients should get a "complete picture" of the data they need.
       # after the initial sources are fetched, the client will subscribe only to update notifications sent by the server.
-      - OPAL_DATA_CONFIG_SOURCES={"config":{"entries":[{"url":"http://host.docker.internal:7002/policy-data","topics":["policy_data"],"dst_path":"/static"}]}}
+      - OPAL_DATA_CONFIG_SOURCES={"config":{"entries":[{"url":"http://opal-server:7002/policy-data","topics":["policy_data"],"dst_path":"/static"}]}}
       - OPAL_LOG_FORMAT_INCLUDE_PID=true
       # turning on statistics collection on the server side
       - OPAL_STATISTICS_ENABLED=true

--- a/documentation/docs/getting-started/quickstart/docker-compose-config/overview.mdx
+++ b/documentation/docs/getting-started/quickstart/docker-compose-config/overview.mdx
@@ -11,7 +11,6 @@ This example is running three containers that we have mentioned at the beginning
 Here is an overview of the whole `docker-compose.yml` file, but don't worry, we will be referring to each section separately.
 
 ```yml showLineNumbers
-version: "3.8"
 services:
   broadcast_channel:
     image: postgres:alpine

--- a/documentation/docs/getting-started/quickstart/opal-playground/updating-the-policy.mdx
+++ b/documentation/docs/getting-started/quickstart/opal-playground/updating-the-policy.mdx
@@ -35,7 +35,6 @@ opal_server:
 You can also simply change the tracked repo in the example `docker-compose.yml` file by editing these variables:
 
 ```yml {7,9,11} showLineNumbers
-version: "3.8"
 services:
   ...
   opal_server:


### PR DESCRIPTION
1. `DATA_CONFIG_SOURCES` pointed to `host.docker.internal` which only works on Mac. Renamed to `opal_server` which is the container's name and should be cross-platform. **Fixing that also fixes the flakiness with the latest logging of broadcaster connection failures fix (which we've reverted) - But I'll re-introduce it after adding a retry mechanism for the initial broadcaster connection**
2. Fixed CI's `docker test` to also check that the client actually fetched data and stored it to OPA.
3. Removed obsolete `version: 3.8` from example docker-compose yamls