### PR TITLE
chore: update python base images to 3.12

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,7 +1,7 @@
 # BUILD STAGE ---------------------------------------
 # split this stage to save time and reduce image size
 # ---------------------------------------------------
-FROM python:3.10-bookworm AS build-stage
+FROM python:3.12-bookworm AS build-stage
 # from now on, work in the /app directory
 WORKDIR /app/
 # Layer dependency install (for caching)
@@ -14,11 +14,11 @@ RUN pip install --no-cache-dir --upgrade pip && pip install --no-cache-dir -r ./
 
 # COMMON IMAGE --------------------------------------
 # ---------------------------------------------------
-FROM python:3.10-slim-bookworm AS common
+FROM python:3.12-slim-bookworm AS common
 
 # copy libraries from build stage (This won't copy redundant libraries we used in build-stage)
 # also remove the default python site-packages that has older versions of packages that won't be overridden
-RUN rm -r /usr/local/lib/python3.10/site-packages
+RUN rm -r /usr/local/lib/python3.12/site-packages
 COPY --from=build-stage /usr/local /usr/local
 
 # Add non-root user (with home dir at /opal)
@@ -161,7 +161,7 @@ USER opal
 # Extract the Cedar Agent binary from the existing image
 # CEDAR AGENT DOWNLOAD STAGE -----------------------
 # Stage to locate and extract the cedar-agent binary
-FROM permitio/cedar-agent:0.2.1 AS cedar-extractor
+FROM permitio/cedar-agent:0.2.2 AS cedar-extractor
 
 FROM client-standalone AS client-cedar
 
@@ -244,14 +244,14 @@ USER opal
 # ===================== ALPINE VARIANTS =====================
 # BUILD STAGE (ALPINE) --------------------------------------
 # -----------------------------------------------------------
-FROM python:3.10-alpine AS build-stage-alpine
-ARG LIBGIT2_VERSION=1.7.2
+FROM python:3.12-alpine AS build-stage-alpine
 WORKDIR /app/
 RUN apk add --no-cache \
   bash \
   build-base \
   musl-dev \
   libffi-dev \
+  libgit2-dev \
   openssl-dev \
   pkgconfig \
   cmake \
@@ -262,17 +262,6 @@ RUN apk add --no-cache \
   openssh-client \
   jq \
   wget
-RUN wget -O /tmp/libgit2.tar.gz https://github.com/libgit2/libgit2/archive/refs/tags/v${LIBGIT2_VERSION}.tar.gz && \
-  tar -xzf /tmp/libgit2.tar.gz -C /tmp && \
-  cd /tmp/libgit2-${LIBGIT2_VERSION} && \
-  cmake -S . -B build \
-    -DCMAKE_BUILD_TYPE=Release \
-    -DCMAKE_INSTALL_PREFIX=/usr/local \
-    -DBUILD_SHARED_LIBS=ON \
-    -DBUILD_TESTS=OFF \
-    -DUSE_SSH=ON && \
-  cmake --build build --config Release --target install && \
-  rm -rf /tmp/libgit2*
 COPY ./packages/requires.txt ./base_requires.txt
 COPY ./packages/opal-common/requires.txt ./common_requires.txt
 COPY ./packages/opal-client/requires.txt ./client_requires.txt
@@ -281,8 +270,8 @@ RUN pip install --no-cache-dir --upgrade pip && pip install --no-cache-dir -r ./
 
 # COMMON IMAGE (ALPINE) -------------------------------------
 # -----------------------------------------------------------
-FROM python:3.10-alpine AS common-alpine
-RUN rm -r /usr/local/lib/python3.10/site-packages || true
+FROM python:3.12-alpine AS common-alpine
+RUN rm -r /usr/local/lib/python3.12/site-packages || true
 COPY --from=build-stage-alpine /usr/local /usr/local
 RUN adduser -D -h /opal -s /bin/bash opal && apk add --no-cache bash netcat-openbsd jq wget
 RUN apk add --no-cache libssh2 http-parser

--- a/packages/opal-server/opal_server/git_fetcher.py
+++ b/packages/opal-server/opal_server/git_fetcher.py
@@ -64,9 +64,9 @@ class RepoInterface:
             else:
                 raise RuntimeError("Base branch was not found on remote")
             logger.debug(
-                f"Created local branch '{branch_name}', pointing to: {commit.hex}"
+                f"Created local branch '{branch_name}', pointing to: {str(commit.id)}"
             )
-            return repo.create_reference(f"refs/heads/{branch_name}", commit.hex)
+            return repo.create_reference(f"refs/heads/{branch_name}", str(commit.id))
         else:
             logger.debug(
                 f"No need to create local branch '{branch_name}': already exists!"
@@ -92,7 +92,7 @@ class RepoInterface:
     def get_commit_hash(repo: Repository, branch: str, remote: str) -> Optional[str]:
         try:
             (commit, _) = repo.resolve_refish(f"{remote}/{branch}")
-            return commit.hex
+            return str(commit.id)
         except (pygit2.GitError, KeyError):
             return None
 
@@ -311,7 +311,7 @@ class GitPolicyFetcher(PolicyFetcher):
                 repo, self.local_branch_name, self._remote, self._source.branch
             )
         else:
-            old_revision = local_branch.target.hex
+            old_revision = str(local_branch.target)
 
         await self.callbacks.on_update(old_revision, new_revision)
 

--- a/packages/opal-server/requires.txt
+++ b/packages/opal-server/requires.txt
@@ -4,6 +4,6 @@ gitpython>=3.1.32,<4
 pyjwt[crypto]>=2.1.0,<3
 slowapi>=0.1.5,<1
 # slowapi is stuck on and old `redis`, so fix that and switch from aioredis to redis
-pygit2>=1.14.1,<1.15
+pygit2>=1.15.1,<2
 asgiref>=3.5.2,<4
 redis>=4.3.4,<5


### PR DESCRIPTION
## Fixes Issue

This PR updates the Dockerfile so that it uses Python 3.12 base images. Python 3.10 is set to be [EOL](https://devguide.python.org/versions/) very soon and since the packages are already built for 3.12 I'd say it makes sense to update the container images to this version as well.

<!-- Remove this section if not applicable -->

<!-- Example: Closes #31 -->

## Changes proposed

<!-- List all the proposed changes in your PR -->

<!-- Mark all the applicable boxes. To mark the box as done follow the following conventions -->
<!--
[x] - Correct; marked as done
[X] - Correct; marked as done

[ ] - Not correct; marked as **not** done
-->

## Check List (Check all the applicable boxes) <!-- Follow the above conventions to check the box -->

- [x] I sign off on contributing this submission to open-source
- [x] My code follows the code style of this project.
- [ ] My change requires changes to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] This PR does not contain plagiarized content.
- [x] The title of my pull request is a short description of the requested changes.

## Screenshots

<!-- Add all the screenshots which support your changes -->

## Note to reviewers

<!-- Add notes to reviewers if applicable -->
