### PR TITLE
Allow running on privileged ports.

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -39,7 +39,7 @@ RUN chmod +x ./wait-for.sh
 RUN ln -s /opal/wait-for.sh /usr/wait-for.sh
 
 # netcat (nc) is used by the wait-for.sh script
-RUN apt-get update && apt-get install -y netcat-traditional jq && apt-get clean
+RUN apt-get update && apt-get install -y netcat-traditional jq libcap2-bin && apt-get clean
 
 # copy startup script (create link at old path to maintain backward compatibility)
 COPY ./scripts/start.sh .
@@ -47,6 +47,8 @@ RUN chmod +x ./start.sh
 RUN ln -s /opal/start.sh /start.sh
 # copy gunicorn_config
 COPY ./scripts/gunicorn_conf.py .
+# setcap CAP_NET_BIND_SERVICE
+RUN setcap 'cap_net_bind_service=+ep' /usr/local/bin/python3.10
 # copy app code
 
 COPY ./README.md .


### PR DESCRIPTION
This should fix getting following error when running OPAL on port 443 as Fargate containers

```
Can't connect to ('0.0.0.0', 443)
```