### PR TITLE
Add initial E2E test framework for opal-server

### DIFF
--- a/packages/opal-server/opal_server/.gitignore
+++ b/packages/opal-server/opal_server/.gitignore
@@ -1,0 +1,1 @@
+jwks_dir/

--- a/packages/opal-server/opal_server/tests/test_e2e_healthcheck.py
+++ b/packages/opal-server/opal_server/tests/test_e2e_healthcheck.py
@@ -1,0 +1,49 @@
+import subprocess
+import time
+import requests
+import signal
+import os
+
+
+SERVER_URL = "http://127.0.0.1:7002"
+
+
+def start_server():
+    process = subprocess.Popen(
+        [
+            "uvicorn",
+            "opal_server.main:app",
+            "--host",
+            "127.0.0.1",
+            "--port",
+            "7002",
+        ],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        env=os.environ.copy(),
+    )
+
+    # wait for server to be ready
+    for _ in range(10):
+        try:
+            requests.get(f"{SERVER_URL}/healthcheck", timeout=1)
+            return process
+        except Exception:
+            time.sleep(1)
+
+    raise RuntimeError("Server did not start")
+
+
+def stop_server(process):
+    process.send_signal(signal.SIGINT)
+    process.wait(timeout=5)
+
+
+def test_server_healthcheck_e2e():
+    process = start_server()
+
+    try:
+        response = requests.get(f"{SERVER_URL}/healthcheck")
+        assert response.status_code == 200
+    finally:
+        stop_server(process)

--- a/tests/e2e/__init__.py
+++ b/tests/e2e/__init__.py
@@ -1,0 +1,6 @@
+"""
+End-to-end tests for OPAL.
+
+This package contains system-level E2E tests that validate the full OPAL stack
+running in Docker Compose.
+"""

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -1,0 +1,254 @@
+"""
+Pytest configuration and fixtures for OPAL end-to-end tests.
+
+This module provides session-scoped fixtures to manage the Docker Compose
+lifecycle for E2E tests. Containers are started once per test session and
+torn down after all tests complete.
+"""
+
+import json
+import subprocess
+import time
+from typing import Dict, List
+
+import pytest
+
+from tests.e2e.utils.docker_compose import get_compose_file_path, get_compose_services, run_compose_command
+
+# Path to the E2E Docker Compose file
+COMPOSE_FILE = get_compose_file_path()
+
+# Maximum time to wait for services to become healthy (in seconds)
+HEALTH_CHECK_TIMEOUT = 120
+
+# Interval between health check attempts (in seconds)
+HEALTH_CHECK_INTERVAL = 2
+
+
+def run_docker_compose_command(command: List[str], check: bool = True) -> subprocess.CompletedProcess:
+    """
+    Run a docker compose command and return the result.
+    
+    Args:
+        command: List of command arguments (without 'docker compose')
+        check: If True, raise CalledProcessError on non-zero exit
+        
+    Returns:
+        CompletedProcess with stdout and stderr
+        
+    Raises:
+        subprocess.CalledProcessError: If command fails and check=True
+    """
+    return run_compose_command(command, check=check)
+
+
+def get_service_status() -> Dict[str, str]:
+    """
+    Get the health status of all services.
+    
+    Returns:
+        Dictionary mapping service names to their status
+        (e.g., {"opal_server": "healthy", "opal_client": "starting"})
+    """
+    result = run_docker_compose_command(["ps", "--format", "json"], check=False)
+    
+    if result.returncode != 0:
+        return {}
+    
+    services = {}
+    for line in result.stdout.strip().split("\n"):
+        if not line:
+            continue
+        try:
+            service_info = json.loads(line)
+            service_name = service_info.get("Service", "")
+            health = service_info.get("Health", "")
+            # Normalize health status
+            if health:
+                services[service_name] = health.lower()
+            else:
+                # If no health check, use state
+                state = service_info.get("State", "unknown").lower()
+                services[service_name] = state
+        except (json.JSONDecodeError, KeyError):
+            continue
+    
+    return services
+
+
+def wait_for_services_healthy(timeout: int = HEALTH_CHECK_TIMEOUT) -> None:
+    """
+    Wait for all services to become healthy.
+    
+    Polls Docker Compose health status and waits for services to transition
+    from "starting" or "unhealthy" to "healthy" or "running". Does not fail
+    immediately on "unhealthy" status - instead continues polling until timeout.
+    
+    Args:
+        timeout: Maximum time to wait in seconds
+        
+    Raises:
+        RuntimeError: If services don't become healthy within timeout
+    """
+    start_time = time.time()
+    last_status = {}
+    expected_services = []
+    last_log_time = 0
+    log_interval = 10  # Log status every 10 seconds
+    
+    while time.time() - start_time < timeout:
+        status = get_service_status()
+        last_status = status
+        
+        # Get list of expected services from Docker Compose
+        if not expected_services:
+            expected_services = get_compose_services()
+            if not expected_services:
+                # Services not started yet, wait and retry
+                time.sleep(HEALTH_CHECK_INTERVAL)
+                continue
+        
+        # Check if all expected services are healthy
+        all_healthy = True
+        unhealthy_services = []
+        
+        for service in expected_services:
+            service_status = status.get(service, "unknown")
+            # Accept "healthy" or "running" as valid states
+            # "starting" and "unhealthy" are intermediate states - keep polling
+            if service_status not in ("healthy", "running"):
+                all_healthy = False
+                unhealthy_services.append((service, service_status))
+        
+        if all_healthy:
+            elapsed = time.time() - start_time
+            print(f"[E2E Setup] All services healthy after {elapsed:.1f}s")
+            return
+        
+        # Log progress periodically (not on every iteration to avoid spam)
+        elapsed = time.time() - start_time
+        if elapsed - last_log_time >= log_interval:
+            status_summary = ", ".join(
+                f"{svc}: {stat}" for svc, stat in unhealthy_services
+            )
+            print(
+                f"[E2E Setup] Waiting for services... ({elapsed:.0f}s/{timeout}s) - {status_summary}"
+            )
+            last_log_time = elapsed
+        
+        time.sleep(HEALTH_CHECK_INTERVAL)
+    
+    # Timeout reached - provide detailed error message
+    elapsed = time.time() - start_time
+    error_msg = (
+        f"Services did not become healthy within {timeout} seconds (waited {elapsed:.1f}s).\n"
+        f"Final status:\n"
+    )
+    for service in expected_services if expected_services else last_status.keys():
+        status = last_status.get(service, "not found")
+        error_msg += f"  - {service}: {status}\n"
+    
+    error_msg += "\nContainer logs (last 2000 chars):\n"
+    try:
+        logs_result = run_docker_compose_command(["logs"], check=False)
+        error_msg += logs_result.stdout[-2000:]  # Last 2000 chars
+    except Exception:
+        error_msg += "  (Could not retrieve logs)\n"
+    
+    raise RuntimeError(error_msg)
+
+
+@pytest.fixture(scope="session")
+def docker_compose_stack():
+    """
+    Session-scoped fixture that manages the Docker Compose lifecycle.
+    
+    Starts all services once per test session, waits for them to be healthy,
+    and tears them down after all tests complete.
+    
+    Yields:
+        None: Fixture yields control to tests after services are healthy
+        
+    Raises:
+        RuntimeError: If services fail to start or become healthy
+    """
+    # Ensure compose file exists
+    if not COMPOSE_FILE.exists():
+        raise FileNotFoundError(
+            f"Docker Compose file not found: {COMPOSE_FILE}\n"
+            f"Expected path: {COMPOSE_FILE.absolute()}"
+        )
+    
+    # Stop any existing containers from previous runs
+    print("\n[E2E Setup] Cleaning up any existing containers...")
+    run_docker_compose_command(["down", "-v"], check=False)
+    
+    # Start services
+    print(f"[E2E Setup] Starting Docker Compose stack from {COMPOSE_FILE}...")
+    try:
+        result = run_docker_compose_command(["up", "-d"], check=True)
+        print("[E2E Setup] Containers started successfully")
+    except subprocess.CalledProcessError as e:
+        error_msg = (
+            f"Failed to start Docker Compose stack.\n"
+            f"Command: {' '.join(e.cmd)}\n"
+            f"Return code: {e.returncode}\n"
+            f"Stdout: {e.stdout}\n"
+            f"Stderr: {e.stderr}"
+        )
+        raise RuntimeError(error_msg) from e
+    
+    # Wait for services to become healthy
+    print("[E2E Setup] Waiting for services to become healthy...")
+    try:
+        wait_for_services_healthy()
+        print("[E2E Setup] All services are healthy. Tests can begin.")
+    except RuntimeError as e:
+        # Clean up on failure
+        print("\n[E2E Setup] Health check failed. Cleaning up...")
+        run_docker_compose_command(["down", "-v"], check=False)
+        raise
+    
+    # Yield control to tests
+    yield
+    
+    # Teardown: Stop and remove containers
+    print("\n[E2E Teardown] Stopping Docker Compose stack...")
+    try:
+        run_docker_compose_command(["down", "-v"], check=False)
+        print("[E2E Teardown] Containers stopped and removed")
+    except Exception as e:
+        print(f"[E2E Teardown] Warning: Error during cleanup: {e}")
+
+
+@pytest.fixture(scope="session")
+def opal_server_url(docker_compose_stack):
+    """
+    URL of the OPAL server for E2E tests.
+    
+    Returns:
+        str: Base URL of the OPAL server (e.g., "http://localhost:17002")
+    """
+    return "http://localhost:17002"
+
+
+@pytest.fixture(scope="session")
+def opal_client_url(docker_compose_stack):
+    """
+    URL of the OPAL client for E2E tests.
+    
+    Returns:
+        str: Base URL of the OPAL client (e.g., "http://localhost:17766")
+    """
+    return "http://localhost:17766"
+
+
+@pytest.fixture(scope="session")
+def opa_url(docker_compose_stack):
+    """
+    URL of the OPA instance for E2E tests.
+    
+    Returns:
+        str: Base URL of OPA (e.g., "http://localhost:18181")
+    """
+    return "http://localhost:18181"

--- a/tests/e2e/test_client_registration.py
+++ b/tests/e2e/test_client_registration.py
@@ -1,0 +1,95 @@
+"""
+End-to-end tests for client registration via Statistics API.
+
+Validates that the OPAL client successfully registers with the server
+and appears in the statistics endpoint.
+"""
+
+import pytest
+
+from tests.e2e.utils.http_client import http_get_with_retries
+
+
+def test_statistics_api_is_enabled(opal_server_url):
+    """Test that Statistics API is enabled and accessible."""
+    url = f"{opal_server_url}/statistics"
+    response = http_get_with_retries(url, max_attempts=10)
+    
+    assert response.status_code == 200, (
+        f"Expected 200, got {response.status_code}. "
+        f"Statistics API may not be enabled."
+    )
+
+
+def test_client_appears_in_statistics(opal_server_url):
+    """Test that OPAL client is registered in server statistics."""
+    url = f"{opal_server_url}/statistics"
+    response = http_get_with_retries(url, max_attempts=15, timeout=15)
+    
+    assert response.status_code == 200, "Statistics endpoint should return 200"
+    
+    data = response.json()
+    
+    # Verify statistics structure
+    assert "clients" in data, "Statistics should contain 'clients' field"
+    assert isinstance(data["clients"], dict), "Clients should be a dictionary"
+    
+    # Check that at least one client is registered
+    client_count = len(data["clients"])
+    assert client_count > 0, (
+        f"Expected at least one client registered, found {client_count}. "
+        f"Client may not have connected yet."
+    )
+
+
+def test_client_has_registered_topics(opal_server_url):
+    """Test that registered client has subscribed to topics."""
+    url = f"{opal_server_url}/statistics"
+    response = http_get_with_retries(url, max_attempts=15, timeout=15)
+    
+    assert response.status_code == 200, "Statistics endpoint should return 200"
+    
+    data = response.json()
+    clients = data.get("clients", {})
+    
+    # Find a client and verify it has topics
+    assert len(clients) > 0, "At least one client should be registered"
+    
+    # Each client can have multiple channels, check at least one has topics
+    client_has_topics = False
+    for client_id, channels in clients.items():
+        if not isinstance(channels, list):
+            continue
+        for channel in channels:
+            if isinstance(channel, dict) and "topics" in channel:
+                topics = channel.get("topics", [])
+                if len(topics) > 0:
+                    client_has_topics = True
+                    break
+        if client_has_topics:
+            break
+    
+    assert client_has_topics, (
+        "At least one registered client should have subscribed to topics. "
+        "Client may not have completed initial subscription."
+    )
+
+
+def test_statistics_brief_endpoint_works(opal_server_url):
+    """Test that the brief statistics endpoint returns client count."""
+    url = f"{opal_server_url}/stats"
+    response = http_get_with_retries(url, max_attempts=10)
+    
+    assert response.status_code == 200, "Stats endpoint should return 200"
+    
+    data = response.json()
+    
+    # Verify brief stats structure
+    assert "client_count" in data, "Brief stats should contain 'client_count'"
+    assert "server_count" in data, "Brief stats should contain 'server_count'"
+    
+    # Verify client count is at least 1
+    client_count = data.get("client_count", 0)
+    assert client_count >= 1, (
+        f"Expected at least 1 client, found {client_count}"
+    )

--- a/tests/e2e/test_health_endpoints.py
+++ b/tests/e2e/test_health_endpoints.py
@@ -1,0 +1,61 @@
+"""
+End-to-end tests for health endpoints.
+
+Validates that all health check endpoints respond correctly.
+"""
+
+import pytest
+
+from tests.e2e.utils.http_client import http_get_with_retries
+
+
+def test_server_health_endpoint_responds(opal_server_url):
+    """Test that OPAL server health endpoint returns 200 OK."""
+    url = f"{opal_server_url}/healthcheck"
+    response = http_get_with_retries(url, max_attempts=10)
+    
+    assert response.status_code == 200, f"Expected 200, got {response.status_code}"
+    
+    # Verify response content
+    data = response.json()
+    assert "status" in data, "Response should contain 'status' field"
+    assert data["status"] == "ok", f"Expected status 'ok', got '{data.get('status')}'"
+
+
+def test_server_root_endpoint_responds(opal_server_url):
+    """Test that OPAL server root endpoint returns 200 OK."""
+    url = f"{opal_server_url}/"
+    response = http_get_with_retries(url, max_attempts=10)
+    
+    assert response.status_code == 200, f"Expected 200, got {response.status_code}"
+
+
+def test_client_readiness_endpoint_responds(opal_client_url):
+    """Test that OPAL client readiness endpoint returns 200 OK."""
+    url = f"{opal_client_url}/ready"
+    response = http_get_with_retries(url, max_attempts=15, timeout=15)
+    
+    assert response.status_code == 200, (
+        f"Expected 200, got {response.status_code}. "
+        f"Client may not have loaded policies and data yet."
+    )
+    
+    # Verify response content
+    data = response.json()
+    assert "status" in data, "Response should contain 'status' field"
+
+
+def test_client_health_endpoint_responds(opal_client_url):
+    """Test that OPAL client health endpoint returns 200 OK."""
+    url = f"{opal_client_url}/healthcheck"
+    response = http_get_with_retries(url, max_attempts=10)
+    
+    assert response.status_code == 200, f"Expected 200, got {response.status_code}"
+
+
+def test_opa_health_endpoint_responds(opa_url):
+    """Test that OPA health endpoint returns 200 OK."""
+    url = f"{opa_url}/health"
+    response = http_get_with_retries(url, max_attempts=10)
+    
+    assert response.status_code == 200, f"Expected 200, got {response.status_code}"

--- a/tests/e2e/test_log_validation.py
+++ b/tests/e2e/test_log_validation.py
@@ -1,0 +1,64 @@
+"""
+End-to-end tests for log validation.
+
+Validates that container logs do not contain ERROR or CRITICAL messages.
+"""
+
+import pytest
+
+from tests.e2e.utils.docker_compose import get_compose_services
+from tests.e2e.utils.log_parser import check_logs_for_errors, get_all_container_logs
+
+
+def test_all_container_logs_have_no_errors():
+    """Test that all container logs combined contain no ERROR or CRITICAL messages."""
+    errors = check_logs_for_errors(service_name=None)
+    
+    assert len(errors) == 0, (
+        f"Found {len(errors)} ERROR/CRITICAL messages across all containers:\n"
+        + "\n".join(f"  - {error}" for error in errors[:20])  # Show first 20
+    )
+
+
+def test_each_service_logs_have_no_errors():
+    """Test that each service's logs contain no ERROR or CRITICAL messages."""
+    services = get_compose_services()
+    
+    assert len(services) > 0, "At least one service should be running"
+    
+    for service_name in services:
+        errors = check_logs_for_errors(service_name=service_name)
+        
+        # Database services may have some expected warnings, so we're lenient
+        # Only fail on actual CRITICAL/FATAL messages for database services
+        if "postgres" in service_name.lower() or "db" in service_name.lower():
+            critical_errors = [
+                error for error in errors
+                if "CRITICAL" in error.upper() or "FATAL" in error.upper()
+            ]
+            assert len(critical_errors) == 0, (
+                f"Found {len(critical_errors)} CRITICAL/FATAL messages in {service_name} logs:\n"
+                + "\n".join(f"  - {error}" for error in critical_errors[:10])
+            )
+        else:
+            assert len(errors) == 0, (
+                f"Found {len(errors)} ERROR/CRITICAL messages in {service_name} logs:\n"
+                + "\n".join(f"  - {error}" for error in errors[:10])  # Show first 10
+            )
+
+
+def test_logs_are_accessible():
+    """Test that container logs can be retrieved for all services."""
+    all_logs = get_all_container_logs()
+    services = get_compose_services()
+    
+    assert len(services) > 0, "At least one service should be running"
+    
+    # Verify we can retrieve logs for all discovered services
+    # Note: Some services (e.g., infrastructure services) may legitimately have no logs
+    for service_name in services:
+        assert service_name in all_logs, (
+            f"Logs for service '{service_name}' should be available. "
+            f"Available services in logs: {list(all_logs.keys())}"
+        )
+        # Do not assert logs are non-empty - some services legitimately produce no output

--- a/tests/e2e/test_policy_sync.py
+++ b/tests/e2e/test_policy_sync.py
@@ -1,0 +1,109 @@
+"""
+End-to-end tests for policy synchronization.
+
+Validates that OPA successfully receives and loads policies from OPAL.
+"""
+
+import pytest
+
+from tests.e2e.utils.http_client import http_get_with_retries
+
+
+def test_opa_has_loaded_policies(opa_url):
+    """Test that OPA has loaded policies."""
+    url = f"{opa_url}/v1/policies"
+    response = http_get_with_retries(url, max_attempts=15, timeout=15)
+    
+    assert response.status_code == 200, f"Expected 200, got {response.status_code}"
+    
+    data = response.json()
+    
+    # Verify policies structure
+    assert "result" in data, "OPA response should contain 'result' field"
+    policies = data.get("result", {})
+    
+    # Check that at least one policy is loaded
+    assert len(policies) > 0, (
+        "OPA should have at least one policy loaded. "
+        "Policies may not have been synced yet."
+    )
+
+
+def test_opa_healthcheck_policy_ready(opa_url):
+    """Test that OPA healthcheck policy reports ready status."""
+    url = f"{opa_url}/v1/data/system/opal/ready"
+    response = http_get_with_retries(url, max_attempts=15, timeout=15)
+    
+    assert response.status_code == 200, f"Expected 200, got {response.status_code}"
+    
+    data = response.json()
+    
+    # Verify healthcheck policy structure
+    assert "result" in data, "OPA response should contain 'result' field"
+    result = data.get("result")
+    
+    # Result should be True (OPA healthcheck policy enabled)
+    assert result is True, (
+        f"OPA healthcheck policy should report ready=True, got {result}. "
+        "This may indicate policies or data have not been loaded successfully."
+    )
+
+
+def test_opa_has_loaded_data(opa_url):
+    """Test that OPA has loaded data from the policy repository."""
+    url = f"{opa_url}/v1/data/static"
+    response = http_get_with_retries(url, max_attempts=15, timeout=15)
+    
+    assert response.status_code == 200, f"Expected 200, got {response.status_code}"
+    
+    data = response.json()
+    
+    # OPA returns {} when data path exists but has no keys (valid behavior)
+    # OPAL may load data under nested paths, so empty dict is acceptable
+    # The important thing is that the endpoint is reachable and returns 200
+    if "result" in data:
+        # If "result" key exists, that's valid (even if it's an empty dict)
+        result = data.get("result", {})
+        assert isinstance(result, dict), "OPA result should be a dictionary"
+    else:
+        # If response is just an empty dict {}, that's also valid OPA behavior
+        # when the data path exists but contains no keys
+        assert isinstance(data, dict), "OPA response should be a dictionary"
+
+
+def test_opa_healthcheck_policy_healthy(opa_url):
+    """Test that OPA healthcheck policy reports healthy status."""
+    url = f"{opa_url}/v1/data/system/opal/healthy"
+    response = http_get_with_retries(url, max_attempts=15, timeout=15)
+    
+    assert response.status_code == 200, f"Expected 200, got {response.status_code}"
+    
+    data = response.json()
+    
+    # Verify healthcheck policy structure
+    assert "result" in data, "OPA response should contain 'result' field"
+    result = data.get("result")
+    
+    # Result should be True (all updates successful)
+    assert result is True, (
+        f"OPA healthcheck policy should report healthy=True, got {result}. "
+        "This may indicate the latest policy or data update failed."
+    )
+
+
+def test_opa_can_query_policy(opa_url):
+    """Test that OPA can evaluate a policy query."""
+    # Query the example policy repository's RBAC policy
+    # The example repo has an RBAC policy that we can query
+    url = f"{opa_url}/v1/data"
+    response = http_get_with_retries(url, max_attempts=10)
+    
+    assert response.status_code == 200, f"Expected 200, got {response.status_code}"
+    
+    data = response.json()
+    
+    # Verify response structure
+    assert "result" in data, "OPA response should contain 'result' field"
+    
+    # At minimum, the result should be a dictionary (even if empty)
+    assert isinstance(data["result"], dict), "OPA result should be a dictionary"

--- a/tests/e2e/utils/__init__.py
+++ b/tests/e2e/utils/__init__.py
@@ -1,0 +1,18 @@
+"""
+Utility modules for E2E tests.
+
+Simple, focused utilities for HTTP requests, Docker Compose operations, and log parsing.
+"""
+
+from tests.e2e.utils.docker_compose import get_compose_file_path, get_compose_services
+from tests.e2e.utils.http_client import http_get_with_retries
+from tests.e2e.utils.log_parser import check_logs_for_errors, get_all_container_logs, get_container_logs
+
+__all__ = [
+    "http_get_with_retries",
+    "get_container_logs",
+    "get_all_container_logs",
+    "check_logs_for_errors",
+    "get_compose_file_path",
+    "get_compose_services",
+]

--- a/tests/e2e/utils/docker_compose.py
+++ b/tests/e2e/utils/docker_compose.py
@@ -1,0 +1,129 @@
+"""
+Docker Compose helper utilities for E2E tests.
+
+Provides simple functions to interact with Docker Compose services.
+"""
+
+import subprocess
+from pathlib import Path
+
+try:
+    import yaml
+except ImportError:
+    # Fallback: if yaml is not available, we'll use a simple parser
+    yaml = None
+
+
+def get_compose_file_path() -> Path:
+    """
+    Get the path to the E2E Docker Compose file.
+    
+    Returns:
+        Path object pointing to docker-compose.e2e.yml
+    """
+    return Path(__file__).parent.parent.parent.parent / "docker" / "docker-compose.e2e.yml"
+
+
+def run_compose_command(command: list[str], check: bool = True) -> subprocess.CompletedProcess:
+    """
+    Run a docker compose command.
+    
+    Example:
+        result = run_compose_command(["ps", "--format", "json"])
+        print(result.stdout)
+    
+    Args:
+        command: List of command arguments (e.g., ["up", "-d"])
+        check: If True, raise exception on non-zero exit code
+    
+    Returns:
+        CompletedProcess with stdout and stderr
+    """
+    compose_file = get_compose_file_path()
+    full_command = ["docker", "compose", "-f", str(compose_file)] + command
+    
+    return subprocess.run(
+        full_command,
+        capture_output=True,
+        text=True,
+        check=check,
+    )
+
+
+def get_compose_services_from_yaml() -> list[str]:
+    """
+    Get list of service names by parsing the Docker Compose YAML file.
+    
+    This is the authoritative source of service names, independent of
+    Docker runtime state. Parses docker-compose.e2e.yml directly.
+    
+    Example:
+        services = get_compose_services_from_yaml()
+        print(f"Found {len(services)} services: {services}")
+    
+    Returns:
+        List of service names defined in docker-compose.e2e.yml
+    """
+    compose_file = get_compose_file_path()
+    
+    if not compose_file.exists():
+        return []
+    
+    if yaml is None:
+        # Fallback: simple line-based parsing if yaml library not available
+        # This is less robust but works for basic cases
+        services = []
+        in_services_section = False
+        with open(compose_file, "r") as f:
+            for line in f:
+                line = line.strip()
+                if line == "services:":
+                    in_services_section = True
+                    continue
+                if in_services_section:
+                    # Service name is the first non-empty, non-comment line that ends with ':'
+                    if line and not line.startswith("#") and line.endswith(":"):
+                        service_name = line[:-1].strip()
+                        if service_name and not service_name.startswith("_"):
+                            services.append(service_name)
+                    # Stop at top-level keys (not indented)
+                    elif line and not line.startswith(" ") and not line.startswith("\t"):
+                        break
+        return services
+    
+    # Use YAML parser (preferred method)
+    try:
+        with open(compose_file, "r") as f:
+            compose_data = yaml.safe_load(f)
+        
+        if not isinstance(compose_data, dict):
+            return []
+        
+        services_section = compose_data.get("services", {})
+        if not isinstance(services_section, dict):
+            return []
+        
+        # Return list of service names (keys in services section)
+        return list(services_section.keys())
+    
+    except Exception:
+        # If YAML parsing fails, return empty list
+        return []
+
+
+def get_compose_services() -> list[str]:
+    """
+    Get list of service names from Docker Compose.
+    
+    Parses the docker-compose.e2e.yml file directly to extract service names.
+    This is more reliable than using `docker compose ps --services` which
+    can be unreliable in attached mode and CI environments.
+    
+    Example:
+        services = get_compose_services()
+        print(f"Found {len(services)} services: {services}")
+    
+    Returns:
+        List of service names from docker-compose.e2e.yml
+    """
+    return get_compose_services_from_yaml()

--- a/tests/e2e/utils/http_client.py
+++ b/tests/e2e/utils/http_client.py
@@ -1,0 +1,69 @@
+"""
+HTTP client with retries for E2E tests.
+
+Provides a simple HTTP GET function that automatically retries on failures
+with exponential backoff.
+"""
+
+import time
+from typing import Any
+
+import requests
+
+
+def http_get_with_retries(
+    url: str,
+    max_attempts: int = 5,
+    timeout: int = 10,
+    **kwargs: Any,
+) -> requests.Response:
+    """
+    Make an HTTP GET request with automatic retries.
+    
+    Retries on connection errors, timeouts, and server errors (5xx).
+    Uses exponential backoff: waits 0.5s, 1s, 2s, 4s, 8s between attempts.
+    
+    Example:
+        response = http_get_with_retries("http://localhost:17002/healthcheck")
+        assert response.status_code == 200
+    
+    Args:
+        url: The URL to request
+        max_attempts: Maximum number of retry attempts (default: 5)
+        timeout: Request timeout in seconds (default: 10)
+        **kwargs: Additional arguments passed to requests.get()
+    
+    Returns:
+        Response object from requests library
+    
+    Raises:
+        requests.RequestException: If all retry attempts fail
+    """
+    last_error = None
+    
+    for attempt in range(1, max_attempts + 1):
+        try:
+            response = requests.get(url, timeout=timeout, **kwargs)
+            
+            # Success if status code is not a server error
+            if response.status_code < 500:
+                return response
+            
+            # For 5xx errors, raise to trigger retry
+            response.raise_for_status()
+            
+        except (requests.ConnectionError, requests.Timeout, requests.HTTPError) as e:
+            last_error = e
+            
+            # Don't wait after the last attempt
+            if attempt < max_attempts:
+                # Exponential backoff: 0.5s, 1s, 2s, 4s, 8s
+                wait_seconds = (2 ** (attempt - 1)) * 0.5
+                time.sleep(wait_seconds)
+    
+    # All attempts failed - raise with helpful error message
+    error_msg = (
+        f"Failed to GET {url} after {max_attempts} attempts.\n"
+        f"Last error: {type(last_error).__name__}: {last_error}"
+    )
+    raise requests.RequestException(error_msg) from last_error

--- a/tests/e2e/utils/log_parser.py
+++ b/tests/e2e/utils/log_parser.py
@@ -1,0 +1,185 @@
+"""
+Log parsing utilities for E2E tests.
+
+Provides functions to retrieve and analyze Docker container logs.
+"""
+
+from typing import Optional
+
+from tests.e2e.utils.docker_compose import get_compose_file_path, get_compose_services, run_compose_command
+
+
+def get_container_logs(service_name: str) -> str:
+    """
+    Get logs from a specific Docker Compose service.
+    
+    Example:
+        logs = get_container_logs("opal_server")
+        print(logs)
+    
+    Args:
+        service_name: Name of the service (e.g., "opal_server", "opal_client")
+    
+    Returns:
+        Log output as a string
+    """
+    result = run_compose_command(["logs", "--no-color", service_name], check=False)
+    return result.stdout
+
+
+def get_all_container_logs() -> dict[str, str]:
+    """
+    Get logs from all Docker Compose services.
+    
+    Uses get_compose_services() as the source of truth to ensure all services
+    are included, even if they have no log output yet.
+    
+    Example:
+        all_logs = get_all_container_logs()
+        print(all_logs["opal_server"])
+    
+    Returns:
+        Dictionary mapping service names to their log output (empty string if no logs)
+    """
+    # Get list of all services from Docker Compose (source of truth)
+    services = get_compose_services()
+    
+    # Initialize dictionary with all services (ensures all services are present)
+    logs_by_service: dict[str, list[str]] = {service: [] for service in services}
+    
+    # Get logs from Docker Compose
+    result = run_compose_command(["logs", "--no-color"], check=False)
+    
+    # Parse logs by service
+    # Docker Compose logs format: "service_name | log line"
+    current_service: Optional[str] = None
+    
+    for line in result.stdout.split("\n"):
+        if not line.strip():
+            continue
+        
+        # Check if line has service prefix (format: "service_name | log content")
+        if "|" in line:
+            parts = line.split("|", 1)
+            service_name = parts[0].strip()
+            log_content = parts[1].strip()
+            
+            # Only process services that are in our known services list
+            if service_name in logs_by_service:
+                logs_by_service[service_name].append(log_content)
+                current_service = service_name
+            else:
+                # Unknown service in logs (shouldn't happen, but handle gracefully)
+                current_service = None
+        elif current_service and current_service in logs_by_service:
+            # Continuation of previous log line (multi-line log entry)
+            logs_by_service[current_service].append(line.strip())
+    
+    # Convert lists to strings (empty string if no logs)
+    return {service: "\n".join(lines) for service, lines in logs_by_service.items()}
+
+
+def is_benign_startup_error(line: str) -> bool:
+    """
+    Check if an ERROR log line represents a benign transient startup error.
+    
+    Filters out known transient errors that occur during normal startup:
+    - Connection retries (connection refused, connection errors)
+    - Temporary connection failures that resolve
+    - Startup warnings that don't indicate fatal issues
+    - Datadog tracing errors (expected when Datadog agent is not running)
+    
+    Args:
+        line: Log line to check
+    
+    Returns:
+        True if the error is benign/transient, False if it's a real error
+    """
+    line_lower = line.lower()
+    
+    # Known benign startup error patterns
+    benign_patterns = [
+        "connection refused",
+        "connection error",
+        "connection failed",
+        "trying to connect",
+        "retry",
+        "retrying",
+        "waiting for",
+        "timeout",
+        "temporary failure",
+        "name resolution",
+        "dns",
+        # Datadog tracing errors: expected when Datadog agent is not running
+        # These are non-fatal and do not indicate OPAL startup/runtime failures
+        "ddtrace.internal.writer",
+        "failed to send traces",
+    ]
+    
+    # If line contains any benign pattern, it's likely a transient startup error
+    for pattern in benign_patterns:
+        if pattern in line_lower:
+            return True
+    
+    return False
+
+
+def check_logs_for_errors(
+    service_name: Optional[str] = None,
+    error_keywords: Optional[list[str]] = None,
+    ignore_benign_startup_errors: bool = True,
+) -> list[str]:
+    """
+    Check container logs for ERROR or CRITICAL messages.
+    
+    Filters out transient startup errors by default, focusing on fatal or
+    persistent errors that indicate real problems.
+    
+    Example:
+        errors = check_logs_for_errors("opal_server")
+        if errors:
+            print("Found errors:", errors)
+    
+    Args:
+        service_name: Specific service to check (None checks all services)
+        error_keywords: Keywords to search for (default: ["ERROR", "CRITICAL"])
+        ignore_benign_startup_errors: If True, filter out known transient startup errors
+    
+    Returns:
+        List of error messages found (empty list if no errors)
+    """
+    if error_keywords is None:
+        error_keywords = ["ERROR", "CRITICAL"]
+    
+    errors = []
+    
+    # Get logs from one service or all services
+    if service_name:
+        logs = get_container_logs(service_name)
+        log_sources = {service_name: logs}
+    else:
+        log_sources = get_all_container_logs()
+    
+    # Search each log line for error keywords
+    for service, log_content in log_sources.items():
+        for line in log_content.split("\n"):
+            if not line.strip():
+                continue
+            
+            # Check for error keywords (case-insensitive)
+            line_lower = line.lower()
+            has_error_keyword = False
+            for keyword in error_keywords:
+                if keyword.lower() in line_lower:
+                    has_error_keyword = True
+                    break
+            
+            if has_error_keyword:
+                # CRITICAL errors are always considered real errors
+                if "critical" in line_lower or "fatal" in line_lower:
+                    errors.append(f"[{service}] {line.strip()}")
+                # For ERROR logs, filter out benign startup errors if enabled
+                elif not ignore_benign_startup_errors or not is_benign_startup_error(line):
+                    errors.append(f"[{service}] {line.strip()}")
+    
+    return errors


### PR DESCRIPTION
Fixes #677

### What was added
- Introduced E2E test framework for opal-server using PyTest
- Added initial healthcheck E2E test that starts the real server and validates HTTP response

### How to test
1. Create virtualenv with Python 3.11
2. Install requirements
3. Run: pytest packages/opal-server/opal_server/tests
