### PR TITLE
How often OPA should check the TLS certificate and private key file f…

### DIFF
--- a/packages/opal-client/opal_client/engine/options.py
+++ b/packages/opal-client/opal_client/engine/options.py
@@ -62,6 +62,9 @@ class OpaServerOptions(BaseModel):
     tls_private_key_file: Optional[str] = Field(
         None, description="path of TLS private key file"
     )
+    tls_cert_refresh_period: Optional[str] = Field(
+        None, description="how often OPA should check the TLS certificate and private key file for changes"
+    )
     log_level: LogLevel = Field(LogLevel.info, description="log level for opa logs")
     files: Optional[List[str]] = Field(
         None,


### PR DESCRIPTION
In the recent OPAL version only following OPA TLS CLI arguments are supported

`--tls-cert-file=<path>` specifies the path of the file containing the TLS certificate.
`--tls-private-key-file=<path>` specifies the path of the file containing the TLS private key.
`--tls-ca-cert-file=<path>`

Let us have `tls-cert-refresh-period` as well.

`--tls-cert-refresh-period=<duration>` specifies how often OPA should check the TLS certificate and private key file for changes (defaults to 0s, disabling periodic refresh). This argument accepts any duration, such as “30s”, “5m” or “24h”.

resolves #656 
