### PR TITLE
Add IAM based auth for S3 policy repo

### DIFF
--- a/packages/opal-common/opal_common/sources/api_policy_source.py
+++ b/packages/opal-common/opal_common/sources/api_policy_source.py
@@ -53,6 +53,8 @@ class ApiPolicySource(BasePolicySource):
         token: Optional[str] = None,
         token_id: Optional[str] = None,
         region: Optional[str] = None,
+        role_arn: Optional[str] = None,
+        token_file: Optional[str] = None,
         bundle_server_type: Optional[PolicyBundleServerType] = None,
         policy_bundle_path=".",
         policy_bundle_git_add_pattern="*",
@@ -66,6 +68,8 @@ class ApiPolicySource(BasePolicySource):
         self.token_id = token_id
         self.server_type = bundle_server_type
         self.region = region
+        self.role_arn = role_arn
+        self.token_file = token_file
         self.bundle_hash = None
         self.etag = None
         self.tmp_bundle_path = Path(policy_bundle_path)

--- a/packages/opal-common/opal_common/sources/api_policy_source.py
+++ b/packages/opal-common/opal_common/sources/api_policy_source.py
@@ -130,7 +130,7 @@ class ApiPolicySource(BasePolicySource):
                     )
                     raise
 
-    def build_auth_headers(self, token=None, path=None):
+    async def build_auth_headers(self, token=None, path=None):
         # if it's a simple HTTP server with a bearer token
         if self.server_type == PolicyBundleServerType.HTTP and token is not None:
             return tuple_to_dict(get_authorization_header(token))
@@ -170,7 +170,7 @@ class ApiPolicySource(BasePolicySource):
         """
         path = "bundle.tar.gz"
 
-        auth_headers = self.build_auth_headers(token=token, path=path)
+        auth_headers = await self.build_auth_headers(token=token, path=path)
         etag_headers = (
             {"ETag": self.etag, "If-None-Match": self.etag} if self.etag else {}
         )

--- a/packages/opal-common/opal_common/sources/api_policy_source.py
+++ b/packages/opal-common/opal_common/sources/api_policy_source.py
@@ -18,6 +18,7 @@ from opal_common.utils import (
     hash_file,
     throw_if_bad_status_code,
     tuple_to_dict,
+    async_time_cache,
 )
 from opal_server.config import PolicyBundleServerType
 from tenacity import AsyncRetrying
@@ -132,6 +133,7 @@ class ApiPolicySource(BasePolicySource):
                     raise
 
     async def get_temporary_sts_credentials(self) -> Tuple[str, str]:
+    @async_time_cache(ttl=3000)
         assert self.token_file
         assert self.role_arn
         assert self.region

--- a/packages/opal-common/opal_common/utils.py
+++ b/packages/opal-common/opal_common/utils.py
@@ -296,7 +296,7 @@ class AsyncioEventLoopThread(threading.Thread):
 
 def async_time_cache(ttl: float):
     """
-    This decorator a wrapper around lru_cache that makes it time sensitive.
+    This decorator is a wrapper around lru_cache that makes it time sensitive.
 
     ttl is in seconds
     """

--- a/packages/opal-server/opal_server/config.py
+++ b/packages/opal-server/opal_server/config.py
@@ -133,6 +133,16 @@ class OpalServerConfig(Confi):
         "us-east-1",
         description="The AWS region of the S3 bucket",
     )
+    POLICY_BUNDLE_AWS_ROLE_ARN = confi.str(
+        "AWS_ROLE_ARN",
+        None,
+        description="The IAM role to be used when accessing the bundle server. This is set by AWS automatically in EKS",
+    )
+    POLICY_BUNDLE_AWS_WEB_IDENTITY_TOKEN_FILE = confi.str(
+        "AWS_WEB_IDENTITY_TOKEN_FILE",
+        None,
+        description="The oidc token for the IAM role to be used when accessing the bundle server. This is set by AWS automatically in EKS",
+    )
     POLICY_BUNDLE_TMP_PATH = confi.str(
         "POLICY_BUNDLE_TMP_PATH",
         "/tmp/bundle.tar.gz",

--- a/packages/opal-server/opal_server/config.py
+++ b/packages/opal-server/opal_server/config.py
@@ -8,7 +8,7 @@ from opal_common.schemas.data import DEFAULT_DATA_TOPIC, ServerDataSourceConfig
 from opal_common.schemas.webhook import GitWebhookRequestParams
 
 confi = Confi(prefix="OPAL_")
-confi_no_prefix = Confi(prefix=None)
+# confi_no_prefix = Confi(prefix="")
 
 
 class PolicySourceTypes(str, Enum):
@@ -52,7 +52,8 @@ class OpalServerConfig(Confi):
     AUTH_PRIVATE_KEY_PASSPHRASE = confi.str("AUTH_PRIVATE_KEY_PASSPHRASE", None)
 
     AUTH_PRIVATE_KEY = confi.delay(
-        lambda AUTH_PRIVATE_KEY_FORMAT=None, AUTH_PRIVATE_KEY_PASSPHRASE="": confi.private_key(
+        lambda AUTH_PRIVATE_KEY_FORMAT=None,
+        AUTH_PRIVATE_KEY_PASSPHRASE="": confi.private_key(
             "AUTH_PRIVATE_KEY",
             default=None,
             key_format=AUTH_PRIVATE_KEY_FORMAT,
@@ -134,16 +135,16 @@ class OpalServerConfig(Confi):
         "us-east-1",
         description="The AWS region of the S3 bucket",
     )
-    POLICY_BUNDLE_AWS_ROLE_ARN = confi_no_prefix.str(
-        "AWS_ROLE_ARN",
-        None,
-        description="The IAM role to be used when accessing the bundle server. This is set by AWS automatically in EKS",
-    )
-    POLICY_BUNDLE_AWS_WEB_IDENTITY_TOKEN_FILE = confi_no_prefix.str(
-        "AWS_WEB_IDENTITY_TOKEN_FILE",
-        None,
-        description="The oidc token for the IAM role to be used when accessing the bundle server. This is set by AWS automatically in EKS",
-    )
+    # POLICY_BUNDLE_AWS_ROLE_ARN = confi_no_prefix.str(
+    #     "AWS_ROLE_ARN",
+    #     None,
+    #     description="The IAM role to be used when accessing the bundle server. This is set by AWS automatically in EKS",
+    # )
+    # POLICY_BUNDLE_AWS_WEB_IDENTITY_TOKEN_FILE = confi_no_prefix.str(
+    #     "AWS_WEB_IDENTITY_TOKEN_FILE",
+    #     None,
+    #     description="The oidc token for the IAM role to be used when accessing the bundle server. This is set by AWS automatically in EKS",
+    # )
     POLICY_BUNDLE_TMP_PATH = confi.str(
         "POLICY_BUNDLE_TMP_PATH",
         "/tmp/bundle.tar.gz",

--- a/packages/opal-server/opal_server/config.py
+++ b/packages/opal-server/opal_server/config.py
@@ -8,6 +8,7 @@ from opal_common.schemas.data import DEFAULT_DATA_TOPIC, ServerDataSourceConfig
 from opal_common.schemas.webhook import GitWebhookRequestParams
 
 confi = Confi(prefix="OPAL_")
+confi_no_prefix = Confi(prefix=None)
 
 
 class PolicySourceTypes(str, Enum):
@@ -133,12 +134,12 @@ class OpalServerConfig(Confi):
         "us-east-1",
         description="The AWS region of the S3 bucket",
     )
-    POLICY_BUNDLE_AWS_ROLE_ARN = confi.str(
+    POLICY_BUNDLE_AWS_ROLE_ARN = confi_no_prefix.str(
         "AWS_ROLE_ARN",
         None,
         description="The IAM role to be used when accessing the bundle server. This is set by AWS automatically in EKS",
     )
-    POLICY_BUNDLE_AWS_WEB_IDENTITY_TOKEN_FILE = confi.str(
+    POLICY_BUNDLE_AWS_WEB_IDENTITY_TOKEN_FILE = confi_no_prefix.str(
         "AWS_WEB_IDENTITY_TOKEN_FILE",
         None,
         description="The oidc token for the IAM role to be used when accessing the bundle server. This is set by AWS automatically in EKS",

--- a/packages/opal-server/opal_server/config.py
+++ b/packages/opal-server/opal_server/config.py
@@ -8,7 +8,6 @@ from opal_common.schemas.data import DEFAULT_DATA_TOPIC, ServerDataSourceConfig
 from opal_common.schemas.webhook import GitWebhookRequestParams
 
 confi = Confi(prefix="OPAL_")
-# confi_no_prefix = Confi(prefix="")
 
 
 class PolicySourceTypes(str, Enum):
@@ -135,16 +134,18 @@ class OpalServerConfig(Confi):
         "us-east-1",
         description="The AWS region of the S3 bucket",
     )
-    # POLICY_BUNDLE_AWS_ROLE_ARN = confi_no_prefix.str(
-    #     "AWS_ROLE_ARN",
-    #     None,
-    #     description="The IAM role to be used when accessing the bundle server. This is set by AWS automatically in EKS",
-    # )
-    # POLICY_BUNDLE_AWS_WEB_IDENTITY_TOKEN_FILE = confi_no_prefix.str(
-    #     "AWS_WEB_IDENTITY_TOKEN_FILE",
-    #     None,
-    #     description="The oidc token for the IAM role to be used when accessing the bundle server. This is set by AWS automatically in EKS",
-    # )
+    POLICY_BUNDLE_AWS_ROLE_ARN = confi.str(
+        "AWS_ROLE_ARN",
+        # default to the env var injected by aws
+        os.getenv("AWS_ROLE_ARN"),
+        description="The IAM role to be used when accessing the bundle server. This is set by AWS automatically in EKS, but can be overridden if required.",
+    )
+    POLICY_BUNDLE_AWS_WEB_IDENTITY_TOKEN_FILE = confi.str(
+        "AWS_WEB_IDENTITY_TOKEN_FILE",
+        # default to the env var injected by aws
+        os.getenv("AWS_WEB_IDENTITY_TOKEN_FILE"),
+        description="The oidc token for the IAM role to be used when accessing the bundle server. This is set by AWS automatically in EKS, but can be overridden if required.",
+    )
     POLICY_BUNDLE_TMP_PATH = confi.str(
         "POLICY_BUNDLE_TMP_PATH",
         "/tmp/bundle.tar.gz",

--- a/packages/opal-server/opal_server/policy/watcher/factory.py
+++ b/packages/opal-server/opal_server/policy/watcher/factory.py
@@ -129,6 +129,8 @@ def setup_watcher_task(
             policy_bundle_path=opal_server_config.POLICY_BUNDLE_TMP_PATH,
             policy_bundle_git_add_pattern=opal_server_config.POLICY_BUNDLE_GIT_ADD_PATTERN,
             region=policy_bundle_aws_region,
+            role_arn=opal_server_config.POLICY_BUNDLE_AWS_ROLE_ARN,
+            token_file=opal_server_config.POLICY_BUNDLE_AWS_WEB_IDENTITY_TOKEN_FILE,,
         )
     else:
         raise ValueError("Unknown value for OPAL_POLICY_SOURCE_TYPE")

--- a/packages/opal-server/opal_server/policy/watcher/factory.py
+++ b/packages/opal-server/opal_server/policy/watcher/factory.py
@@ -130,7 +130,7 @@ def setup_watcher_task(
             policy_bundle_git_add_pattern=opal_server_config.POLICY_BUNDLE_GIT_ADD_PATTERN,
             region=policy_bundle_aws_region,
             role_arn=opal_server_config.POLICY_BUNDLE_AWS_ROLE_ARN,
-            token_file=opal_server_config.POLICY_BUNDLE_AWS_WEB_IDENTITY_TOKEN_FILE,,
+            token_file=opal_server_config.POLICY_BUNDLE_AWS_WEB_IDENTITY_TOKEN_FILE,
         )
     else:
         raise ValueError("Unknown value for OPAL_POLICY_SOURCE_TYPE")

--- a/packages/opal-server/opal_server/policy/watcher/factory.py
+++ b/packages/opal-server/opal_server/policy/watcher/factory.py
@@ -130,10 +130,8 @@ def setup_watcher_task(
             policy_bundle_path=opal_server_config.POLICY_BUNDLE_TMP_PATH,
             policy_bundle_git_add_pattern=opal_server_config.POLICY_BUNDLE_GIT_ADD_PATTERN,
             region=policy_bundle_aws_region,
-            # role_arn=opal_server_config.POLICY_BUNDLE_AWS_ROLE_ARN,
-            # token_file=opal_server_config.POLICY_BUNDLE_AWS_WEB_IDENTITY_TOKEN_FILE,
-            role_arn=os.getenv("AWS_ROLE_ARN"),
-            token_file=os.getenv("AWS_WEB_IDENTITY_TOKEN_FILE"),
+            aws_role_arn=opal_server_config.POLICY_BUNDLE_AWS_ROLE_ARN,
+            aws_web_id_token_file=opal_server_config.POLICY_BUNDLE_AWS_WEB_IDENTITY_TOKEN_FILE,
         )
     else:
         raise ValueError("Unknown value for OPAL_POLICY_SOURCE_TYPE")

--- a/packages/opal-server/opal_server/policy/watcher/factory.py
+++ b/packages/opal-server/opal_server/policy/watcher/factory.py
@@ -1,5 +1,6 @@
 from functools import partial
 from typing import Any, List, Optional
+import os
 
 from fastapi_websocket_pubsub.pub_sub_server import PubSubEndpoint
 from opal_common.confi.confi import load_conf_if_none
@@ -129,8 +130,10 @@ def setup_watcher_task(
             policy_bundle_path=opal_server_config.POLICY_BUNDLE_TMP_PATH,
             policy_bundle_git_add_pattern=opal_server_config.POLICY_BUNDLE_GIT_ADD_PATTERN,
             region=policy_bundle_aws_region,
-            role_arn=opal_server_config.POLICY_BUNDLE_AWS_ROLE_ARN,
-            token_file=opal_server_config.POLICY_BUNDLE_AWS_WEB_IDENTITY_TOKEN_FILE,
+            # role_arn=opal_server_config.POLICY_BUNDLE_AWS_ROLE_ARN,
+            # token_file=opal_server_config.POLICY_BUNDLE_AWS_WEB_IDENTITY_TOKEN_FILE,
+            role_arn=os.getenv("AWS_ROLE_ARN"),
+            token_file=os.getenv("AWS_WEB_IDENTITY_TOKEN_FILE"),
         )
     else:
         raise ValueError("Unknown value for OPAL_POLICY_SOURCE_TYPE")


### PR DESCRIPTION
## Changes proposed
This pull request introduces an additional method for retrieving credentials to access an s3 bucket. When using Amazon's EKS it is possible to create a service account that corresponds to an IAM role. That role ARN and a web identity token file are injected into running pods and can be used with STS to generate temporary credentials.

This PR makes the following changes to accommodate this:
- Add the role name and web token file environment variables to be read in by the config. As these are injected by EKS, they do not have the `OPAL_` prefix, which is why the default for those fields directly reads from the environment. I'm not sure if this is the best way to do this.
- Change the `build_auth_headers` function. I've added an extra branch where if the ARN and token file are present, it will attempt to use that. I have also made that function async as it now has to read a file, and make requests. I've also added additional logging to indicate which authentication method is being used.
- Add the `get_temporary_sts_credentials` function. This handles the reading of the token file, and sending the request to STS. It also parses the response. This makes use of a time based cache decorator so that the temporary credentials are refreshed on a timer.
- Addition of a cache decorator. This is a wrapper around lru_cache adding a time based cache invalidator, as well as code to make it work with async functions.
- Change the `build_aws_rest_auth_headers` function to include an optional session token. Temporary credentials also include a session token which needs to be included in auth headers when they are used.

## Check List (Check all the applicable boxes)

- [x] I sign off on contributing this submission to open-source
- [ ] My code follows the code style of this project.
- [x] My change requires changes to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [x] This PR does not contain plagiarized content.
- [x] The title of my pull request is a short description of the requested changes.

## Note to reviewers
- I'm not certain I'm reading from the environment in a way that matches the style of the rest of the project.
- I've added the async decorator, but there do exist [libraries](https://pypi.org/project/async-lru/) that provide this functionality, maybe more robustly. I've erred on the side of not including dependencies, but let me know if it'd be better to use a dependency here.
- I'm not sure how testable these changes are :/
- The in code documentation has been updated, is there anywhere else documentation should be updated?
