### PR TITLE
fix: clean up partial clone artifacts when git clone fails (#634)

### DIFF
--- a/packages/opal-server/opal_server/git_fetcher.py
+++ b/packages/opal-server/opal_server/git_fetcher.py
@@ -230,6 +230,13 @@ class GitPolicyFetcher(PolicyFetcher):
             )
         except pygit2.GitError:
             logger.exception(f"Could not clone repo at {self._source.url}")
+            # Clean up any partial clone artifacts (broken symlinks, incomplete dirs)
+            # that may have been created before the error occurred
+            if self._repo_path.exists():
+                logger.warning(
+                    "Cleaning up partial clone at {path}", path=self._repo_path
+                )
+                shutil.rmtree(self._repo_path, ignore_errors=True)
         else:
             logger.info(f"Clone completed: {self._source.url}")
             await self._notify_on_changes(repo)


### PR DESCRIPTION
## Problem

When GitHub (or any git remote) is unavailable and `clone_repository` raises `pygit2.GitError`, the partially created repo directory is left behind with broken symlinks and incomplete files. On subsequent sync attempts, these artifacts accumulate in the filesystem, appearing as zombie-like processes in `/proc`.

## Root Cause

In `git_fetcher.py`, the `_clone()` method catches `pygit2.GitError` but does not clean up the partially-created repo directory at `self._repo_path`. The directory may contain broken symlinks and incomplete git objects from the interrupted clone.

## Fix

Added cleanup of the partial clone directory when `pygit2.GitError` is caught in `_clone()`. Uses `shutil.rmtree(path, ignore_errors=True)` to safely remove any residual files.

## Changes
- **1 file changed, +7 lines**
- `packages/opal-server/opal_server/git_fetcher.py`

This is a minimal, surgical fix — no other files or logic are modified.

Fixes #634