### PR TITLE
Fix data update using scopes

### DIFF
--- a/packages/opal-server/opal_server/scopes/api.py
+++ b/packages/opal-server/opal_server/scopes/api.py
@@ -350,7 +350,7 @@ def init_scope_router(
                 entry.topics = [f"{scope_id}:data:{topic}" for topic in entry.topics]
 
             await DataUpdatePublisher(
-                ScopedServerSideTopicPublisher(pubsub_endpoint, scope_id)
+                ServerSideTopicPublisher(pubsub_endpoint)
             ).publish_data_updates(update)
         except Unauthorized as ex:
             logger.error(f"Unauthorized to publish update: {repr(ex)}")


### PR DESCRIPTION
<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing -->

## Fixes Issue

Closes #773 

In the current implementation publishing a data update using scopes doesn't work. This is due to issues with a missing prefixing of the topic.


## Changes proposed

### Current Faulty Setup
- Topic as part of DataSourceEntry: `data:topic` (Missing prefix with scope id)
- Pubsub manager topic published to: `scope:data:topic` (correct topic)

### Corrected Setup
- Topic as part of DataSourceEntry: `scope:data:topic` 
- Pubsub manager topic published to: `scope:data:topic`

Both topics need to be correct. The topic published to needs to be correct as the client only subscribes to the topic in the correct format and would ignore publications to the incorrect topic (format). The topic in the DataSourceEntry needs to be correct since with an incorrect topic the client will receive the message but discard it later due to an unknown topic in the entry.


To accomplish the corrected setup there are two changes necessary. The first is to prefix the topic with the scope id in the scope data update api endpoint. However in the ScopedDataPublisher the topic is prefixed with the scope id again. To avoid publishing to a topic with a duplicate prefix (`scope:scope:data:topic`) the ServerSideTopicPublisher is used instead of the ScopedTopicPublisher.


## Check List (Check all the applicable boxes) <!-- Follow the above conventions to check the box -->

- [x] I sign off on contributing this submission to open-source
- [x] My code follows the code style of this project.
- [ ] My change requires changes to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [x] This PR does not contain plagiarized content.
- [x] The title of my pull request is a short description of the requested changes.

## Screenshots

n/a

## Note to reviewers

n/a


EDIT: Used non scoped data topic publisher to avoid duplicate prefixing instead of modifying ScopedTopicPublisher to avoid interference with policy publishing.