### PR TITLE
Add fetch-depth: 0 to opal checkout in sync workflow

### DIFF
--- a/.github/workflows/sync_opal_plus.yml
+++ b/.github/workflows/sync_opal_plus.yml
@@ -30,6 +30,7 @@ jobs:
           repository: permitio/opal
           ref: master
           path: opal
+          fetch-depth: 0
 
       - name: Checkout permitio/opal-plus repository
         uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- Adds `fetch-depth: 0` to the opal checkout step
- Without full history, `git fetch opal master` from the opal-plus directory fails with "Could not read object" / "did not send all necessary objects" because the shallow `../opal` clone is missing objects needed for the cross-repo fetch

## Test plan
- [ ] Merge and verify the "Sync branch to OPAL Plus" workflow passes the "Mirror opal/master to public-master" step

🤖 Generated with [Claude Code](https://claude.com/claude-code)