### PR TITLE
fix: stop logging FetcherConfig in callback reporter

### DIFF
--- a/packages/opal-client/opal_client/callbacks/reporter.py
+++ b/packages/opal-client/opal_client/callbacks/reporter.py
@@ -40,6 +40,7 @@ class CallbacksReporter:
     ):
         try:
             # all the urls that will be eventually called by the fetcher
+            callback_requests = []
             urls = []
             if self._get_user_data_handler is not None:
                 report = report.copy()
@@ -52,16 +53,18 @@ class CallbacksReporter:
                     entry.config or HttpFetcherConfig()
                 )  # should not be None if we got it from the register
                 config.data = report_data
-                urls.append((entry.url, config, None))
+                callback_requests.append((entry.url, config, None))
+                urls.append(entry.url)
 
             # next we add the "one time" callbacks from extra_callbacks (i.e: callbacks sent as part of a DataUpdate message)
             if extra_callbacks is not None:
                 for url, config in extra_callbacks:
                     config.data = report_data
-                    urls.append((url, config, None))
+                    callback_requests.append((url, config, None))
+                    urls.append(url)
 
-            logger.info("Reporting the update to requested callbacks", urls=repr(urls))
-            report_results = await self._fetcher.handle_urls(urls)
+            logger.info("Reporting the update to requested callbacks", urls=urls)
+            report_results = await self._fetcher.handle_urls(callback_requests)
             # log reports which we failed to send
             for url, config, result in report_results:
                 if isinstance(result, Exception):

--- a/packages/opal-client/opal_client/callbacks/reporter.py
+++ b/packages/opal-client/opal_client/callbacks/reporter.py
@@ -39,7 +39,7 @@ class CallbacksReporter:
         extra_callbacks: Optional[List[CallbackConfig]] = None,
     ):
         try:
-            # all the urls that will be eventually called by the fetcher
+            # all callback request tuples (url, config, None) that will be eventually called by the fetcher
             callback_requests = []
             if self._get_user_data_handler is not None:
                 report = report.copy()

--- a/packages/opal-client/opal_client/callbacks/reporter.py
+++ b/packages/opal-client/opal_client/callbacks/reporter.py
@@ -41,7 +41,6 @@ class CallbacksReporter:
         try:
             # all the urls that will be eventually called by the fetcher
             callback_requests = []
-            urls = []
             if self._get_user_data_handler is not None:
                 report = report.copy()
                 report.user_data = await self._get_user_data_handler(report)
@@ -54,15 +53,15 @@ class CallbacksReporter:
                 )  # should not be None if we got it from the register
                 config.data = report_data
                 callback_requests.append((entry.url, config, None))
-                urls.append(entry.url)
 
             # next we add the "one time" callbacks from extra_callbacks (i.e: callbacks sent as part of a DataUpdate message)
             if extra_callbacks is not None:
                 for url, config in extra_callbacks:
                     config.data = report_data
                     callback_requests.append((url, config, None))
-                    urls.append(url)
 
+            # log only the URLs — FetcherConfig may carry Authorization headers and the full report payload
+            urls = [request[0] for request in callback_requests]
             logger.info("Reporting the update to requested callbacks", urls=urls)
             report_results = await self._fetcher.handle_urls(callback_requests)
             # log reports which we failed to send

--- a/packages/opal-client/opal_client/tests/callbacks_reporter_test.py
+++ b/packages/opal-client/opal_client/tests/callbacks_reporter_test.py
@@ -1,0 +1,92 @@
+import os
+import sys
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from loguru import logger
+
+# Add parent path to use local src as package for tests
+root_dir = os.path.abspath(
+    os.path.join(os.path.dirname(__file__), os.path.pardir, os.path.pardir)
+)
+sys.path.append(root_dir)
+
+from opal_client.callbacks.register import CallbacksRegister
+from opal_client.callbacks.reporter import CallbacksReporter
+from opal_common.fetcher.providers.http_fetch_provider import HttpFetcherConfig
+from opal_common.schemas.data import DataUpdateReport
+
+CALLBACK_URL = "http://callback.example.com/report"
+EXTRA_CALLBACK_URL = "http://extra-callback.example.com/report"
+SECRET_TOKEN = "Bearer super-secret-token-must-not-leak"
+
+
+@pytest.fixture
+def capture_loguru():
+    """Capture loguru output with serialize=True.
+
+    OPAL's production log sinks can be configured with LOG_SERIALIZE=true, which
+    dumps the full record (including ``record["extra"]``) as JSON. That is the
+    scenario in which #901 leaked credentials, so the regression sink must
+    serialize too — otherwise the default format string hides ``extra`` fields
+    and the test passes vacuously.
+    """
+    captured: list[str] = []
+    sink_id = logger.add(
+        lambda message: captured.append(str(message)),
+        level="DEBUG",
+        serialize=True,
+    )
+    try:
+        yield captured
+    finally:
+        logger.remove(sink_id)
+
+
+@pytest.mark.asyncio
+async def test_report_update_results_does_not_log_fetcher_config(capture_loguru):
+    """Regression test for #901: the reporter must not log FetcherConfig.
+
+    HttpFetcherConfig may carry Authorization headers and the full report
+    payload (assigned to ``config.data`` just before the log line).
+    Only the URLs are safe to log.
+    """
+    register = CallbacksRegister()
+    register.put(
+        CALLBACK_URL,
+        config=HttpFetcherConfig(headers={"Authorization": SECRET_TOKEN}),
+    )
+
+    fetcher = MagicMock()
+    fetcher.handle_urls = AsyncMock(return_value=[])
+
+    reporter = CallbacksReporter(register=register, data_fetcher=fetcher)
+    report = DataUpdateReport(update_id="test-update", reports=[])
+
+    extra_config = HttpFetcherConfig(headers={"Authorization": SECRET_TOKEN})
+    await reporter.report_update_results(
+        report=report,
+        extra_callbacks=[(EXTRA_CALLBACK_URL, extra_config)],
+    )
+
+    combined_log = "\n".join(capture_loguru)
+    # the secret token itself must never appear in any log line
+    assert SECRET_TOKEN not in combined_log
+    # the HttpFetcherConfig repr (which embeds headers and data) must never appear
+    assert "HttpFetcherConfig" not in combined_log
+    assert "headers=" not in combined_log
+    # the URLs themselves are expected in the log line
+    assert CALLBACK_URL in combined_log
+    assert EXTRA_CALLBACK_URL in combined_log
+
+    # the fetcher must still receive the full (url, config, None) tuple shape
+    fetcher.handle_urls.assert_awaited_once()
+    forwarded_requests = fetcher.handle_urls.await_args.args[0]
+    assert len(forwarded_requests) == 2
+    forwarded_urls = [request[0] for request in forwarded_requests]
+    assert CALLBACK_URL in forwarded_urls
+    assert EXTRA_CALLBACK_URL in forwarded_urls
+    for _, config, sentinel in forwarded_requests:
+        assert isinstance(config, HttpFetcherConfig)
+        assert config.headers == {"Authorization": SECRET_TOKEN}
+        assert sentinel is None


### PR DESCRIPTION
<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing -->

## Fixes Issue 

Closes #901 

<!-- Remove this section if not applicable -->

<!-- Example: Closes #31 -->

## Changes proposed

- Updates CallbacksReporter to only log urls, rather than the full (url, FetcherConfig) tuple, which contains sensitive credentials. 

<!-- List all the proposed changes in your PR -->

<!-- Mark all the applicable boxes. To mark the box as done follow the following conventions -->
<!--
[x] - Correct; marked as done
[X] - Correct; marked as done

[ ] - Not correct; marked as **not** done
-->

## Check List (Check all the applicable boxes) <!-- Follow the above conventions to check the box -->

- [x] I sign off on contributing this submission to open-source
- [ ] My code follows the code style of this project.
- [ ] My change requires changes to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] This PR does not contain plagiarized content.
- [x] The title of my pull request is a short description of the requested changes.

