### PR TITLE
feat: add support for tag tracking

### DIFF
--- a/documentation/docs/getting-started/configuration.mdx
+++ b/documentation/docs/getting-started/configuration.mdx
@@ -13,6 +13,7 @@ OPAL supports multiple ways to configure your deployment:
 Let's get OPAL running! You'll need to set a few environment variables that tell OPAL where to find your policies and how to connect everything together.
 
 #### OPAL Server
+
 ```bash
 # Where your policies are stored (Git repo)
 export OPAL_POLICY_REPO_URL=https://github.com/your-org/policy-repo.git
@@ -33,6 +34,7 @@ export OPAL_BROADCAST_URI=postgres://postgres:postgres@localhost:5432/postgres
 ```
 
 #### OPAL Client
+
 ```bash
 # Connect to your OPAL server
 export OPAL_SERVER_URL=http://localhost:7002
@@ -646,9 +648,17 @@ Set if OPAL server should use a fixed clone path (and reuse if it already exists
 
 #### OPAL_POLICY_REPO_MAIN_BRANCH
 
-Default: `master`
+Default: `None`
 
-The main branch to track for policy files.
+The git branch to track for policy files. If neither `OPAL_POLICY_REPO_MAIN_BRANCH` nor `OPAL_POLICY_REPO_TAG` is set, defaults to `master`. Cannot be used together with `OPAL_POLICY_REPO_TAG`.
+
+For more information, see [tracking a Git repository](/tutorials/track_a_git_repo).
+
+#### OPAL_POLICY_REPO_TAG
+
+Default: `None`
+
+The git tag to track for policy files. When set, OPAL will track the specified tag instead of a branch. This is useful for pinning policies to a specific release. Cannot be used together with `OPAL_POLICY_REPO_MAIN_BRANCH`.
 
 For more information, see [tracking a Git repository](/tutorials/track_a_git_repo).
 
@@ -783,6 +793,7 @@ Enforce webhook events only from a specific branch.
 #### OPAL_POLICY_REPO_WEBHOOK_PARAMS
 
 Default:
+
 ```json
 {
   "secret_header_name": "x-hub-signature-256",
@@ -846,7 +857,7 @@ Default: `[]`
 **DEPRECATED** - Use [OPAL_BUNDLE_IGNORE](#opal_bundle_ignore) instead.
 :::
 
-Paths to omit from policy bundle. List of glob-style paths, or paths without wildcards but ending with "/**" indicating a parent path (ignoring all under it).
+Paths to omit from policy bundle. List of glob-style paths, or paths without wildcards but ending with "/\*\*" indicating a parent path (ignoring all under it).
 
 _Added in OPAL v0.5.0_
 
@@ -885,13 +896,16 @@ Default route for data callbacks (exists as a sane default in case the user did 
 #### OPAL_DATA_CONFIG_SOURCES
 
 Default:
+
 ```json
 {
   "config": {
-    "entries": [{
-      "url": "http://localhost:7002/policy-data",
-      "topics": ["data"]
-    }]
+    "entries": [
+      {
+        "url": "http://localhost:7002/policy-data",
+        "topics": ["data"]
+      }
+    ]
   }
 }
 ```
@@ -1098,7 +1112,7 @@ Retry options when connecting to the policy store (i.e., the agent that handles 
 
 Default: `[]`
 
-Which policy paths pushed to the client should be ignored. List of glob-style paths, or paths without wildcards but ending with "/**" indicating a parent path (ignoring all under it). Supports paths starting with '!' to force not ignoring them: a negated path always takes precedence.
+Which policy paths pushed to the client should be ignored. List of glob-style paths, or paths without wildcards but ending with "/\*\*" indicating a parent path (ignoring all under it). Supports paths starting with '!' to force not ignoring them: a negated path always takes precedence.
 
 #### OPAL_OPA_HEALTH_CHECK_POLICY_ENABLED
 
@@ -1223,6 +1237,7 @@ For more information, see [tracking a Git repository](/tutorials/track_a_git_rep
 #### OPAL_POLICY_UPDATER_CONN_RETRY
 
 Default:
+
 ```json
 {
   "wait_strategy": "random_exponential",
@@ -1275,6 +1290,7 @@ For more information, see [monitoring OPAL](/tutorials/monitoring_opal).
 #### OPAL_DEFAULT_UPDATE_CALLBACK_CONFIG
 
 Default:
+
 ```json
 {
   "method": "POST",
@@ -1300,6 +1316,7 @@ For more information, see [monitoring OPAL](/tutorials/monitoring_opal).
 #### OPAL_DATA_UPDATER_CONN_RETRY
 
 Default:
+
 ```json
 {
   "wait_strategy": "random_exponential",
@@ -1324,6 +1341,7 @@ _Added in OPAL v0.7.5_
 ## Advanced Configuration Options
 
 #### CLI Help
+
 ```bash
 # View all options
 opal-server --help
@@ -1335,12 +1353,15 @@ opal-client run --help
 ```
 
 #### Kubernetes Deployment
+
 For Kubernetes deployments, see [OPAL Helm Chart for Kubernetes](/tutorials/helm-chart-for-kubernetes).
 
 #### Proxy Configuration
+
 For proxy configurations, see [Setup OPAL Behind a Proxy](/tutorials/setup_opal_behind_proxy).
 
 #### Source Code
+
 - [Common config](https://github.com/permitio/opal/blob/master/packages/opal-common/opal_common/config.py) - Shared variables
 - [Server config](https://github.com/permitio/opal/blob/master/packages/opal-server/opal_server/config.py) - Server-specific variables
 - [Client config](https://github.com/permitio/opal/blob/master/packages/opal-client/opal_client/config.py) - Client-specific variables

--- a/documentation/docs/getting-started/running-opal/as-python-package/opal-server-setup.mdx
+++ b/documentation/docs/getting-started/running-opal/as-python-package/opal-server-setup.mdx
@@ -90,9 +90,11 @@ a [Github SSH key here](https://docs.github.com/en/github/authenticating-to-gith
 
 The value you pass for the `POLICY_REPO_SSH_KEY` can either be a file path, or the contents of the SSH-key - with newlines replaced with `\_`.
 
-#### `OPAL_POLICY_REPO_CLONE_PATH` & `OPAL_POLICY_REPO_MAIN_BRANCH`
+#### `OPAL_POLICY_REPO_CLONE_PATH`, `OPAL_POLICY_REPO_MAIN_BRANCH` & `OPAL_POLICY_REPO_TAG`
 
-These will allow you to control how the repo is cloned.
+These will allow you to control how the repo is cloned. By default OPAL will track the `master` branch of the repo, you may optionally track another branch or a tag in the repo.
+
+You must choose between tracking a branch or a tag, OPAL will fail if you try to supply both `OPAL_POLICY_REPO_MAIN_BRANCH` and `OPAL_POLICY_REPO_TAG`.
 
 ### Simple run with Data source configuration
 

--- a/documentation/docs/getting-started/running-opal/as-python-package/overview.mdx
+++ b/documentation/docs/getting-started/running-opal/as-python-package/overview.mdx
@@ -185,7 +185,9 @@ The value you pass for the `POLICY_REPO_SSH_KEY` can either be a file path, or t
 
 ##### `OPAL_POLICY_REPO_CLONE_PATH` & `OPAL_POLICY_REPO_MAIN_BRANCH`
 
-These will allow you to control how the repo is cloned.
+These will allow you to control how the repo is cloned. By default OPAL will track the `master` branch of the repo, you may optionally track another branch or a tag in the repo.
+
+You must choose between tracking a branch or a tag, OPAL will fail if you try to supply both `OPAL_POLICY_REPO_MAIN_BRANCH` and `OPAL_POLICY_REPO_TAG`.
 
 #### Simple run with Data source configuration
 

--- a/documentation/docs/getting-started/running-opal/run-opal-server/policy-repo-location.mdx
+++ b/documentation/docs/getting-started/running-opal/run-opal-server/policy-repo-location.mdx
@@ -87,7 +87,13 @@ For these config vars, in most cases you are good with the default values:
     <tr>
       <td valign="top">OPAL_POLICY_REPO_MAIN_BRANCH</td>
       <td>
-        Name of the git branch to track for policy files (default: `master`)
+        Name of the git branch to track for policy files (default: `master`, unless `OPAL_POLICY_REPO_TAG` is set)
+      </td>
+    </tr>
+    <tr>
+      <td valign="top">OPAL_POLICY_REPO_TAG</td>
+      <td>
+        Name of the git tag to track for policy files (default: `None`).
       </td>
     </tr>
   </tbody>

--- a/packages/opal-common/opal_common/git_utils/branch_tracker.py
+++ b/packages/opal-common/opal_common/git_utils/branch_tracker.py
@@ -1,7 +1,7 @@
 from functools import partial
 from typing import Optional, Tuple
 
-from git import GitCommandError, Head, Remote, Repo, Reference
+from git import GitCommandError, Head, Reference, Remote, Repo
 from git.objects.commit import Commit
 from opal_common.git_utils.env import provide_git_ssh_environment
 from opal_common.git_utils.exceptions import GitFailed
@@ -134,7 +134,7 @@ class BranchTracker:
                 branches_found=branches,
             )
             raise GitFailed(e)
-    
+
     @property
     def tracked_reference(self) -> Reference:
         return self.tracked_branch

--- a/packages/opal-common/opal_common/git_utils/branch_tracker.py
+++ b/packages/opal-common/opal_common/git_utils/branch_tracker.py
@@ -1,7 +1,7 @@
 from functools import partial
 from typing import Optional, Tuple
 
-from git import GitCommandError, Head, Remote, Repo
+from git import GitCommandError, Head, Remote, Repo, Reference
 from git.objects.commit import Commit
 from opal_common.git_utils.env import provide_git_ssh_environment
 from opal_common.git_utils.exceptions import GitFailed
@@ -134,6 +134,10 @@ class BranchTracker:
                 branches_found=branches,
             )
             raise GitFailed(e)
+    
+    @property
+    def tracked_reference(self) -> Reference:
+        return self.tracked_branch
 
     @property
     def tracked_remote(self) -> Remote:

--- a/packages/opal-common/opal_common/git_utils/repo_cloner.py
+++ b/packages/opal-common/opal_common/git_utils/repo_cloner.py
@@ -139,7 +139,8 @@ class RepoCloner:
         self,
         repo_url: str,
         clone_path: str,
-        branch_name: str = "master",
+        branch_name: Optional[str] = "master",
+        tag_name: Optional[str] = None,
         retry_config=None,
         ssh_key: Optional[str] = None,
         ssh_key_file_path: Optional[str] = None,
@@ -151,6 +152,10 @@ class RepoCloner:
             repo_url (str): the url to the remote repo we want to clone
             clone_path (str): the target local path in our file system we want the
                 repo to be cloned to
+            branch_name (str, optional): branch to clone. git clone --branch accepts
+                both branch and tag names.
+            tag_name (str, optional): tag to clone. Used as the --branch value when
+                branch_name is not set.
             retry_config (dict): Tenacity.retry config (@see https://tenacity.readthedocs.io/en/latest/api.html#retry-main-api)
             ssh_key (str, optional): private ssh key used to gain access to the cloned repo
             ssh_key_file_path (str, optional): local path to save the private ssh key contents
@@ -160,7 +165,8 @@ class RepoCloner:
 
         self.url = repo_url
         self.path = os.path.expanduser(clone_path)
-        self.branch_name = branch_name
+        # git clone --branch accepts both branch and tag names
+        self.clone_ref = branch_name or tag_name
         self._ssh_key = ssh_key
         self._ssh_key_file_path = (
             ssh_key_file_path or opal_common_config.GIT_SSH_KEY_FILE
@@ -178,10 +184,10 @@ class RepoCloner:
         - finds a cloned repo locally and does not clone from remote.
         """
         logger.info(
-            "Cloning repo from '{url}' to '{to_path}' (branch: '{branch}')",
+            "Cloning repo from '{url}' to '{to_path}' (ref: '{ref}')",
             url=self.url,
             to_path=self.path,
-            branch=self.branch_name,
+            ref=self.clone_ref,
         )
         loop = asyncio.get_running_loop()
         return await loop.run_in_executor(None, self._attempt_clone_from_url)
@@ -204,9 +210,10 @@ class RepoCloner:
 
     def _clone(self, env) -> Repo:
         try:
-            return Repo.clone_from(
-                url=self.url, to_path=self.path, branch=self.branch_name, env=env
-            )
+            kwargs = dict(url=self.url, to_path=self.path, env=env)
+            if self.clone_ref is not None:
+                kwargs["branch"] = self.clone_ref
+            return Repo.clone_from(**kwargs)
         except (GitError, GitCommandError) as e:
             logger.error("cannot clone policy repo: {error}", error=e)
             raise

--- a/packages/opal-common/opal_common/git_utils/tag_tracker.py
+++ b/packages/opal-common/opal_common/git_utils/tag_tracker.py
@@ -1,0 +1,107 @@
+from functools import partial
+from typing import Optional, Tuple
+
+from git import GitCommandError, Tag, Repo, Reference
+from git.objects.commit import Commit
+from opal_common.git_utils.env import provide_git_ssh_environment
+from opal_common.git_utils.exceptions import GitFailed
+from opal_common.logger import logger
+from tenacity import retry, stop_after_attempt, wait_fixed
+from opal_common.git_utils.branch_tracker import BranchTracker
+
+class TagTracker(BranchTracker):
+    """Tracks the state of a git tag (hash the tag is pointing at).
+
+    Can detect if the tag has been moved to point at a different commit.
+    """
+
+    def __init__(
+        self,
+        repo: Repo,
+        tag_name: str,
+        remote_name: str = "origin",
+        retry_config=None,
+        ssh_key: Optional[str] = None,
+    ):
+        """Initializes the TagTracker.
+
+        Args:
+            repo (Repo): a git repo in which we want to track the specific commit a tag is pointing to
+            tag_name (str): the tag we want to track
+            remote_name (str): the remote in which the tag is located
+            retry_config (dict): Tenacity.retry config
+            ssh_key (Optional[str]): SSH key for private repositories
+        """
+        self._tag_name = tag_name
+        super().__init__(repo, branch_name=None, remote_name=remote_name, retry_config=retry_config, ssh_key=ssh_key)
+
+    def checkout(self):
+        """Checkouts the repository at the current tag."""
+        checkout_func = partial(self._repo.git.checkout, self._tag_name)
+        attempt_checkout = retry(**self._retry_config)(checkout_func)
+        try:
+            return attempt_checkout()
+        except GitCommandError as e:
+            tags = [tag.name for tag in self._repo.tags]
+            logger.error(
+                "did not find tag: {tag_name}, instead found: {tags_found}, got error: {error}",
+                tag_name=self._tag_name,
+                tags_found=tags,
+                error=str(e),
+            )
+            raise GitFailed(e)
+
+    def _fetch(self):
+        """Fetch updates including tags with force option."""
+        def _inner_fetch(*args, **kwargs):
+            env = provide_git_ssh_environment(self.tracked_remote.url, self._ssh_key)
+            with self.tracked_remote.repo.git.custom_environment(**env):
+                self.tracked_remote.repo.git.fetch('--tags', '--force', *args, **kwargs)
+
+        attempt_fetch = retry(**self._retry_config)(_inner_fetch)
+        return attempt_fetch()
+
+    @property
+    def latest_commit(self) -> Commit:
+        """the commit of the tracked tag."""
+        return self.tracked_tag.commit
+
+    @property
+    def tracked_tag(self) -> Tag:
+        """returns the tracked tag reference (of type git.Reference) or throws if
+        such tag does not exist on the repo."""
+        try:
+            return getattr(self._repo.tags, self._tag_name)
+        except AttributeError as e:
+            tags = [
+                {"path": tag.path} for tag in self._repo.tags
+            ]
+            logger.exception(
+                "did not find main branch: {error}, instead found: {tags_found}",
+                error=e,
+                tags_found=tags,
+            )
+            raise GitFailed(e)
+
+    @property
+    def tracked_reference(self) -> Reference:
+        return self.tracked_tag
+
+    def pull(self) -> Tuple[bool, Commit, Commit]:
+        """Overrides the pull method to handle tag updates.
+
+        Returns:
+            pull_result (bool, Commit, Commit): a tuple consisting of:
+                has_changes (bool): whether the tag has been moved to a different commit
+                prev (Commit): the previous commit the tag was pointing to
+                latest (Commit): the new commit the tag is currently pointing to
+        """
+        self._fetch()
+        self.checkout()
+
+        if self.prev_commit.hexsha == self.latest_commit.hexsha:
+            return False, self.prev_commit, self.prev_commit
+        else:
+            prev = self._prev_commit
+            self._save_latest_commit_as_prev_commit()
+            return True, prev, self.latest_commit

--- a/packages/opal-common/opal_common/git_utils/tag_tracker.py
+++ b/packages/opal-common/opal_common/git_utils/tag_tracker.py
@@ -1,13 +1,14 @@
 from functools import partial
 from typing import Optional, Tuple
 
-from git import GitCommandError, Tag, Repo, Reference
+from git import GitCommandError, Reference, Repo, Tag
 from git.objects.commit import Commit
+from opal_common.git_utils.branch_tracker import BranchTracker
 from opal_common.git_utils.env import provide_git_ssh_environment
 from opal_common.git_utils.exceptions import GitFailed
 from opal_common.logger import logger
 from tenacity import retry, stop_after_attempt, wait_fixed
-from opal_common.git_utils.branch_tracker import BranchTracker
+
 
 class TagTracker(BranchTracker):
     """Tracks the state of a git tag (hash the tag is pointing at).
@@ -33,7 +34,13 @@ class TagTracker(BranchTracker):
             ssh_key (Optional[str]): SSH key for private repositories
         """
         self._tag_name = tag_name
-        super().__init__(repo, branch_name=None, remote_name=remote_name, retry_config=retry_config, ssh_key=ssh_key)
+        super().__init__(
+            repo,
+            branch_name=None,
+            remote_name=remote_name,
+            retry_config=retry_config,
+            ssh_key=ssh_key,
+        )
 
     def checkout(self):
         """Checkouts the repository at the current tag."""
@@ -53,10 +60,11 @@ class TagTracker(BranchTracker):
 
     def _fetch(self):
         """Fetch updates including tags with force option."""
+
         def _inner_fetch(*args, **kwargs):
             env = provide_git_ssh_environment(self.tracked_remote.url, self._ssh_key)
             with self.tracked_remote.repo.git.custom_environment(**env):
-                self.tracked_remote.repo.git.fetch('--tags', '--force', *args, **kwargs)
+                self.tracked_remote.repo.git.fetch("--tags", "--force", *args, **kwargs)
 
         attempt_fetch = retry(**self._retry_config)(_inner_fetch)
         return attempt_fetch()
@@ -68,14 +76,12 @@ class TagTracker(BranchTracker):
 
     @property
     def tracked_tag(self) -> Tag:
-        """returns the tracked tag reference (of type git.Reference) or throws if
-        such tag does not exist on the repo."""
+        """returns the tracked tag reference (of type git.Reference) or throws
+        if such tag does not exist on the repo."""
         try:
             return getattr(self._repo.tags, self._tag_name)
         except AttributeError as e:
-            tags = [
-                {"path": tag.path} for tag in self._repo.tags
-            ]
+            tags = [{"path": tag.path} for tag in self._repo.tags]
             logger.exception(
                 "did not find main branch: {error}, instead found: {tags_found}",
                 error=e,

--- a/packages/opal-common/opal_common/git_utils/tag_tracker.py
+++ b/packages/opal-common/opal_common/git_utils/tag_tracker.py
@@ -71,12 +71,12 @@ class TagTracker(BranchTracker):
 
     @property
     def latest_commit(self) -> Commit:
-        """the commit of the tracked tag."""
+        """The commit of the tracked tag."""
         return self.tracked_tag.commit
 
     @property
     def tracked_tag(self) -> Tag:
-        """returns the tracked tag reference (of type git.Reference) or throws
+        """Returns the tracked tag reference (of type git.Reference) or throws
         if such tag does not exist on the repo."""
         try:
             return getattr(self._repo.tags, self._tag_name)

--- a/packages/opal-common/opal_common/git_utils/tests/conftest.py
+++ b/packages/opal-common/opal_common/git_utils/tests/conftest.py
@@ -73,6 +73,15 @@ class Helpers:
         repo.index.move([filename, new_filename])
         repo.index.commit(commit_msg, author=author)
 
+    @staticmethod
+    def create_new_tag(repo: Repo, tag_name: str):
+        repo.create_tag(tag_name)
+
+    @staticmethod
+    def update_tag_to_head(repo: Repo, tag_name: str):
+        repo.delete_tag(tag_name)
+        repo.create_tag(tag_name)
+
 
 @pytest.fixture
 def helpers() -> Helpers:
@@ -140,6 +149,9 @@ def local_repo(tmp_path, helpers: Helpers) -> Repo:
 
     # create a "delete" commit
     helpers.create_delete_file_commit(repo, root / "deleted.rego")
+
+    # create a test tag
+    helpers.create_new_tag(repo, "test_tag")
     return repo
 
 

--- a/packages/opal-common/opal_common/git_utils/tests/repo_watcher_test.py
+++ b/packages/opal-common/opal_common/git_utils/tests/repo_watcher_test.py
@@ -46,6 +46,7 @@ async def test_repo_watcher_git_failed_callback(tmp_path):
     # configure the watcher to watch an invalid repo
     watcher = GitPolicySource(
         remote_source_url=INVALID_REPO_REMOTE_URL,
+        branch_name="master",
         local_clone_path=target_path,
         request_timeout=3,
     )
@@ -86,7 +87,9 @@ async def test_repo_watcher_detect_new_commits_with_manual_trigger(
     # configure the watcher with a valid local repo (our test repo)
     # the returned repo will track the local remote repo
     watcher = GitPolicySource(
-        remote_source_url=remote_repo.working_tree_dir, local_clone_path=target_path
+        remote_source_url=remote_repo.working_tree_dir,
+        local_clone_path=target_path,
+        branch_name=remote_repo.active_branch.name,
     )
     # configure the error callback
     watcher.add_on_new_policy_callback(partial(new_commits_callback, detected_commits))
@@ -157,6 +160,7 @@ async def test_repo_watcher_detect_new_commits_with_polling(
     watcher = GitPolicySource(
         remote_source_url=remote_repo.working_tree_dir,
         local_clone_path=target_path,
+        branch_name=remote_repo.active_branch.name,
         polling_interval=3,  # every 3 seconds do a pull to try and detect changes
     )
     # configure the error callback

--- a/packages/opal-common/opal_common/git_utils/tests/tag_tracker_test.py
+++ b/packages/opal-common/opal_common/git_utils/tests/tag_tracker_test.py
@@ -1,0 +1,78 @@
+import os
+import sys
+
+import pytest
+
+# Add root opal dir to use local src as package for tests (i.e, no need for python -m pytest)
+root_dir = os.path.abspath(
+    os.path.join(
+        os.path.dirname(__file__),
+        os.path.pardir,
+        os.path.pardir,
+        os.path.pardir,
+    )
+)
+sys.path.append(root_dir)
+
+from pathlib import Path
+
+from git import Repo
+from git.objects.commit import Commit
+from opal_common.git_utils.tag_tracker import TagTracker
+from opal_common.git_utils.exceptions import GitFailed
+
+
+def test_pull_with_no_changes(local_repo_clone: Repo):
+    """Test pulling when there are no changes on the remote repo."""
+    repo: Repo = local_repo_clone  # local repo, cloned from another local repo
+    tracker = TagTracker(repo=repo, tag_name="test_tag")
+    latest_commit: Commit = repo.head.commit
+    assert latest_commit == tracker.latest_commit == tracker.prev_commit
+    has_changes, prev, latest = tracker.pull()  # pulls from origin
+    assert has_changes == False
+    assert latest_commit == prev == latest
+
+
+def test_pull_with_new_commits(
+    local_repo: Repo,
+    local_repo_clone: Repo,
+    helpers,
+):
+    """Test pulling when there are changes (new commits) on the remote repo."""
+    remote_repo: Repo = (
+        local_repo  # local repo, the 'origin' remote of 'local_repo_clone'
+    )
+    repo: Repo = local_repo_clone  # local repo, cloned from 'local_repo'
+
+    tracker = TagTracker(repo=repo, tag_name="test_tag")
+    most_recent_commit_before_pull: Commit = repo.head.commit
+
+    assert (
+        most_recent_commit_before_pull == tracker.latest_commit == tracker.prev_commit
+    )
+
+    # create new file commit on the remote repo
+    helpers.create_new_file_commit(
+        remote_repo, Path(remote_repo.working_tree_dir) / "2.txt"
+    )
+
+    helpers.update_tag_to_head(remote_repo, "test_tag")
+
+    # now the remote repo tag is pointing at a different commit
+    assert remote_repo.tags.__getattr__("test_tag").commit != repo.head.commit
+    # and our tag tracker does not know it yet
+    assert remote_repo.tags.__getattr__("test_tag").commit != tracker.latest_commit
+
+    has_changes, prev, latest = tracker.pull()  # pulls from origin
+    assert has_changes == True
+    assert prev != latest
+    assert most_recent_commit_before_pull == prev
+    assert (
+        remote_repo.tags.__getattr__("test_tag").commit == repo.tags.__getattr__("test_tag").commit == latest == tracker.latest_commit
+    )
+
+
+def test_tracked_branch_does_not_exist(local_repo: Repo):
+    """Test that tag tracker throws when tag does not exist."""
+    with pytest.raises(GitFailed):
+        tracker = TagTracker(local_repo, tag_name="no_such_tag")

--- a/packages/opal-common/opal_common/git_utils/tests/tag_tracker_test.py
+++ b/packages/opal-common/opal_common/git_utils/tests/tag_tracker_test.py
@@ -18,8 +18,8 @@ from pathlib import Path
 
 from git import Repo
 from git.objects.commit import Commit
-from opal_common.git_utils.tag_tracker import TagTracker
 from opal_common.git_utils.exceptions import GitFailed
+from opal_common.git_utils.tag_tracker import TagTracker
 
 
 def test_pull_with_no_changes(local_repo_clone: Repo):

--- a/packages/opal-common/opal_common/git_utils/tests/tag_tracker_test.py
+++ b/packages/opal-common/opal_common/git_utils/tests/tag_tracker_test.py
@@ -68,7 +68,10 @@ def test_pull_with_new_commits(
     assert prev != latest
     assert most_recent_commit_before_pull == prev
     assert (
-        remote_repo.tags.__getattr__("test_tag").commit == repo.tags.__getattr__("test_tag").commit == latest == tracker.latest_commit
+        remote_repo.tags.__getattr__("test_tag").commit
+        == repo.tags.__getattr__("test_tag").commit
+        == latest
+        == tracker.latest_commit
     )
 
 

--- a/packages/opal-common/opal_common/schemas/policy_source.py
+++ b/packages/opal-common/opal_common/schemas/policy_source.py
@@ -7,7 +7,7 @@ except ImportError:
     from typing_extensions import Literal
 
 from opal_common.schemas.policy import BaseSchema
-from pydantic import Field
+from pydantic import Field, root_validator
 
 
 class NoAuthData(BaseSchema):
@@ -52,4 +52,17 @@ class BasePolicyScopeSource(BaseSchema):
 
 
 class GitPolicyScopeSource(BasePolicyScopeSource):
-    branch: str = Field("main", description="Git branch to track")
+    branch: Optional[str] = Field(None, description="Git branch to track")
+    tag: Optional[str] = Field(None, description="Git tag to track")
+
+    @root_validator
+    def validate_branch_or_tag(cls, values):
+        branch = values.get("branch") or None
+        tag = values.get("tag") or None
+        values["branch"] = branch
+        values["tag"] = tag
+        if branch is None and tag is None:
+            raise ValueError("Must provide either 'branch' or 'tag'")
+        if branch is not None and tag is not None:
+            raise ValueError("Must provide either 'branch' or 'tag', not both")
+        return values

--- a/packages/opal-common/opal_common/sources/git_policy_source.py
+++ b/packages/opal-common/opal_common/sources/git_policy_source.py
@@ -44,16 +44,17 @@ class GitPolicySource(BasePolicySource):
         )
         self._ssh_key = ssh_key
 
+        branch_name = branch_name or None
+        tag_name = tag_name or None
+
         self._cloner = RepoCloner(
             remote_source_url,
             local_clone_path,
             branch_name=branch_name,
+            tag_name=tag_name,
             ssh_key=self._ssh_key,
             clone_timeout=request_timeout,
         )
-
-        branch_name = branch_name or None
-        tag_name = tag_name or None
 
         if branch_name is None and tag_name is None:
             logger.exception("Must provide either branch_name or tag_name")

--- a/packages/opal-common/opal_common/sources/git_policy_source.py
+++ b/packages/opal-common/opal_common/sources/git_policy_source.py
@@ -4,6 +4,7 @@ from git import Repo
 from opal_common.git_utils.branch_tracker import BranchTracker
 from opal_common.git_utils.exceptions import GitFailed
 from opal_common.git_utils.repo_cloner import RepoCloner
+from opal_common.git_utils.tag_tracker import TagTracker
 from opal_common.logger import logger
 from opal_common.sources.base_policy_source import BasePolicySource
 
@@ -30,7 +31,8 @@ class GitPolicySource(BasePolicySource):
         self,
         remote_source_url: str,
         local_clone_path: str,
-        branch_name: str = "master",
+        branch_name: Optional[str] = None,
+        tag_name: Optional[str] = None,
         ssh_key: Optional[str] = None,
         polling_interval: int = 0,
         request_timeout: int = 0,
@@ -49,7 +51,16 @@ class GitPolicySource(BasePolicySource):
             ssh_key=self._ssh_key,
             clone_timeout=request_timeout,
         )
+
+        if branch_name is None and tag_name is None:
+            logger.exception("Must provide either branch_name or tag_name")
+            raise ValueError("Must provide either branch_name or tag_name")
+        if branch_name is not None and tag_name is not None:
+            logger.exception("Must provide either branch_name or tag_name, not both")
+            raise ValueError("Must provide either branch_name or tag_name, not both")
+
         self._branch_name = branch_name
+        self._tag_name = tag_name
         self._tracker = None
 
     async def get_initial_policy_state_from_remote(self):
@@ -82,9 +93,14 @@ class GitPolicySource(BasePolicySource):
             await self._on_git_failed(e)
             return
 
-        self._tracker = BranchTracker(
-            repo=repo, branch_name=self._branch_name, ssh_key=self._ssh_key
-        )
+        if self._tag_name is not None:
+            self._tracker = TagTracker(
+                repo=repo, tag_name=self._tag_name, ssh_key=self._ssh_key
+            )
+        else:
+            self._tracker = BranchTracker(
+                repo=repo, branch_name=self._branch_name, ssh_key=self._ssh_key
+            )
 
     async def check_for_changes(self):
         """Calling this method will trigger a git pull from the tracked remote.
@@ -98,7 +114,7 @@ class GitPolicySource(BasePolicySource):
         )
         has_changes, prev, latest = self._tracker.pull()
         if not has_changes:
-            logger.info("No new commits: HEAD is at '{head}'", head=latest.hexsha)
+            logger.info("No new commits: {ref} is at '{head}'", ref=self._tracker.tracked_reference.name, head=latest.hexsha)
         else:
             logger.info(
                 "Found new commits: old HEAD was '{prev_head}', new HEAD is '{new_head}'",

--- a/packages/opal-common/opal_common/sources/git_policy_source.py
+++ b/packages/opal-common/opal_common/sources/git_policy_source.py
@@ -52,6 +52,9 @@ class GitPolicySource(BasePolicySource):
             clone_timeout=request_timeout,
         )
 
+        branch_name = branch_name or None
+        tag_name = tag_name or None
+
         if branch_name is None and tag_name is None:
             logger.exception("Must provide either branch_name or tag_name")
             raise ValueError("Must provide either branch_name or tag_name")

--- a/packages/opal-common/opal_common/sources/git_policy_source.py
+++ b/packages/opal-common/opal_common/sources/git_policy_source.py
@@ -114,7 +114,11 @@ class GitPolicySource(BasePolicySource):
         )
         has_changes, prev, latest = self._tracker.pull()
         if not has_changes:
-            logger.info("No new commits: {ref} is at '{head}'", ref=self._tracker.tracked_reference.name, head=latest.hexsha)
+            logger.info(
+                "No new commits: {ref} is at '{head}'",
+                ref=self._tracker.tracked_reference.name,
+                head=latest.hexsha,
+            )
         else:
             logger.info(
                 "Found new commits: old HEAD was '{prev_head}', new HEAD is '{new_head}'",

--- a/packages/opal-server/opal_server/config.py
+++ b/packages/opal-server/opal_server/config.py
@@ -131,7 +131,7 @@ class OpalServerConfig(Confi):
     )
     POLICY_REPO_MAIN_BRANCH = confi.str(
         "POLICY_REPO_MAIN_BRANCH",
-        "master",
+        None,
         description="The main branch of the policy repository",
     )
     POLICY_REPO_TAG = confi.str(

--- a/packages/opal-server/opal_server/config.py
+++ b/packages/opal-server/opal_server/config.py
@@ -134,6 +134,9 @@ class OpalServerConfig(Confi):
         "master",
         description="The main branch of the policy repository",
     )
+    POLICY_REPO_TAG = confi.str(
+        "POLICY_REPO_TAG", None, description="The tag of the policy repository"
+    )
     POLICY_REPO_SSH_KEY = confi.str(
         "POLICY_REPO_SSH_KEY", None, description="The SSH key for the policy repository"
     )

--- a/packages/opal-server/opal_server/git_fetcher.py
+++ b/packages/opal-server/opal_server/git_fetcher.py
@@ -64,9 +64,9 @@ class RepoInterface:
             else:
                 raise RuntimeError("Base branch was not found on remote")
             logger.debug(
-                f"Created local branch '{branch_name}', pointing to: {commit.hex}"
+                f"Created local branch '{branch_name}', pointing to: {str(commit.id)}"
             )
-            return repo.create_reference(f"refs/heads/{branch_name}", commit.hex)
+            return repo.create_reference(f"refs/heads/{branch_name}", str(commit.id))
         else:
             logger.debug(
                 f"No need to create local branch '{branch_name}': already exists!"
@@ -92,7 +92,7 @@ class RepoInterface:
     def get_commit_hash(repo: Repository, branch: str, remote: str) -> Optional[str]:
         try:
             (commit, _) = repo.resolve_refish(f"{remote}/{branch}")
-            return commit.hex
+            return str(commit.id)
         except (pygit2.GitError, KeyError):
             return None
 
@@ -104,7 +104,7 @@ class RepoInterface:
             # If the tag is annotated, dereference to the commit
             if commit.type == pygit2.GIT_OBJECT_TAG:
                 commit = commit.peel(pygit2.Commit)
-            return commit.hex
+            return str(commit.id)
         except (KeyError, pygit2.GitError):
             return None
 
@@ -373,7 +373,7 @@ class GitPolicyFetcher(PolicyFetcher):
                     repo, self.local_branch_name, self._remote, self._source.branch
                 )
         else:
-            old_revision = local_branch.target.hex
+            old_revision = str(local_branch.target)
 
         await self.callbacks.on_update(old_revision, new_revision)
 

--- a/packages/opal-server/opal_server/git_fetcher.py
+++ b/packages/opal-server/opal_server/git_fetcher.py
@@ -305,7 +305,9 @@ class GitPolicyFetcher(PolicyFetcher):
                 )
                 return True  # missing tag
         else:
-            if not RepoInterface.has_remote_branch(repo, self._source.branch, self._remote):
+            if not RepoInterface.has_remote_branch(
+                repo, self._source.branch, self._remote
+            ):
                 logger.info(
                     "Target branch was not found in local clone, re-fetching the remote"
                 )
@@ -341,9 +343,7 @@ class GitPolicyFetcher(PolicyFetcher):
     async def _notify_on_changes(self, repo: Repository):
         # Get the latest commit hash of the target ref (branch or tag)
         if self._is_tag:
-            new_revision = RepoInterface.get_tag_commit_hash(
-                repo, self._source.tag
-            )
+            new_revision = RepoInterface.get_tag_commit_hash(repo, self._source.tag)
             if new_revision is None:
                 logger.error(f"Did not find target tag: {self._source.tag}")
                 return
@@ -352,7 +352,9 @@ class GitPolicyFetcher(PolicyFetcher):
                 repo, self._source.branch, self._remote
             )
             if new_revision is None:
-                logger.error(f"Did not find target branch on remote: {self._source.branch}")
+                logger.error(
+                    f"Did not find target branch on remote: {self._source.branch}"
+                )
                 return
 
         # Get the previous commit hash of the target ref
@@ -362,7 +364,9 @@ class GitPolicyFetcher(PolicyFetcher):
             old_revision = None
             if self._is_tag:
                 # For tags, create a local branch pointing at the tag's commit
-                ref = repo.create_reference(f"refs/heads/{self.local_branch_name}", new_revision)
+                ref = repo.create_reference(
+                    f"refs/heads/{self.local_branch_name}", new_revision
+                )
                 local_branch = ref
             else:
                 local_branch = RepoInterface.create_local_branch_ref(
@@ -379,9 +383,7 @@ class GitPolicyFetcher(PolicyFetcher):
     def _get_current_head(self) -> str:
         repo = self._get_repo()
         if self._is_tag:
-            head_commit_hash = RepoInterface.get_tag_commit_hash(
-                repo, self._source.tag
-            )
+            head_commit_hash = RepoInterface.get_tag_commit_hash(repo, self._source.tag)
         else:
             head_commit_hash = RepoInterface.get_commit_hash(
                 repo, self._source.branch, self._remote

--- a/packages/opal-server/opal_server/git_fetcher.py
+++ b/packages/opal-server/opal_server/git_fetcher.py
@@ -97,6 +97,26 @@ class RepoInterface:
             return None
 
     @staticmethod
+    def get_tag_commit_hash(repo: Repository, tag_name: str) -> Optional[str]:
+        try:
+            ref = repo.lookup_reference(f"refs/tags/{tag_name}")
+            commit = repo.get(ref.target)
+            # If the tag is annotated, dereference to the commit
+            if commit.type == pygit2.GIT_OBJECT_TAG:
+                commit = commit.peel(pygit2.Commit)
+            return commit.hex
+        except (KeyError, pygit2.GitError):
+            return None
+
+    @staticmethod
+    def has_tag(repo: Repository, tag_name: str) -> bool:
+        try:
+            repo.lookup_reference(f"refs/tags/{tag_name}")
+            return True
+        except KeyError:
+            return False
+
+    @staticmethod
     def verify_found_repo_matches_remote(
         repo: Repository,
         expected_remote_url: str,
@@ -135,7 +155,7 @@ class GitPolicyFetcher(PolicyFetcher):
         self._remote = remote_name
         self._scope_id = scope_id
         logger.debug(
-            f"Initializing git fetcher: scope_id={scope_id}, url={source.url}, branch={self._source.branch}, path={GitPolicyFetcher.source_id(source)}"
+            f"Initializing git fetcher: scope_id={scope_id}, url={source.url}, ref={self._ref_name}, path={GitPolicyFetcher.source_id(source)}"
         )
 
     async def _get_repo_lock(self):
@@ -190,9 +210,13 @@ class GitPolicyFetcher(PolicyFetcher):
                             GitPolicyFetcher.repos_last_fetched[
                                 self.source_id
                             ] = datetime.datetime.now()
+                            fetch_kwargs = dict(callbacks=self._auth_callbacks)
+                            if self._is_tag:
+                                # Force-update tags so moved tags are detected
+                                fetch_kwargs["refspecs"] = ["+refs/tags/*:refs/tags/*"]
                             await run_sync(
                                 repo.remotes[self._remote].fetch,
-                                callbacks=self._auth_callbacks,
+                                **fetch_kwargs,
                             )
                             logger.debug(f"Fetch completed: {self._source.url}")
 
@@ -249,6 +273,16 @@ class GitPolicyFetcher(PolicyFetcher):
             logger.warning("Invalid repo at: {path}", path=self._repo_path)
             return None
 
+    @property
+    def _is_tag(self) -> bool:
+        return self._source.tag is not None
+
+    @property
+    def _ref_name(self) -> str:
+        if self._is_tag:
+            return self._source.tag
+        return self._source.branch
+
     async def _should_fetch(
         self,
         repo: Repository,
@@ -264,11 +298,18 @@ class GitPolicyFetcher(PolicyFetcher):
             else:
                 return True  # must fetch
 
-        if not RepoInterface.has_remote_branch(repo, self._source.branch, self._remote):
-            logger.info(
-                "Target branch was not found in local clone, re-fetching the remote"
-            )
-            return True  # missing branch
+        if self._is_tag:
+            if not RepoInterface.has_tag(repo, self._source.tag):
+                logger.info(
+                    "Target tag was not found in local clone, re-fetching the remote"
+                )
+                return True  # missing tag
+        else:
+            if not RepoInterface.has_remote_branch(repo, self._source.branch, self._remote):
+                logger.info(
+                    "Target branch was not found in local clone, re-fetching the remote"
+                )
+                return True  # missing branch
 
         if hinted_hash is not None:
             try:
@@ -279,6 +320,10 @@ class GitPolicyFetcher(PolicyFetcher):
                     "Hinted commit hash was not found in local clone, re-fetching the remote"
                 )
                 return True  # hinted commit was not found
+
+        # Tags can be moved silently (no webhook), so always re-fetch to detect changes
+        if self._is_tag:
+            return True
 
         # by default, we try to avoid re-fetching the repo for performance
         return False
@@ -294,22 +339,35 @@ class GitPolicyFetcher(PolicyFetcher):
         return f"scopes/{self._scope_id.encode().hex()}"
 
     async def _notify_on_changes(self, repo: Repository):
-        # Get the latest commit hash of the target branch
-        new_revision = RepoInterface.get_commit_hash(
-            repo, self._source.branch, self._remote
-        )
-        if new_revision is None:
-            logger.error(f"Did not find target branch on remote: {self._source.branch}")
-            return
+        # Get the latest commit hash of the target ref (branch or tag)
+        if self._is_tag:
+            new_revision = RepoInterface.get_tag_commit_hash(
+                repo, self._source.tag
+            )
+            if new_revision is None:
+                logger.error(f"Did not find target tag: {self._source.tag}")
+                return
+        else:
+            new_revision = RepoInterface.get_commit_hash(
+                repo, self._source.branch, self._remote
+            )
+            if new_revision is None:
+                logger.error(f"Did not find target branch on remote: {self._source.branch}")
+                return
 
-        # Get the previous commit hash of the target branch
+        # Get the previous commit hash of the target ref
         local_branch = RepoInterface.get_local_branch(repo, self.local_branch_name)
         if local_branch is None:
-            # First sync of a new branch (the first synced branch in this repo was set by the clone (see `checkout_branch`))
+            # First sync of a new ref (the first synced branch in this repo was set by the clone (see `checkout_branch`))
             old_revision = None
-            local_branch = RepoInterface.create_local_branch_ref(
-                repo, self.local_branch_name, self._remote, self._source.branch
-            )
+            if self._is_tag:
+                # For tags, create a local branch pointing at the tag's commit
+                ref = repo.create_reference(f"refs/heads/{self.local_branch_name}", new_revision)
+                local_branch = ref
+            else:
+                local_branch = RepoInterface.create_local_branch_ref(
+                    repo, self.local_branch_name, self._remote, self._source.branch
+                )
         else:
             old_revision = local_branch.target.hex
 
@@ -318,14 +376,19 @@ class GitPolicyFetcher(PolicyFetcher):
         # Bring forward local branch (a bit like "pull"), so we won't detect changes again
         local_branch.set_target(new_revision)
 
-    def _get_current_branch_head(self) -> str:
+    def _get_current_head(self) -> str:
         repo = self._get_repo()
-        head_commit_hash = RepoInterface.get_commit_hash(
-            repo, self._source.branch, self._remote
-        )
+        if self._is_tag:
+            head_commit_hash = RepoInterface.get_tag_commit_hash(
+                repo, self._source.tag
+            )
+        else:
+            head_commit_hash = RepoInterface.get_commit_hash(
+                repo, self._source.branch, self._remote
+            )
         if not head_commit_hash:
-            logger.error("Could not find current branch head")
-            raise ValueError("Could not find current branch head")
+            logger.error("Could not find current head")
+            raise ValueError("Could not find current head")
         return head_commit_hash
 
     @tracer.wrap("git_policy_fetcher.make_bundle")
@@ -338,7 +401,7 @@ class GitPolicyFetcher(PolicyFetcher):
             root_manifest_path=self._source.manifest,
             bundle_ignore=self._source.bundle_ignore,
         )
-        current_head_commit = repo.commit(self._get_current_branch_head())
+        current_head_commit = repo.commit(self._get_current_head())
 
         if not base_hash:
             return bundle_maker.make_bundle(current_head_commit)
@@ -352,8 +415,9 @@ class GitPolicyFetcher(PolicyFetcher):
     @staticmethod
     def source_id(source: GitPolicyScopeSource) -> str:
         base = hashlib.sha256(source.url.encode("utf-8")).hexdigest()
+        ref = source.tag if source.tag is not None else source.branch
         index = (
-            hashlib.sha256(source.branch.encode("utf-8")).digest()[0]
+            hashlib.sha256(ref.encode("utf-8")).digest()[0]
             % opal_server_config.SCOPES_REPO_CLONES_SHARDS
         )
         return f"{base}-{index}"

--- a/packages/opal-server/opal_server/policy/bundles/api.py
+++ b/packages/opal-server/opal_server/policy/bundles/api.py
@@ -69,15 +69,19 @@ async def get_input_paths_or_throw(
     paths = paths or []
     paths = [normalize_path(p) for p in paths]
 
-    # if the repo is currently being cloned - the repo.heads is empty
-    if len(repo.heads) == 0:
+    # if the repo is currently being cloned or HEAD is invalid, the repo is
+    # not ready.  A tag checkout produces a detached HEAD with no local
+    # branches, so we cannot rely on repo.heads being non-empty.
+    try:
+        head_commit = repo.head.commit
+    except (TypeError, ValueError):
         raise HTTPException(
             status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
             detail="policy repo is not ready",
         )
 
     # verify all input paths exists under the commit hash
-    with CommitViewer(repo.head.commit) as viewer:
+    with CommitViewer(head_commit) as viewer:
         for path in paths:
             if not viewer.exists(path):
                 raise HTTPException(

--- a/packages/opal-server/opal_server/policy/watcher/factory.py
+++ b/packages/opal-server/opal_server/policy/watcher/factory.py
@@ -75,6 +75,8 @@ def setup_watcher_task(
         branch_name, opal_server_config.POLICY_REPO_MAIN_BRANCH
     )
     tag_name = load_conf_if_none(tag_name, opal_server_config.POLICY_REPO_TAG)
+    branch_name = branch_name or None
+    tag_name = tag_name or None
     if branch_name is None and tag_name is None:
         logger.info("No branch or tag specified, falling back to using branch 'master'")
         branch_name = "master"

--- a/packages/opal-server/opal_server/policy/watcher/factory.py
+++ b/packages/opal-server/opal_server/policy/watcher/factory.py
@@ -74,9 +74,7 @@ def setup_watcher_task(
     branch_name = load_conf_if_none(
         branch_name, opal_server_config.POLICY_REPO_MAIN_BRANCH
     )
-    tag_name = load_conf_if_none(
-        tag_name, opal_server_config.POLICY_REPO_TAG
-    )
+    tag_name = load_conf_if_none(tag_name, opal_server_config.POLICY_REPO_TAG)
     if branch_name is None and tag_name is None:
         logger.info("No branch or tag specified, falling back to using branch 'master'")
         branch_name = "master"

--- a/packages/opal-server/opal_server/policy/watcher/factory.py
+++ b/packages/opal-server/opal_server/policy/watcher/factory.py
@@ -21,6 +21,7 @@ def setup_watcher_task(
     remote_source_url: str = None,
     clone_path_finder: RepoClonePathFinder = None,
     branch_name: str = None,
+    tag_name: str = None,
     ssh_key: Optional[str] = None,
     polling_interval: int = None,
     request_timeout: int = None,
@@ -40,6 +41,7 @@ def setup_watcher_task(
         remote_source_url(str): the base address to request the policy from
         clone_path_finder(RepoClonePathFinder): from which the local dir path for the repo clone would be retrieved
         branch_name(str):  name of remote branch in git to pull
+        tag_name(str):  name of remote tag in git to track
         ssh_key (str, optional): private ssh key used to gain access to the cloned repo
         polling_interval(int):  how many seconds need to wait between polling
         request_timeout(int):  how many seconds need to wait until timeout
@@ -72,6 +74,13 @@ def setup_watcher_task(
     branch_name = load_conf_if_none(
         branch_name, opal_server_config.POLICY_REPO_MAIN_BRANCH
     )
+    tag_name = load_conf_if_none(
+        tag_name, opal_server_config.POLICY_REPO_TAG
+    )
+    if branch_name is None and tag_name is None:
+        logger.info("No branch or tag specified, falling back to using branch 'master'")
+        branch_name = "master"
+
     ssh_key = load_conf_if_none(ssh_key, opal_server_config.POLICY_REPO_SSH_KEY)
     polling_interval = load_conf_if_none(
         polling_interval, opal_server_config.POLICY_REPO_POLLING_INTERVAL
@@ -98,6 +107,7 @@ def setup_watcher_task(
             remote_source_url=remote_source_url,
             local_clone_path=clone_path,
             branch_name=branch_name,
+            tag_name=tag_name,
             ssh_key=ssh_key,
             polling_interval=polling_interval,
             request_timeout=request_timeout,

--- a/packages/opal-server/opal_server/scopes/loader.py
+++ b/packages/opal-server/opal_server/scopes/loader.py
@@ -35,13 +35,22 @@ async def _load_env_scope(repo: ScopeRepository):
 
             auth = SSHAuthData(username="git", private_key=private_ssh_key)
 
+        branch = opal_server_config.POLICY_REPO_MAIN_BRANCH
+        tag = opal_server_config.POLICY_REPO_TAG
+        if branch is None and tag is None:
+            logger.info(
+                "No branch or tag specified for default scope, falling back to branch 'master'"
+            )
+            branch = "master"
+
         scope = Scope(
             scope_id=DEFAULT_SCOPE_ID,
             policy=GitPolicyScopeSource(
                 source_type=opal_server_config.POLICY_SOURCE_TYPE.lower(),
                 url=opal_server_config.POLICY_REPO_URL,
                 manifest=opal_server_config.POLICY_REPO_MANIFEST_PATH,
-                branch=opal_server_config.POLICY_REPO_MAIN_BRANCH,
+                branch=branch,
+                tag=tag,
                 auth=auth,
             ),
         )

--- a/packages/opal-server/opal_server/scopes/service.py
+++ b/packages/opal-server/opal_server/scopes/service.py
@@ -129,8 +129,9 @@ class ScopesService:
                 return
             source = cast(GitPolicyScopeSource, scope.policy)
 
+            ref = source.tag if source.tag is not None else source.branch
             logger.debug(
-                f"Sync scope: {scope.scope_id} (remote: {source.url}, branch: {source.branch}, req_time: {req_time})"
+                f"Sync scope: {scope.scope_id} (remote: {source.url}, ref: {ref}, req_time: {req_time})"
             )
 
             callbacks = PolicyFetcherCallbacks()

--- a/packages/opal-server/opal_server/tests/test_scopes_tag_support.py
+++ b/packages/opal-server/opal_server/tests/test_scopes_tag_support.py
@@ -82,9 +82,7 @@ def pygit2_repo(tmp_path):
     # Create an initial commit
     sig = pygit2.Signature("Test", "test@test.com")
     tree = repo.TreeBuilder().write()
-    commit_oid = repo.create_commit(
-        "refs/heads/master", sig, sig, "init", tree, []
-    )
+    commit_oid = repo.create_commit("refs/heads/master", sig, sig, "init", tree, [])
     # Create a lightweight tag
     repo.create_reference("refs/tags/v1.0", commit_oid)
 
@@ -200,9 +198,7 @@ class TestShouldFetchWithTags:
         fetcher = self._make_fetcher(source)
         mock_repo = MagicMock()
 
-        with patch.object(
-            RepoInterface, "has_tag", return_value=False
-        ):
+        with patch.object(RepoInterface, "has_tag", return_value=False):
             result = await fetcher._should_fetch(mock_repo)
             assert result is True
 
@@ -213,9 +209,7 @@ class TestShouldFetchWithTags:
         fetcher = self._make_fetcher(source)
         mock_repo = MagicMock()
 
-        with patch.object(
-            RepoInterface, "has_tag", return_value=True
-        ):
+        with patch.object(RepoInterface, "has_tag", return_value=True):
             result = await fetcher._should_fetch(mock_repo)
             assert result is True
 
@@ -234,9 +228,7 @@ class TestShouldFetchWithTags:
         fetcher = self._make_fetcher(source)
         mock_repo = MagicMock()
 
-        with patch.object(
-            RepoInterface, "has_remote_branch", return_value=False
-        ):
+        with patch.object(RepoInterface, "has_remote_branch", return_value=False):
             result = await fetcher._should_fetch(mock_repo)
             assert result is True
 
@@ -246,9 +238,7 @@ class TestShouldFetchWithTags:
         fetcher = self._make_fetcher(source)
         mock_repo = MagicMock()
 
-        with patch.object(
-            RepoInterface, "has_remote_branch", return_value=True
-        ):
+        with patch.object(RepoInterface, "has_remote_branch", return_value=True):
             result = await fetcher._should_fetch(mock_repo)
             assert result is False
 
@@ -280,9 +270,7 @@ class TestNotifyOnChangesWithTags:
 
         with patch.object(
             RepoInterface, "get_tag_commit_hash", return_value=fake_hash
-        ), patch.object(
-            RepoInterface, "get_local_branch", return_value=None
-        ):
+        ), patch.object(RepoInterface, "get_local_branch", return_value=None):
             mock_repo.create_reference.return_value = MagicMock()
             await fetcher._notify_on_changes(mock_repo)
 
@@ -294,9 +282,7 @@ class TestNotifyOnChangesWithTags:
         fetcher = self._make_fetcher(source)
         mock_repo = MagicMock()
 
-        with patch.object(
-            RepoInterface, "get_tag_commit_hash", return_value=None
-        ):
+        with patch.object(RepoInterface, "get_tag_commit_hash", return_value=None):
             await fetcher._notify_on_changes(mock_repo)
 
         fetcher.callbacks.on_update.assert_not_awaited()

--- a/packages/opal-server/opal_server/tests/test_scopes_tag_support.py
+++ b/packages/opal-server/opal_server/tests/test_scopes_tag_support.py
@@ -1,0 +1,446 @@
+import os
+import sys
+
+import pytest
+
+root_dir = os.path.abspath(
+    os.path.join(os.path.dirname(__file__), os.path.pardir, os.path.pardir)
+)
+sys.path.append(root_dir)
+
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pygit2
+from opal_common.schemas.policy_source import GitPolicyScopeSource
+from opal_server.git_fetcher import GitPolicyFetcher, RepoInterface
+from pydantic import ValidationError
+
+
+# ---------------------------------------------------------------------------
+# Helper to build a GitPolicyScopeSource without repeating boilerplate
+# ---------------------------------------------------------------------------
+def _make_source(branch=None, tag=None):
+    return GitPolicyScopeSource(
+        source_type="git",
+        url="https://example.com/repo.git",
+        auth={"auth_type": "none"},
+        branch=branch,
+        tag=tag,
+    )
+
+
+# ========================================================================
+# GitPolicyScopeSource schema validation
+# ========================================================================
+
+
+class TestGitPolicyScopeSourceValidation:
+    def test_branch_only(self):
+        src = _make_source(branch="main")
+        assert src.branch == "main"
+        assert src.tag is None
+
+    def test_tag_only(self):
+        src = _make_source(tag="v1.0")
+        assert src.tag == "v1.0"
+        assert src.branch is None
+
+    def test_neither_branch_nor_tag_raises(self):
+        with pytest.raises(ValidationError, match="Must provide either"):
+            _make_source()
+
+    def test_both_branch_and_tag_raises(self):
+        with pytest.raises(ValidationError, match="not both"):
+            _make_source(branch="main", tag="v1.0")
+
+    def test_empty_string_branch_treated_as_none(self):
+        src = _make_source(branch="", tag="v1.0")
+        assert src.branch is None
+        assert src.tag == "v1.0"
+
+    def test_empty_string_tag_treated_as_none(self):
+        src = _make_source(branch="main", tag="")
+        assert src.branch == "main"
+        assert src.tag is None
+
+    def test_both_empty_strings_raises(self):
+        with pytest.raises(ValidationError, match="Must provide either"):
+            _make_source(branch="", tag="")
+
+
+# ========================================================================
+# RepoInterface tag helpers (using a real pygit2 repo on disk)
+# ========================================================================
+
+
+@pytest.fixture
+def pygit2_repo(tmp_path):
+    """Create a bare-minimum pygit2 Repository with one commit and a tag."""
+    repo = pygit2.init_repository(str(tmp_path / "repo"), bare=False)
+
+    # Create an initial commit
+    sig = pygit2.Signature("Test", "test@test.com")
+    tree = repo.TreeBuilder().write()
+    commit_oid = repo.create_commit(
+        "refs/heads/master", sig, sig, "init", tree, []
+    )
+    # Create a lightweight tag
+    repo.create_reference("refs/tags/v1.0", commit_oid)
+
+    return repo, str(commit_oid)
+
+
+class TestRepoInterfaceTagHelpers:
+    def test_has_tag_existing(self, pygit2_repo):
+        repo, _ = pygit2_repo
+        assert RepoInterface.has_tag(repo, "v1.0") is True
+
+    def test_has_tag_missing(self, pygit2_repo):
+        repo, _ = pygit2_repo
+        assert RepoInterface.has_tag(repo, "no_such_tag") is False
+
+    def test_get_tag_commit_hash_existing(self, pygit2_repo):
+        repo, commit_hex = pygit2_repo
+        result = RepoInterface.get_tag_commit_hash(repo, "v1.0")
+        assert result == commit_hex
+
+    def test_get_tag_commit_hash_missing(self, pygit2_repo):
+        repo, _ = pygit2_repo
+        result = RepoInterface.get_tag_commit_hash(repo, "no_such_tag")
+        assert result is None
+
+    def test_get_tag_commit_hash_annotated_tag(self, pygit2_repo):
+        repo, commit_hex = pygit2_repo
+        # Create an annotated tag
+        sig = pygit2.Signature("Test", "test@test.com")
+        commit = repo.get(commit_hex)
+        tag_oid = repo.create_tag(
+            "v2.0", commit.id, pygit2.GIT_OBJECT_COMMIT, sig, "annotated tag"
+        )
+        result = RepoInterface.get_tag_commit_hash(repo, "v2.0")
+        assert result == commit_hex
+
+
+# ========================================================================
+# GitPolicyFetcher properties and source_id
+# ========================================================================
+
+
+class TestGitPolicyFetcherProperties:
+    @patch("opal_server.git_fetcher.opal_server_config")
+    @patch("opal_server.git_fetcher.GitCallback")
+    def test_is_tag_true_when_tag_set(self, mock_callback, mock_config):
+        mock_config.SCOPES_REPO_CLONES_SHARDS = 10
+        source = _make_source(tag="v1.0")
+        fetcher = GitPolicyFetcher(
+            base_dir=Path("/tmp/test"),
+            scope_id="test-scope",
+            source=source,
+        )
+        assert fetcher._is_tag is True
+        assert fetcher._ref_name == "v1.0"
+
+    @patch("opal_server.git_fetcher.opal_server_config")
+    @patch("opal_server.git_fetcher.GitCallback")
+    def test_is_tag_false_when_branch_set(self, mock_callback, mock_config):
+        mock_config.SCOPES_REPO_CLONES_SHARDS = 10
+        source = _make_source(branch="main")
+        fetcher = GitPolicyFetcher(
+            base_dir=Path("/tmp/test"),
+            scope_id="test-scope",
+            source=source,
+        )
+        assert fetcher._is_tag is False
+        assert fetcher._ref_name == "main"
+
+    @patch("opal_server.git_fetcher.opal_server_config")
+    def test_source_id_differs_for_branch_vs_tag(self, mock_config):
+        mock_config.SCOPES_REPO_CLONES_SHARDS = 10
+        branch_source = _make_source(branch="main")
+        tag_source = _make_source(tag="main")  # same name, different ref type
+        # source_id uses the ref value to compute the shard index
+        branch_id = GitPolicyFetcher.source_id(branch_source)
+        tag_id = GitPolicyFetcher.source_id(tag_source)
+        # Same ref name means same source_id (by design: same shard)
+        assert branch_id == tag_id
+
+    @patch("opal_server.git_fetcher.opal_server_config")
+    def test_source_id_different_tag_names(self, mock_config):
+        mock_config.SCOPES_REPO_CLONES_SHARDS = 256
+        src_a = _make_source(tag="v1.0")
+        src_b = _make_source(tag="v2.0")
+        id_a = GitPolicyFetcher.source_id(src_a)
+        id_b = GitPolicyFetcher.source_id(src_b)
+        # Different tags may (and likely do for distinct names) produce different ids
+        # At minimum, both should be valid strings
+        assert isinstance(id_a, str) and len(id_a) > 0
+        assert isinstance(id_b, str) and len(id_b) > 0
+
+
+# ========================================================================
+# GitPolicyFetcher._should_fetch with tags
+# ========================================================================
+
+
+class TestShouldFetchWithTags:
+    @patch("opal_server.git_fetcher.opal_server_config")
+    @patch("opal_server.git_fetcher.GitCallback")
+    def _make_fetcher(self, source, mock_callback, mock_config):
+        mock_config.SCOPES_REPO_CLONES_SHARDS = 10
+        return GitPolicyFetcher(
+            base_dir=Path("/tmp/test"),
+            scope_id="test-scope",
+            source=source,
+        )
+
+    @pytest.mark.asyncio
+    async def test_should_fetch_when_tag_missing(self):
+        source = _make_source(tag="v1.0")
+        fetcher = self._make_fetcher(source)
+        mock_repo = MagicMock()
+
+        with patch.object(
+            RepoInterface, "has_tag", return_value=False
+        ):
+            result = await fetcher._should_fetch(mock_repo)
+            assert result is True
+
+    @pytest.mark.asyncio
+    async def test_should_always_fetch_when_tag_present_no_hint(self):
+        """Tags can be moved silently, so we always re-fetch."""
+        source = _make_source(tag="v1.0")
+        fetcher = self._make_fetcher(source)
+        mock_repo = MagicMock()
+
+        with patch.object(
+            RepoInterface, "has_tag", return_value=True
+        ):
+            result = await fetcher._should_fetch(mock_repo)
+            assert result is True
+
+    @pytest.mark.asyncio
+    async def test_should_fetch_force(self):
+        source = _make_source(tag="v1.0")
+        fetcher = self._make_fetcher(source)
+        mock_repo = MagicMock()
+
+        result = await fetcher._should_fetch(mock_repo, force_fetch=True)
+        assert result is True
+
+    @pytest.mark.asyncio
+    async def test_should_fetch_when_branch_missing(self):
+        source = _make_source(branch="main")
+        fetcher = self._make_fetcher(source)
+        mock_repo = MagicMock()
+
+        with patch.object(
+            RepoInterface, "has_remote_branch", return_value=False
+        ):
+            result = await fetcher._should_fetch(mock_repo)
+            assert result is True
+
+    @pytest.mark.asyncio
+    async def test_should_not_fetch_when_branch_present_no_hint(self):
+        source = _make_source(branch="main")
+        fetcher = self._make_fetcher(source)
+        mock_repo = MagicMock()
+
+        with patch.object(
+            RepoInterface, "has_remote_branch", return_value=True
+        ):
+            result = await fetcher._should_fetch(mock_repo)
+            assert result is False
+
+
+# ========================================================================
+# GitPolicyFetcher._notify_on_changes with tags
+# ========================================================================
+
+
+class TestNotifyOnChangesWithTags:
+    @patch("opal_server.git_fetcher.opal_server_config")
+    @patch("opal_server.git_fetcher.GitCallback")
+    def _make_fetcher(self, source, mock_callback, mock_config):
+        mock_config.SCOPES_REPO_CLONES_SHARDS = 10
+        fetcher = GitPolicyFetcher(
+            base_dir=Path("/tmp/test"),
+            scope_id="test-scope",
+            source=source,
+        )
+        fetcher.callbacks = AsyncMock()
+        return fetcher
+
+    @pytest.mark.asyncio
+    async def test_notify_calls_callback_for_tag(self):
+        source = _make_source(tag="v1.0")
+        fetcher = self._make_fetcher(source)
+        mock_repo = MagicMock()
+        fake_hash = "abc123"
+
+        with patch.object(
+            RepoInterface, "get_tag_commit_hash", return_value=fake_hash
+        ), patch.object(
+            RepoInterface, "get_local_branch", return_value=None
+        ):
+            mock_repo.create_reference.return_value = MagicMock()
+            await fetcher._notify_on_changes(mock_repo)
+
+        fetcher.callbacks.on_update.assert_awaited_once_with(None, fake_hash)
+
+    @pytest.mark.asyncio
+    async def test_notify_returns_early_when_tag_not_found(self):
+        source = _make_source(tag="v1.0")
+        fetcher = self._make_fetcher(source)
+        mock_repo = MagicMock()
+
+        with patch.object(
+            RepoInterface, "get_tag_commit_hash", return_value=None
+        ):
+            await fetcher._notify_on_changes(mock_repo)
+
+        fetcher.callbacks.on_update.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_notify_detects_tag_change(self):
+        source = _make_source(tag="v1.0")
+        fetcher = self._make_fetcher(source)
+        mock_repo = MagicMock()
+        old_hash = "old123"
+        new_hash = "new456"
+
+        mock_local_branch = MagicMock()
+        mock_local_branch.target.hex = old_hash
+
+        with patch.object(
+            RepoInterface, "get_tag_commit_hash", return_value=new_hash
+        ), patch.object(
+            RepoInterface, "get_local_branch", return_value=mock_local_branch
+        ):
+            await fetcher._notify_on_changes(mock_repo)
+
+        fetcher.callbacks.on_update.assert_awaited_once_with(old_hash, new_hash)
+        mock_local_branch.set_target.assert_called_once_with(new_hash)
+
+    @pytest.mark.asyncio
+    async def test_notify_calls_callback_for_branch(self):
+        source = _make_source(branch="main")
+        fetcher = self._make_fetcher(source)
+        mock_repo = MagicMock()
+        fake_hash = "abc123"
+
+        with patch.object(
+            RepoInterface, "get_commit_hash", return_value=fake_hash
+        ), patch.object(
+            RepoInterface, "get_local_branch", return_value=None
+        ), patch.object(
+            RepoInterface, "create_local_branch_ref", return_value=MagicMock()
+        ):
+            await fetcher._notify_on_changes(mock_repo)
+
+        fetcher.callbacks.on_update.assert_awaited_once_with(None, fake_hash)
+
+
+# ========================================================================
+# GitPolicyFetcher._get_current_head with tags
+# ========================================================================
+
+
+class TestGetCurrentHead:
+    @patch("opal_server.git_fetcher.opal_server_config")
+    @patch("opal_server.git_fetcher.GitCallback")
+    def _make_fetcher(self, source, mock_callback, mock_config):
+        mock_config.SCOPES_REPO_CLONES_SHARDS = 10
+        return GitPolicyFetcher(
+            base_dir=Path("/tmp/test"),
+            scope_id="test-scope",
+            source=source,
+        )
+
+    def test_get_current_head_tag(self):
+        source = _make_source(tag="v1.0")
+        fetcher = self._make_fetcher(source)
+        fake_hash = "abc123"
+
+        with patch.object(fetcher, "_get_repo"), patch.object(
+            RepoInterface, "get_tag_commit_hash", return_value=fake_hash
+        ):
+            result = fetcher._get_current_head()
+            assert result == fake_hash
+
+    def test_get_current_head_branch(self):
+        source = _make_source(branch="main")
+        fetcher = self._make_fetcher(source)
+        fake_hash = "abc123"
+
+        with patch.object(fetcher, "_get_repo"), patch.object(
+            RepoInterface, "get_commit_hash", return_value=fake_hash
+        ):
+            result = fetcher._get_current_head()
+            assert result == fake_hash
+
+    def test_get_current_head_raises_when_not_found(self):
+        source = _make_source(tag="v1.0")
+        fetcher = self._make_fetcher(source)
+
+        with patch.object(fetcher, "_get_repo"), patch.object(
+            RepoInterface, "get_tag_commit_hash", return_value=None
+        ):
+            with pytest.raises(ValueError, match="Could not find current head"):
+                fetcher._get_current_head()
+
+
+# ========================================================================
+# Scopes loader fallback behavior
+# ========================================================================
+
+
+class TestScopesLoaderFallback:
+    @pytest.mark.asyncio
+    async def test_loader_falls_back_to_master_when_neither_set(self):
+        """loader.py should fall back to branch='master' when neither
+        POLICY_REPO_MAIN_BRANCH nor POLICY_REPO_TAG is configured."""
+        from unittest.mock import AsyncMock
+
+        mock_repo = AsyncMock()
+
+        with patch("opal_server.scopes.loader.opal_server_config") as mock_config:
+            mock_config.POLICY_REPO_URL = "https://example.com/repo.git"
+            mock_config.POLICY_SOURCE_TYPE = "git"
+            mock_config.POLICY_REPO_MANIFEST_PATH = ".manifest"
+            mock_config.POLICY_REPO_MAIN_BRANCH = None
+            mock_config.POLICY_REPO_TAG = None
+            mock_config.POLICY_REPO_SSH_KEY = None
+
+            from opal_server.scopes.loader import _load_env_scope
+
+            await _load_env_scope(mock_repo)
+
+        mock_repo.put.assert_awaited_once()
+        scope = mock_repo.put.call_args[0][0]
+        assert scope.policy.branch == "master"
+        assert scope.policy.tag is None
+
+    @pytest.mark.asyncio
+    async def test_loader_uses_tag_when_configured(self):
+        """loader.py should use the tag when POLICY_REPO_TAG is set."""
+        from unittest.mock import AsyncMock
+
+        mock_repo = AsyncMock()
+
+        with patch("opal_server.scopes.loader.opal_server_config") as mock_config:
+            mock_config.POLICY_REPO_URL = "https://example.com/repo.git"
+            mock_config.POLICY_SOURCE_TYPE = "git"
+            mock_config.POLICY_REPO_MANIFEST_PATH = ".manifest"
+            mock_config.POLICY_REPO_MAIN_BRANCH = None
+            mock_config.POLICY_REPO_TAG = "v1.0"
+            mock_config.POLICY_REPO_SSH_KEY = None
+
+            from opal_server.scopes.loader import _load_env_scope
+
+            await _load_env_scope(mock_repo)
+
+        mock_repo.put.assert_awaited_once()
+        scope = mock_repo.put.call_args[0][0]
+        assert scope.policy.tag == "v1.0"
+        assert scope.policy.branch is None

--- a/packages/opal-server/opal_server/tests/test_scopes_tag_support.py
+++ b/packages/opal-server/opal_server/tests/test_scopes_tag_support.py
@@ -296,7 +296,7 @@ class TestNotifyOnChangesWithTags:
         new_hash = "new456"
 
         mock_local_branch = MagicMock()
-        mock_local_branch.target.hex = old_hash
+        mock_local_branch.target.__str__ = lambda self: old_hash
 
         with patch.object(
             RepoInterface, "get_tag_commit_hash", return_value=new_hash


### PR DESCRIPTION
This PR adds support for tracking Git tags instead of branches. It is a revival of https://github.com/permitio/opal/pull/517 with some additions to add support for tags in the OPAL scopes as well.

## Fixes Issue

<!-- Remove this section if not applicable -->

<!-- Example: Closes #31 -->

## Changes proposed

### Why tracking git tags instead of branch
In a way this could be considered "against" how git is supposed to be used - some say tags should be immutable. However, mutable tags are defacto sometimes used, the most clear example being using a "latest" tag or a "v1-latest" tag.

Using tags this way could let you use a policy repo with a single base branch, while still giving control of what is rolled out in each env. Consider the traditional dev/prod setup:

- the `dev` instance of OPAL is tracking the base branch (ex. `master`)
- the `prod`instance of OPAL is tracking a `prod` tag which can be moved at will once the changes in dev/master is tested properly.

This current way of doing this is to have multiple long lived branches in the same repo - this can be cumbersome and lead to a bunch of manual merging of branches. 

### Changes
- Add env variable `POLICY_REPO_TAG` and cli arg `--policy-repo-tag`, defaulting to None. When used, OPAL will track the tag.

#### `POLICY_REPO_TAG` and `POLICY_REPO_MAIN_BRANCH`
The two variables are obviously dependent on eachother. My idea was to not break default behaviour.

| POLICY_REPO_TAG | POLICY_REPO_MAIN_BRANCH | Behaviour                                      |
|-----------------|-------------------------|------------------------------------------------|
| Empty           | Empty                   | OPAL tracks the `master` branch                |
| Empty           | Not Empty               | OPAL tracks the given branch                   |
| Not Empty       | Empty                   | OPAL tracks the given tag                      |
| Not Empty       | Not Empty               | OPAL fails (cannot decide what to track)       |

<!-- List all the proposed changes in your PR -->

<!-- Mark all the applicable boxes. To mark the box as done follow the following conventions -->
<!--
[x] - Correct; marked as done
[X] - Correct; marked as done

[ ] - Not correct; marked as **not** done
-->

## Check List (Check all the applicable boxes) <!-- Follow the above conventions to check the box -->

- [x] I sign off on contributing this submission to open-source
- [x] My code follows the code style of this project.
- [x] My change requires changes to the documentation.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] This PR does not contain plagiarized content.
- [x] The title of my pull request is a short description of the requested changes.

## Screenshots

<!-- Add all the screenshots which support your changes -->

## Note to reviewers

<!-- Add notes to reviewers if applicable -->
