### PR TITLE
Remove unnecessary parent references from actions in data.json

### DIFF
--- a/docker/docker_files/cedar_data/data.json
+++ b/docker/docker_files/cedar_data/data.json
@@ -29,16 +29,7 @@
   },
   {
     "attrs": {},
-    "parents": [
-      {
-        "id": "document",
-        "type": "ResourceType"
-      },
-      {
-        "id": "Editor",
-        "type": "Role"
-      }
-    ],
+    "parents": [],
     "uid": {
       "id": "document:delete",
       "type": "Action"
@@ -46,16 +37,7 @@
   },
   {
     "attrs": {},
-    "parents": [
-      {
-        "id": "document",
-        "type": "ResourceType"
-      },
-      {
-        "id": "Editor",
-        "type": "Role"
-      }
-    ],
+    "parents": [],
     "uid": {
       "id": "document:create",
       "type": "Action"
@@ -71,16 +53,7 @@
   },
   {
     "attrs": {},
-    "parents": [
-      {
-        "id": "Editor",
-        "type": "Role"
-      },
-      {
-        "id": "document",
-        "type": "ResourceType"
-      }
-    ],
+    "parents": [],
     "uid": {
       "id": "document:update",
       "type": "Action"
@@ -88,16 +61,7 @@
   },
   {
     "attrs": {},
-    "parents": [
-      {
-        "id": "document",
-        "type": "ResourceType"
-      },
-      {
-        "id": "Editor",
-        "type": "Role"
-      }
-    ],
+    "parents": [],
     "uid": {
       "id": "document:list",
       "type": "Action"
@@ -105,16 +69,7 @@
   },
   {
     "attrs": {},
-    "parents": [
-      {
-        "id": "document",
-        "type": "ResourceType"
-      },
-      {
-        "id": "Editor",
-        "type": "Role"
-      }
-    ],
+    "parents": [],
     "uid": {
       "id": "document:get",
       "type": "Action"


### PR DESCRIPTION
Fixes the example data for the OPAL<>Cedar Agent Integration.

Cedar core was updated in cedar-agent, it had a breaking change that prevents non-action parents for `Action`, this PR fixes the example data