### PR TITLE
Fix: Error resolving broadcast hostname being swallowed #716

### DIFF
--- a/packages/requires.txt
+++ b/packages/requires.txt
@@ -1,7 +1,7 @@
 idna>=3.3,<4
 typer>=0.4.1,<1
 fastapi>=0.109.1,<1
-fastapi_websocket_pubsub==0.3.7
+fastapi_websocket_pubsub==0.3.9
 fastapi_websocket_rpc==0.1.27
 websockets>=10.3,<14
 gunicorn>=22.0.0,<23


### PR DESCRIPTION
## Fixes Issue

Closes #716

## Changes Proposed

- Updated the `fastapi_websocket_pubsub` package version in `opal/packages/requires.txt` from the old version `0.3.7` to the latest version `0.3.9` to resolve the issue where hostname resolution errors for the broadcast URI were logged at the DEBUG level instead of ERROR.  

- Ensured that hostname resolution errors are appropriately logged for better visibility and easier debugging.

## Check List <!-- Follow the above conventions to check the box -->

- [x] I sign off on contributing this submission to open-source.  
- [x] My code follows the code style of this project.  
- [ ] My change requires changes to the documentation.  
- [ ] I have updated the documentation accordingly.  
- [x] All new and existing tests passed.  
- [x] This PR does not contain plagiarized content.  
- [x] The title of my pull request is a short description of the requested changes.  

## Screenshots  

![Screenshot 2024-12-30 152905](https://github.com/user-attachments/assets/6497314f-d633-4bea-8cdf-7eecad06efd4)

## Claim

/claim #716