### PR TITLE
Draft

### DIFF
--- a/packages/opal-client/opal_client/policy_store/openfga_client.py
+++ b/packages/opal-client/opal_client/policy_store/openfga_client.py
@@ -1,0 +1,1 @@
+## Draft for openfga-policy-implementation


### PR DESCRIPTION
### Feature: Add OpenFGA Policy Store to OPAL

This PR addresses [issue #661](https://github.com/permitio/opal/issues/661) by integrating OpenFGA Policy Store into OPAL.