### PR TITLE
fix: elevate broadcast hostname resolution errors from DEBUG to ERROR

### DIFF
--- a/packages/opal-server/opal_server/pubsub.py
+++ b/packages/opal-server/opal_server/pubsub.py
@@ -1,8 +1,10 @@
+import socket
 import time
 from contextlib import contextmanager
 from contextvars import ContextVar
 from threading import Lock
 from typing import Dict, Generator, List, Optional, Set, Tuple, Union, cast
+from urllib.parse import urlparse
 from uuid import UUID, uuid4
 
 from fastapi import APIRouter, Depends, WebSocket
@@ -141,7 +143,10 @@ class PubSub:
 
         self.broadcaster = None
         if broadcaster_uri is not None:
-            logger.info(f"Initializing broadcaster for server<->server communication")
+            logger.info(
+                "Initializing broadcaster for server<->server communication"
+            )
+            self._validate_broadcast_uri(broadcaster_uri)
             self.broadcaster = EventBroadcaster(
                 broadcaster_uri,
                 notifier=self.notifier,
@@ -201,6 +206,35 @@ class PubSub:
                         current_client.reset(token)
             finally:
                 await websocket.close()
+
+    @staticmethod
+    def _validate_broadcast_uri(uri: str):
+        """Validate that the broadcast URI hostname can be resolved.
+
+        Logs an ERROR if DNS resolution fails so that operators can
+        quickly diagnose a misconfigured BROADCAST_URI.  Does not raise
+        -- the broadcaster is still created so existing behaviour is
+        preserved.
+        """
+        parsed = urlparse(uri)
+        hostname = parsed.hostname
+        if not hostname:
+            logger.error(
+                "Broadcast URI has no hostname: {uri}. "
+                "Check your OPAL_BROADCAST_URI configuration.",
+                uri=uri,
+            )
+            return
+        try:
+            socket.getaddrinfo(hostname, None)
+        except socket.gaierror as exc:
+            logger.error(
+                "Cannot resolve broadcast URI hostname '{hostname}': {error}. "
+                "Broadcasting will fail. "
+                "Check your OPAL_BROADCAST_URI configuration.",
+                hostname=hostname,
+                error=str(exc),
+            )
 
     @staticmethod
     async def _verify_permitted_topics(

--- a/packages/opal-server/opal_server/server.py
+++ b/packages/opal-server/opal_server/server.py
@@ -329,7 +329,7 @@ class OpalServer:
                         await self.broadcast_listening_context.__aenter__()
                         # if the broadcast channel is closed, we want to restart worker process because statistics can't be reliable anymore
                         self.broadcast_listening_context._event_broadcaster.get_reader_task().add_done_callback(
-                            lambda _: self._graceful_shutdown()
+                            self._on_broadcaster_disconnected
                         )
                     asyncio.create_task(self.opal_statistics.run())
                     self.pubsub.endpoint.notifier.register_unsubscribe_event(
@@ -397,6 +397,29 @@ class OpalServer:
             await asyncio.gather(*tasks)
         except Exception:
             logger.exception("exception while shutting down background tasks")
+
+    def _on_broadcaster_disconnected(self, task: asyncio.Task):
+        """Callback fired when the broadcast listener task finishes.
+
+        Logs the underlying exception (e.g. ``gaierror``) at ERROR level
+        so that operators can diagnose misconfigured broadcast URIs
+        instead of having the error silently swallowed at DEBUG level.
+        """
+        try:
+            exc = task.exception()
+        except (asyncio.CancelledError, asyncio.InvalidStateError):
+            exc = None
+
+        if exc is not None:
+            logger.error(
+                "Broadcast channel connection failed: {error}. "
+                "Check your OPAL_BROADCAST_URI configuration.",
+                error=exc,
+            )
+        else:
+            logger.warning("Broadcast channel disconnected.")
+
+        self._graceful_shutdown()
 
     def _graceful_shutdown(self):
         logger.info("Trigger worker graceful shutdown")


### PR DESCRIPTION
## Description
Fixes the silent swallowing of DNS resolution errors for the broadcast URI. The `gaierror` when resolving the broadcast hostname was previously logged at DEBUG level, making it extremely difficult for operators to diagnose misconfigured broadcast URIs.

Closes #716

## Changes
- Added `_validate_broadcast_uri()` in `PubSub.__init__()` that performs an early DNS resolution check at startup and logs at ERROR level if it fails, with a descriptive message pointing operators to check their `OPAL_BROADCAST_URI` configuration
- Replaced the anonymous lambda broadcaster disconnect callback in `OpalServer` with `_on_broadcaster_disconnected()` that inspects the task exception (e.g. `gaierror`) and logs it at ERROR level instead of silently swallowing it

## Notes
- Both changes are advisory only -- they log errors but do not prevent startup or alter existing control flow, preserving full backward compatibility
- Minimal change footprint: only `pubsub.py` and `server.py` are modified

/claim #716