### PR TITLE
Update app-tests to use local Gitea server instead of Github

### DIFF
--- a/app-tests/docker-compose-app-tests.yml
+++ b/app-tests/docker-compose-app-tests.yml
@@ -1,4 +1,46 @@
 services:
+  # Minimal Gitea for testing - no authentication, stateless
+  gitea:
+    image: gitea/gitea:latest-rootless
+    container_name: gitea
+    environment:
+      - GITEA__server__DOMAIN=localhost
+      - GITEA__server__HTTP_PORT=3000
+      - GITEA__server__ROOT_URL=http://localhost:3000/
+      - GITEA__server__OFFLINE_MODE=true
+      # Security settings - disable all authentication
+      - GITEA__security__INSTALL_LOCK=true
+      - GITEA__security__SECRET_KEY=not-so-secret
+      - GITEA__security__INTERNAL_TOKEN=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9
+      # Service settings - allow anonymous access
+      - GITEA__service__DISABLE_REGISTRATION=true
+      - GITEA__service__REQUIRE_SIGNIN_VIEW=false
+      - GITEA__service__ENABLE_NOTIFY_MAIL=false
+      - GITEA__service__ENABLE_CAPTCHA=false
+      - GITEA__service__DEFAULT_ALLOW_CREATE_ORGANIZATION=true
+      - GITEA__service__DEFAULT_ENABLE_DEPENDENCIES=false
+      # Repository settings
+      - GITEA__repository__ENABLE_PUSH_CREATE_USER=true
+      - GITEA__repository__ENABLE_PUSH_CREATE_ORG=true
+      - GITEA__repository__DEFAULT_BRANCH=main
+      - GITEA__repository__DEFAULT_PRIVATE=false
+      # Disable features we don't need
+      - GITEA__webhook__ALLOWED_HOST_LIST=*
+      - GITEA__migrations__ALLOWED_DOMAINS=*
+      - GITEA__federation__ENABLED=false
+      - GITEA__packages__ENABLED=false
+      - GITEA__actions__ENABLED=false
+      # Allow anonymous git operations
+      - GITEA__repository__ENABLE_PUSH_CREATE_USER=true
+      - GITEA__repository__ENABLE_PUSH_CREATE_ORG=true
+      - GITEA__repository__FORCE_PRIVATE=false
+      - GITEA__server__ENABLE_GZIP=false
+    ports:
+      - "3000:3000"
+      - "2222:2222"
+    networks:
+      - default
+
   broadcast_channel:
     image: postgres:alpine
     environment:
@@ -15,9 +57,8 @@ services:
     environment:
       - OPAL_BROADCAST_URI=postgres://postgres:postgres@broadcast_channel:5432/postgres
       - UVICORN_NUM_WORKERS=4
-      - OPAL_POLICY_REPO_URL=${OPAL_POLICY_REPO_URL:-git@github.com:permitio/opal-tests-policy-repo.git}
-      - OPAL_POLICY_REPO_MAIN_BRANCH=${POLICY_REPO_BRANCH}
-      - OPAL_POLICY_REPO_SSH_KEY=${OPAL_POLICY_REPO_SSH_KEY}
+      - OPAL_POLICY_REPO_URL=http://gitea:3000/gitea_admin/policy-repo.git
+      - OPAL_POLICY_REPO_MAIN_BRANCH=${POLICY_REPO_BRANCH:-main}
       - OPAL_DATA_CONFIG_SOURCES={"config":{"entries":[{"url":"http://opal_server:7002/policy-data","config":{"headers":{"Authorization":"Bearer ${OPAL_CLIENT_TOKEN}"}},"topics":["policy_data"],"dst_path":"/static"}]}}
       - OPAL_LOG_FORMAT_INCLUDE_PID=true
       - OPAL_POLICY_REPO_WEBHOOK_SECRET=xxxxx
@@ -33,6 +74,7 @@ services:
       - "7002-7003:7002"
     depends_on:
       - broadcast_channel
+      - gitea
 
   opal_client:
     image: permitio/opal-client:${OPAL_IMAGE_TAG:-latest}

--- a/app-tests/opal-tests-policy-repo-main/README.md
+++ b/app-tests/opal-tests-policy-repo-main/README.md
@@ -1,0 +1,1 @@
+# opal-tests-policy-repo

--- a/app-tests/opal-tests-policy-repo-main/data.json
+++ b/app-tests/opal-tests-policy-repo-main/data.json
@@ -1,0 +1,90 @@
+{
+  "users": {
+    "alice": {
+      "roles": ["admin"],
+      "location": {
+        "country": "US",
+        "ip": "8.8.8.8"
+      }
+    },
+    "bob": {
+      "roles": ["employee", "billing"],
+      "location": {
+        "country": "US",
+        "ip": "8.8.8.8"
+      }
+    },
+     "sunil": {
+      "roles": ["guest"],
+      "location": {
+        "country": "US",
+        "ip": "8.8.8.8"
+      }
+    },
+    "eve": {
+      "roles": ["customer"],
+      "location": {
+        "country": "US",
+        "ip": "8.8.8.8"
+      }
+    }
+  },
+  "role_permissions": {
+    "customer": [
+      {
+        "action": "read",
+        "type": "dog"
+      },
+      {
+        "action": "read",
+        "type": "cat"
+      },
+      {
+        "action": "adopt",
+        "type": "dog"
+      },
+      {
+        "action": "adopt",
+        "type": "cat"
+      }
+    ],
+    "employee": [
+      {
+        "action": "read",
+        "type": "dog"
+      },
+      {
+        "action": "read",
+        "type": "cat"
+      },
+      {
+        "action": "update",
+        "type": "dog"
+      },
+      {
+        "action": "update",
+        "type": "cat"
+      }
+    ],
+    "billing": [
+      {
+        "action": "read",
+        "type": "finance"
+      },
+      {
+        "action": "update",
+        "type": "finance"
+      }
+    ],
+    "guest": [
+     {
+       "action": "read",
+       "type": "cat"
+     },
+     {
+       "action": "read",
+       "type": "finance"
+     }
+    ]
+  }
+}

--- a/app-tests/opal-tests-policy-repo-main/policy.cedar
+++ b/app-tests/opal-tests-policy-repo-main/policy.cedar
@@ -1,0 +1,9 @@
+permit(
+    principal in Role::"Editor",
+    action in [
+        Action::"document:read",
+        Action::"document:write",
+        Action::"document:delete"
+	],
+    resource in ResourceType::"document"
+);

--- a/app-tests/opal-tests-policy-repo-main/rbac.rego
+++ b/app-tests/opal-tests-policy-repo-main/rbac.rego
@@ -1,0 +1,99 @@
+# Role-based Access Control (RBAC)
+# --------------------------------
+#
+# This example defines an RBAC model for a Pet Store API. The Pet Store API allows
+# users to look at pets, adopt them, update their stats, and so on. The policy
+# controls which users can perform actions on which resources. The policy implements
+# a classic Role-based Access Control model where users are assigned to roles and
+# roles are granted the ability to perform some action(s) on some type of resource.
+#
+# This example shows how to:
+#
+#	* Define an RBAC model in Rego that interprets role mappings represented in JSON.
+#	* Iterate/search across JSON data structures (e.g., role mappings)
+#
+# For more information see:
+#
+#	* Rego comparison to other systems: https://www.openpolicyagent.org/docs/latest/comparison-to-other-systems/
+#	* Rego Iteration: https://www.openpolicyagent.org/docs/latest/#iteration
+
+package app.rbac
+
+# import data.utils
+
+# By default, deny requests
+default allow = false
+
+# Allow admins to do anything
+allow {
+	user_is_admin
+}
+
+# Allow bob to do anything
+#allow {
+#	input.user == "bob"
+#}
+
+# you can ignore this rule, it's simply here to create a dependency
+# to another rego policy file, so we can demonstate how to work with
+# an explicit manifest file (force order of policy loading).
+#allow {
+#	input.matching_policy.grants
+#	input.roles
+#	utils.hasPermission(input.matching_policy.grants, input.roles)
+#}
+
+# Allow the action if the user is granted permission to perform the action.
+allow {
+	# Find permissions for the user.
+	some permission
+	user_is_granted[permission]
+
+	# Check if the permission permits the action.
+	input.action == permission.action
+	input.type == permission.type
+
+	# unless user location is outside US
+	country := data.users[input.user].location.country
+	country == "US"
+}
+
+# user_is_admin is true if...
+user_is_admin {
+	# for some `i`...
+	some i
+
+	# "admin" is the `i`-th element in the user->role mappings for the identified user.
+	data.users[input.user].roles[i] == "admin"
+}
+
+# user_is_viewer is true if...
+user_is_viewer {
+	# for some `i`...
+	some i
+
+	# "viewer" is the `i`-th element in the user->role mappings for the identified user.
+	data.users[input.user].roles[i] == "viewer"
+}
+
+# user_is_guest is true if...
+user_is_guest {
+	# for some `i`...
+	some i
+
+	# "guest" is the `i`-th element in the user->role mappings for the identified user.
+	data.users[input.user].roles[i] == "guest"
+}
+
+
+# user_is_granted is a set of permissions for the user identified in the request.
+# The `permission` will be contained if the set `user_is_granted` for every...
+user_is_granted[permission] {
+	some i, j
+
+	# `role` assigned an element of the user_roles for this user...
+	role := data.users[input.user].roles[i]
+
+	# `permission` assigned a single permission from the permissions list for 'role'...
+	permission := data.role_permissions[role][j]
+}

--- a/app-tests/opal-tests-policy-repo-main/utils.rego
+++ b/app-tests/opal-tests-policy-repo-main/utils.rego
@@ -1,0 +1,4 @@
+package utils
+hasPermission(grants, roles) {
+	grants[_] == roles[_]
+}

--- a/app-tests/run.sh
+++ b/app-tests/run.sh
@@ -8,6 +8,10 @@ export OPAL_AUTH_MASTER_TOKEN
 export OPAL_CLIENT_TOKEN
 export OPAL_DATA_SOURCE_TOKEN
 
+# Store the initial directory and script directory
+INITIAL_DIR=$(pwd)
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
 function generate_opal_keys {
   echo "- Generating OPAL keys"
 
@@ -17,15 +21,84 @@ function generate_opal_keys {
   OPAL_AUTH_PRIVATE_KEY="$(tr '\n' '_' < opal_crypto_key)"
   rm opal_crypto_key.pub opal_crypto_key
 
+  # Generate tokens without requiring local OPAL installation
+  echo "    Starting OPAL server for keygen"
   OPAL_AUTH_MASTER_TOKEN="$(openssl rand -hex 16)"
-  OPAL_AUTH_JWT_AUDIENCE=https://api.opal.ac/v1/ OPAL_AUTH_JWT_ISSUER=https://opal.ac/ OPAL_REPO_WATCHER_ENABLED=0 \
-    opal-server run &
+  docker rm -f --wait opal-server-keygen >/dev/null 2>&1 || true
+  docker run --rm -d \
+    --name opal-server-keygen \
+    -e OPAL_AUTH_PUBLIC_KEY="$OPAL_AUTH_PUBLIC_KEY" \
+    -e OPAL_AUTH_PRIVATE_KEY="$OPAL_AUTH_PRIVATE_KEY" \
+    -e OPAL_AUTH_PRIVATE_KEY_PASSPHRASE="$OPAL_AUTH_PRIVATE_KEY_PASSPHRASE" \
+    -e OPAL_AUTH_MASTER_TOKEN="$OPAL_AUTH_MASTER_TOKEN" \
+    -e OPAL_AUTH_JWT_AUDIENCE=https://api.opal.ac/v1/ \
+    -e OPAL_AUTH_JWT_ISSUER=https://opal.ac/ \
+    -e OPAL_REPO_WATCHER_ENABLED=0 \
+    -p 7002:7002 \
+    permitio/opal-server:${OPAL_IMAGE_TAG:-latest}
   sleep 2;
 
-  OPAL_CLIENT_TOKEN="$(opal-client obtain-token "$OPAL_AUTH_MASTER_TOKEN" --type client)"
-  OPAL_DATA_SOURCE_TOKEN="$(opal-client obtain-token "$OPAL_AUTH_MASTER_TOKEN" --type datasource)"
-  # shellcheck disable=SC2009
-  ps -ef | grep opal-server | grep -v grep | awk '{print $2}' | xargs kill
+  echo "    Obtaining tokens"
+  set -o pipefail
+
+  # Wait for the OPAL server to be ready
+  echo "    Waiting for OPAL server to be ready..."
+  timeout=30
+  counter=0
+  while ! curl -sf http://localhost:7002/ > /dev/null 2>&1; do
+    counter=$((counter + 1))
+    if [ $counter -gt $timeout ]; then
+      echo "Timeout waiting for OPAL server to start"
+      exit 1
+    fi
+    sleep 1
+  done
+
+  OPAL_CLIENT_TOKEN_RESPONSE="$(curl -s --request POST 'http://localhost:7002/token' \
+    --header "Authorization: Bearer $OPAL_AUTH_MASTER_TOKEN" \
+    --header 'Content-Type: application/json' \
+    --data-raw '{"type": "client"}' 2>&1)"
+
+  if [ $? -ne 0 ]; then
+    echo "Failed to obtain OPAL_CLIENT_TOKEN:"
+    echo "$OPAL_CLIENT_TOKEN_RESPONSE"
+    exit 1
+  fi
+
+  # Extract token from JSON response
+  OPAL_CLIENT_TOKEN="$(echo "$OPAL_CLIENT_TOKEN_RESPONSE" | grep -o '"token":"[^"]*"' | cut -d'"' -f4)"
+  if [ -z "$OPAL_CLIENT_TOKEN" ]; then
+    echo "Failed to extract client token from response:"
+    echo "$OPAL_CLIENT_TOKEN_RESPONSE"
+    exit 1
+  fi
+
+  # Obtain datasource token using curl
+  echo "    Obtaining datasource token..."
+  OPAL_DATA_SOURCE_TOKEN_RESPONSE="$(curl -s --request POST 'http://localhost:7002/token' \
+    --header "Authorization: Bearer $OPAL_AUTH_MASTER_TOKEN" \
+    --header 'Content-Type: application/json' \
+    --data-raw '{"type": "datasource"}' 2>&1)"
+
+  if [ $? -ne 0 ]; then
+    echo "Failed to obtain OPAL_DATA_SOURCE_TOKEN:"
+    echo "$OPAL_DATA_SOURCE_TOKEN_RESPONSE"
+    exit 1
+  fi
+
+  # Extract token from JSON response
+  OPAL_DATA_SOURCE_TOKEN="$(echo "$OPAL_DATA_SOURCE_TOKEN_RESPONSE" | grep -o '"token":"[^"]*"' | cut -d'"' -f4)"
+  if [ -z "$OPAL_DATA_SOURCE_TOKEN" ]; then
+    echo "Failed to extract datasource token from response:"
+    echo "$OPAL_DATA_SOURCE_TOKEN_RESPONSE"
+    exit 1
+  fi
+
+  set +o pipefail
+
+  echo "    Stopping OPAL server for keygen"
+  docker stop opal-server-keygen >/dev/null 2>&1 || true
+  docker rm opal-server-keygen >/dev/null 2>&1 || true
   sleep 5;
 
   echo "- Create .env file"
@@ -40,22 +113,110 @@ function generate_opal_keys {
 }
 
 function prepare_policy_repo {
-  echo "- Clone tests policy repo to create test's branch"
-  export OPAL_POLICY_REPO_URL
-  export POLICY_REPO_BRANCH
-  OPAL_POLICY_REPO_URL=${OPAL_POLICY_REPO_URL:-git@github.com:permitio/opal-tests-policy-repo.git}
-  POLICY_REPO_BRANCH=test-$RANDOM$RANDOM
-  rm -rf ./opal-tests-policy-repo
-  git clone "$OPAL_POLICY_REPO_URL"
-  cd opal-tests-policy-repo
-  git checkout -b $POLICY_REPO_BRANCH
-  git push --set-upstream origin $POLICY_REPO_BRANCH
-  cd -
+  echo "- Preparing policy repository"
 
-  # That's for the docker-compose to use, set ssh key from "~/.ssh/id_rsa", unless another path/key data was configured
-  export OPAL_POLICY_REPO_SSH_KEY
-  OPAL_POLICY_REPO_SSH_KEY_PATH=${OPAL_POLICY_REPO_SSH_KEY_PATH:-~/.ssh/id_rsa}
-  OPAL_POLICY_REPO_SSH_KEY=${OPAL_POLICY_REPO_SSH_KEY:-$(cat "$OPAL_POLICY_REPO_SSH_KEY_PATH")}
+  # Wait for Gitea to be ready and initialized
+  echo "  Waiting for Gitea to be ready..."
+  timeout=120
+  counter=0
+  while ! curl -sf http://localhost:3000 > /dev/null 2>&1; do
+    counter=$((counter + 1))
+    if [ $counter -gt $timeout ]; then
+      echo "Timeout waiting for Gitea to start"
+      exit 1
+    fi
+    sleep 1
+  done
+
+  # Wait for Gitea to be fully initialized (check if admin API is available)
+  echo "  Waiting for Gitea to be fully initialized..."
+  counter=0
+  while ! curl -sf http://localhost:3000/api/v1/version > /dev/null 2>&1; do
+    counter=$((counter + 1))
+    if [ $counter -gt $timeout ]; then
+      echo "Timeout waiting for Gitea to be initialized"
+      exit 1
+    fi
+    sleep 2
+  done
+  echo "  Gitea is ready!"
+
+  # Create initial admin user via CLI
+  echo "  Creating initial admin user..."
+  docker exec gitea gitea admin user create \
+    --username gitea_admin \
+    --password admin123 \
+    --email admin@gitea.local \
+    --admin \
+    --must-change-password=false || echo "  Failed to create admin user, might already exist"
+
+  # Prepare the local repository
+  echo "  Creating temp repo for policy repository at $PWD/temp-repo..."
+  rm -rf ./temp-repo
+  mkdir -p temp-repo
+  cd temp-repo
+  git init
+
+  # Configure git
+  git config user.email "test@opal.local"
+  git config user.name "OPAL Test"
+
+  # Copy the policy files from opal-tests-policy-repo-main
+  echo "  Copying policy files..."
+  cp -r ../opal-tests-policy-repo-main/* .
+  if [ -f ../opal-tests-policy-repo-main/.manifest ]; then
+    cp ../opal-tests-policy-repo-main/.manifest .
+  fi
+
+  # Create initial commit
+  git add .
+  git commit -m "Initial policies from opal-tests-policy-repo"
+
+  # Set up the repository URLs with embedded credentials
+  export OPAL_POLICY_REPO_URL="http://gitea_admin:admin123@localhost:3000/gitea_admin/policy-repo.git"
+  export OPAL_POLICY_REPO_URL_FOR_WEBHOOK="http://gitea:3000/gitea_admin/policy-repo.git"
+  git remote add origin "$OPAL_POLICY_REPO_URL"
+
+  # Check if repository already exists and delete if needed
+  echo "  Checking if repository exists..."
+  if curl -sf http://localhost:3000/api/v1/repos/gitea_admin/policy-repo > /dev/null 2>&1; then
+    echo "  Repository already exists, deleting it..."
+    curl -X DELETE http://localhost:3000/api/v1/repos/gitea_admin/policy-repo \
+      -u "gitea_admin:admin123" 2>/dev/null || true
+    sleep 2
+  fi
+
+  # Create repository via API
+  echo "  Creating repository via API..."
+  curl -X POST http://localhost:3000/api/v1/user/repos \
+    -u "gitea_admin:admin123" \
+    -H "Content-Type: application/json" \
+    -d '{"name":"policy-repo","private":false,"auto_init":false}' 2>/dev/null || {
+    echo "  Failed to create repository via API, trying push method..."
+    # Fallback: try to create by pushing
+    git push -u origin master:main 2>/dev/null || git push -u origin master 2>/dev/null || {
+      echo "  Both methods failed to create repository"
+      exit 1
+    }
+  }
+
+  # Push to the repository
+  echo "  Pushing to repository..."
+  git push -u origin master:main || git push -u origin master
+
+  # Create and push test branch
+  export POLICY_REPO_BRANCH="test-$RANDOM$RANDOM"
+  git checkout -b $POLICY_REPO_BRANCH
+  git push -u origin $POLICY_REPO_BRANCH
+
+  cd ..
+
+  # Clone fresh for testing
+  rm -rf ./opal-tests-policy-repo
+  git clone "$OPAL_POLICY_REPO_URL" opal-tests-policy-repo
+  cd opal-tests-policy-repo
+  git checkout $POLICY_REPO_BRANCH
+  cd ..
 }
 
 function compose {
@@ -71,24 +232,27 @@ function check_clients_logged {
 function check_no_error {
   # Without index would output all replicas
   if compose logs opal_client | grep -q 'ERROR'; then
-    echo "- Found error in logs"
+    echo "- Found error in logs:"
+    compose logs opal_client | grep 'ERROR'
     exit 1
   fi
 }
 
 function clean_up {
     ARG=$?
+    # Ensure we're in the script directory for cleanup
+    cd "$SCRIPT_DIR" 2>/dev/null || cd "$INITIAL_DIR"
+
     if [[ "$ARG" -ne 0 ]]; then
       echo "*** Test Failed ***"
       echo ""
-      compose logs
+      compose logs 2>/dev/null || echo "Could not retrieve logs"
     else
       echo "*** Test Passed ***"
       echo ""
     fi
-    compose down
-    cd opal-tests-policy-repo; git push -d origin $POLICY_REPO_BRANCH; cd - # Remove remote tests branch
-    rm -rf ./opal-tests-policy-repo
+    compose down 2>/dev/null || docker compose -f ./docker-compose-app-tests.yml down
+    rm -rf ./opal-tests-policy-repo ./temp-repo ./gitea-data ./git-repos
     exit $ARG
 }
 
@@ -99,10 +263,16 @@ function test_push_policy {
   echo "package $1" > "$regofile"
   git add "$regofile"
   git commit -m "Add $regofile"
-  git push
+
+  # Push to Gitea
+  git push origin $POLICY_REPO_BRANCH
   cd -
 
-  curl -s --request POST 'http://localhost:7002/webhook' --header 'Content-Type: application/json' --header 'x-webhook-token: xxxxx' --data-raw '{"gitEvent":"git.push","repository":{"git_url":"'"$OPAL_POLICY_REPO_URL"'"}}'
+  # Trigger webhook - using the internal Gitea URL
+  curl -s --request POST 'http://localhost:7002/webhook' \
+    --header 'Content-Type: application/json' \
+    --header 'x-webhook-token: xxxxx' \
+    --data-raw "{\"gitEvent\":\"git.push\",\"repository\":{\"git_url\":\"$OPAL_POLICY_REPO_URL_FOR_WEBHOOK\"}}"
   sleep 5
   check_clients_logged "PUT /v1/policies/$regofile -> 200"
 }
@@ -110,7 +280,21 @@ function test_push_policy {
 function test_data_publish {
   echo "- Testing data publish for user $1"
   user=$1
-  OPAL_CLIENT_TOKEN=$OPAL_DATA_SOURCE_TOKEN opal-client publish-data-update --src-url https://api.country.is/23.54.6.78 -t policy_data --dst-path "/users/$user/location"
+
+  # Use curl to publish data update via OPAL server API
+  curl -s -X POST http://localhost:7002/data/config \
+    -H "Authorization: Bearer $OPAL_DATA_SOURCE_TOKEN" \
+    -H "Content-Type: application/json" \
+    -d '{
+      "entries": [{
+        "url": "https://api.country.is/23.54.6.78",
+        "config": {},
+        "topics": ["policy_data"],
+        "dst_path": "/users/'$user'/location",
+        "save_method": "PUT"
+      }]
+    }'
+
   sleep 5
   check_clients_logged "PUT /v1/data/users/$user/location -> 204"
 }
@@ -126,16 +310,28 @@ function test_statistics {
 }
 
 function main {
+  # Ensure we're in the correct directory
+  cd "$SCRIPT_DIR"
+
   # Setup
   generate_opal_keys
-  prepare_policy_repo
 
   trap clean_up EXIT
 
-  # Bring up OPAL containers
+  # Bring up containers
   compose down --remove-orphans
-  compose up -d
-  sleep 10
+
+  echo "Starting Gitea"
+  compose up -d gitea --force-recreate
+  sleep 5  # Give Gitea time to start
+
+  echo "Preparing policy repository"
+  prepare_policy_repo
+
+  echo "Starting OPAL services"
+  # Start OPAL services
+  compose up -d --force-recreate
+  sleep 15  # Give OPAL more time to start
 
   # Check containers started correctly
   check_clients_logged "Connected to PubSub server"
@@ -171,7 +367,7 @@ while [ $RETRY_COUNT -lt $MAX_RETRIES ]; do
   echo "Test failed, retrying..."
 done
 
-if [ $RETRY_COUNT -eq $MAX_RETRIES ]; then
+if [ $RETRY_COUNT -ge $MAX_RETRIES ]; then
   echo "Tests failed after $MAX_RETRIES attempts."
   exit 1
 fi


### PR DESCRIPTION
- Added a minimal Gitea service to the Docker Compose configuration for local testing.
- Updated the `run.sh` script to initialize Gitea and create a test repository with policy files.
- Modified the README to reflect the new testing approach and prerequisites.
- Introduced new policy files and data structures for comprehensive end-to-end testing.
- Improved error handling and logging in the testing scripts for better troubleshooting.

<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing -->

## Fixes Issue

<!-- Remove this section if not applicable -->

<!-- Example: Closes #31 -->

## Changes proposed

<!-- List all the proposed changes in your PR -->

<!-- Mark all the applicable boxes. To mark the box as done follow the following conventions -->
<!--
[x] - Correct; marked as done
[X] - Correct; marked as done

[ ] - Not correct; marked as **not** done
-->

## Check List (Check all the applicable boxes) <!-- Follow the above conventions to check the box -->

- [x] I sign off on contributing this submission to open-source
- [ ] My code follows the code style of this project.
- [ ] My change requires changes to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] This PR does not contain plagiarized content.
- [ ] The title of my pull request is a short description of the requested changes.

## Screenshots

<!-- Add all the screenshots which support your changes -->

## Note to reviewers

<!-- Add notes to reviewers if applicable -->
