### PR TITLE
Switch sync workflow to merge with .gitattributes protection

### DIFF
--- a/.github/workflows/sync_opal_plus.yml
+++ b/.github/workflows/sync_opal_plus.yml
@@ -1,3 +1,18 @@
+# Sync opal/master into opal-plus via merge-based PR.
+#
+# How it works:
+#   opal-plus has a .gitattributes file that marks certain files with "merge=ours".
+#   During the merge, git automatically keeps opal-plus's version of those files,
+#   so opal-plus customizations (Docker image names, CI release workflow, README
+#   branding) are never overwritten by upstream changes.
+#
+# Protected files (defined in opal-plus/.gitattributes):
+#   - .github/workflows/on_release.yml  (pushes to permitio/opal-plus-* Docker Hub repos)
+#   - .github/workflows/tests.yml       (opal-plus specific test config)
+#   - README.md                          (OPAL Plus branding)
+#
+# All other files merge normally, bringing upstream improvements into opal-plus.
+
 name: Sync branch to OPAL Plus
 
 on:

--- a/.github/workflows/sync_opal_plus.yml
+++ b/.github/workflows/sync_opal_plus.yml
@@ -16,6 +16,8 @@ jobs:
         run: |
           git config --global user.name 'github-actions[bot]'
           git config --global user.email 'github-actions[bot]@users.noreply.github.com'
+          # Configure the "ours" merge driver so .gitattributes merge=ours works
+          git config --global merge.ours.driver true
 
       - name: Get Token
         id: get_workflow_token
@@ -40,24 +42,30 @@ jobs:
           token: ${{ steps.get_workflow_token.outputs.token }}
           fetch-depth: 0
 
-      - name: Mirror opal/master to public-master
+      - name: Merge opal/master into public-master
         working-directory: opal-plus
         run: |
           git remote add opal ../opal
           git fetch opal master
 
-          # Point public-master to exactly match opal/master
-          if git rev-parse --verify public-master >/dev/null 2>&1; then
+          # Start from opal-plus/master so all customizations are preserved
+          if git rev-parse --verify origin/public-master >/dev/null 2>&1; then
             git checkout public-master
-            git reset --hard opal/master
+            # Ensure public-master is up to date with master
+            git merge origin/master --no-edit || true
           else
-            git checkout -b public-master opal/master
+            git checkout -b public-master master
           fi
+
+          # Merge upstream opal changes
+          # .gitattributes merge=ours protects on_release.yml, tests.yml, README.md
+          git merge opal/master --no-edit \
+            -m "Merge opal/master ($(git rev-parse --short opal/master)) into public-master"
 
       - name: Push public-master branch
         working-directory: opal-plus
         run: |
-          git push --force-with-lease origin public-master
+          git push origin public-master
 
       - name: Create or update Pull Request
         working-directory: opal-plus
@@ -73,7 +81,7 @@ jobs:
               --title "Sync opal/master (${OPAL_SHORT_SHA}) into opal-plus" \
               --body "Syncing opal/master (${OPAL_SHORT_SHA}) into opal-plus/master.
 
-          When merging, preserve opal-plus customizations (banner, Docker image names, CI release workflow)." \
+          Protected files (via .gitattributes): on_release.yml, tests.yml, README.md — kept as opal-plus versions." \
               --add-reviewer "$GITHUB_ACTOR" || true
           else
             gh pr create --repo permitio/opal-plus \
@@ -84,7 +92,7 @@ jobs:
               --title "Sync opal/master (${OPAL_SHORT_SHA}) into opal-plus" \
               --body "Syncing opal/master (${OPAL_SHORT_SHA}) into opal-plus/master.
 
-          When merging, preserve opal-plus customizations (banner, Docker image names, CI release workflow)." || true
+          Protected files (via .gitattributes): on_release.yml, tests.yml, README.md — kept as opal-plus versions." || true
             echo "New PR created."
           fi
         shell: bash


### PR DESCRIPTION
## Summary
- Replaces the mirror/force-push sync approach with a proper `git merge`
- Works together with `.gitattributes` in opal-plus (permitio/opal-plus#10) which marks repo-specific files with `merge=ours`
- Configures `merge.ours.driver` in the workflow so the `.gitattributes` strategy is respected
- No more force push — regular `git push` since merges only add commits
- `public-master` starts from opal-plus `master` so all customizations are preserved

## How it works
1. Checkout both repos (full history)
2. Start `public-master` from opal-plus/master (preserves all opal-plus customizations)
3. `git merge opal/master` — brings in upstream changes
4. `.gitattributes merge=ours` automatically keeps opal-plus's version of `on_release.yml`, `tests.yml`, `README.md`
5. Shared files (`client.py`, `server.py`, etc.) merge normally — opal-plus's small additions (banner imports) auto-resolve
6. Push and create/update PR

## Prerequisites
- **Merge permitio/opal-plus#10 first** — adds `.gitattributes` to opal-plus

## Test plan
- [ ] Merge opal-plus#10 (.gitattributes) first
- [ ] Merge this PR
- [ ] Verify the sync workflow creates a clean PR in opal-plus
- [ ] Verify protected files (on_release.yml, README.md) keep opal-plus versions

🤖 Generated with [Claude Code](https://claude.com/claude-code)