### PR TITLE
Fix opal image builtin python packages not being updated

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -25,6 +25,8 @@ RUN CARGO_REGISTRIES_CRATES_IO_PROTOCOL=sparse cargo build --release
 FROM python:3.10-slim-bookworm AS common
 
 # copy libraries from build stage (This won't copy redundant libraries we used in build-stage)
+# also remove the default python site-packages that has older versions of packages that won't be overridden
+RUN rm -r /usr/local/lib/python3.10/site-packages
 COPY --from=build-stage /usr/local /usr/local
 
 # Add non-root user (with home dir at /opal)

--- a/documentation/docs/getting-started/running-opal/run-opal-server/broadcast-interface.mdx
+++ b/documentation/docs/getting-started/running-opal/run-opal-server/broadcast-interface.mdx
@@ -41,14 +41,6 @@ Declaring the broadcast uri is optional, depending on whether you deployed a bro
             .
           </li>
           <li>
-            Note that password authentication is not supported in the
-            broadcaster URI when using redis, see{" "}
-            <a href="https://github.com/encode/broadcaster/blob/master/broadcaster/_backends/redis.py">
-              source
-            </a>
-            .
-          </li>
-          <li>
             Example value:{" "}
             <code>OPAL_BROADCAST_URI=postgres://localhost/mydb</code>
           </li>


### PR DESCRIPTION
This is because copying the site-packages from the build stage only adds files but doesn't remove existing files. Thus older builds of `setuptools` for example stay with the image's default version.

This causes image scanners to report vulnerable packages in opal's images.

Fix it by first removing the existing `site-packages` directory