### PR TITLE
feat(client): live liveness probe for opa policy store

### DIFF
--- a/documentation/docs/getting-started/configuration.mdx
+++ b/documentation/docs/getting-started/configuration.mdx
@@ -1094,6 +1094,37 @@ Default: `{"retries": 3, "backoff_factor": 0.3}`
 
 Retry options when connecting to the policy store (i.e., the agent that handles the policy, e.g., OPA).
 
+#### OPAL_POLICY_STORE_LIVENESS_PROBE_ENABLED
+
+Default: `True`
+
+If enabled, OPAL Client periodically probes the policy store's health endpoint
+in a background task and factors the result into the `/healthy` HTTP response.
+
+Without this probe, `/healthy` reflects only the success of the last
+`server -> policy-store` transaction, which can stay `True` even if OPA hangs,
+deadlocks, or stops accepting HTTP connections in steady state. With it
+enabled, supervisors that probe `/healthy` will see the client report unhealthy
+within one probe interval if the policy store becomes unresponsive, and
+recover automatically once it returns.
+
+The `/healthy` endpoint itself remains O(1): the probe runs once per interval
+in the background and updates a cached flag — high-frequency `/healthy`
+polling does not translate into proportional load on the policy store.
+
+#### OPAL_POLICY_STORE_LIVENESS_PROBE_INTERVAL_SECONDS
+
+Default: `10`
+
+Interval (in seconds) between background liveness probes against the policy store.
+
+#### OPAL_POLICY_STORE_LIVENESS_PROBE_TIMEOUT_SECONDS
+
+Default: `2`
+
+Per-request HTTP timeout (in seconds) for liveness probes against the policy
+store. A probe that exceeds this timeout is treated as an unreachable sample.
+
 #### OPAL_POLICY_STORE_POLICY_PATHS_TO_IGNORE
 
 Default: `[]`

--- a/documentation/docs/tutorials/healthcheck_policy_and_update_callbacks.mdx
+++ b/documentation/docs/tutorials/healthcheck_policy_and_update_callbacks.mdx
@@ -20,6 +20,23 @@ curl -L https://raw.githubusercontent.com/permitio/opal/master/docker/docker-com
 
 ## <a name="healthcheck"></a> OPA healthcheck policy
 
+:::tip
+The OPAL Client also exposes its own HTTP `GET /healthy` endpoint, which is the
+recommended target for kubernetes liveness probes and supervisors. By default,
+that endpoint combines:
+
+1. the success of the last `OPAL server -> policy-store` transaction, **and**
+2. live reachability of the policy store, sampled in the background by
+   `OPAL_POLICY_STORE_LIVENESS_PROBE_ENABLED` (default `True`,
+   interval `OPAL_POLICY_STORE_LIVENESS_PROBE_INTERVAL_SECONDS=10`,
+   timeout `OPAL_POLICY_STORE_LIVENESS_PROBE_TIMEOUT_SECONDS=2`).
+
+This means `/healthy` will report unhealthy within one probe interval if OPA
+hangs, drops its listener, or otherwise becomes unreachable, and recovers
+automatically once OPA returns — without any restart of the OPAL Client.
+See the [configuration reference](/getting-started/configuration#opal_policy_store_liveness_probe_enabled).
+:::
+
 #### What is the healthcheck policy?
 
 A special OPA policy that (if activated) is loaded into OPA as the `system.opal` rego package.

--- a/packages/opal-client/opal_client/client.py
+++ b/packages/opal-client/opal_client/client.py
@@ -305,8 +305,8 @@ class OpalClient:
         @app.get("/healthy", include_in_schema=False)
         async def healthy():
             """Returns 200 if updates keep being successfully fetched from the
-            server and applied to the policy store."""
-            # TODO: Client would only report unhealthy if server -> policy-store transactions failed, but not if server connection gets disconnected.
+            server and applied to the policy store, AND the policy store is
+            reachable (when the background liveness probe is enabled)."""
             healthy = await self.policy_store.is_healthy()
 
             if healthy:
@@ -400,6 +400,12 @@ class OpalClient:
     async def stop_client_background_tasks(self):
         """Stops all background tasks (called on shutdown event)"""
         logger.info("stopping background tasks...")
+
+        # stop the policy store's background liveness probe, if any
+        try:
+            await self.policy_store.stop_liveness_probe()
+        except Exception:
+            logger.exception("error while stopping policy store liveness probe")
 
         # stopping opa runner
         if self.engine_runner:
@@ -572,6 +578,14 @@ class OpalClient:
             logger.critical("healthcheck policy enabled but could not be initialized!")
             self._trigger_shutdown()
             return
+
+        # Start the background liveness probe alongside the policy/data updater
+        # tasks. At this point the engine runner (if any) has already confirmed
+        # the policy store is up, so the probe starts from a known-good state.
+        try:
+            await self.policy_store.start_liveness_probe()
+        except Exception:
+            logger.exception("failed to start policy store liveness probe")
 
         if self.offline_mode_enabled:
             # Immediately attempt loading from backup (waiting for failure loading from server would delay availability)

--- a/packages/opal-client/opal_client/client.py
+++ b/packages/opal-client/opal_client/client.py
@@ -581,11 +581,21 @@ class OpalClient:
 
         # Start the background liveness probe alongside the policy/data updater
         # tasks. At this point the engine runner (if any) has already confirmed
-        # the policy store is up, so the probe starts from a known-good state.
+        # the policy store is up, but for external engines we have no such
+        # guarantee — `start_liveness_probe` runs an initial probe synchronously
+        # so the first reported reachability reflects reality, not the
+        # optimistic default.
         try:
             await self.policy_store.start_liveness_probe()
         except Exception:
-            logger.exception("failed to start policy store liveness probe")
+            # Non-fatal: keep booting, but warn loudly so operators know
+            # /healthy will fall back to the transaction-only signal until
+            # they intervene.
+            logger.error(
+                "Policy store liveness probe failed to start; "
+                "/healthy will not reflect engine reachability."
+            )
+            logger.exception("liveness probe start failure detail")
 
         if self.offline_mode_enabled:
             # Immediately attempt loading from backup (waiting for failure loading from server would delay availability)

--- a/packages/opal-client/opal_client/config.py
+++ b/packages/opal-client/opal_client/config.py
@@ -66,6 +66,28 @@ class OpalClientConfig(Confi):
         {},
         description="Retry options when connecting to the policy store (i.e. the agent that handles the policy, e.g. OPA)",
     )
+
+    # Background liveness probe of the policy store (e.g. OPA).
+    # Without this, /healthy only reflects the success of the last server -> policy-store
+    # transaction, which can stay True even if OPA hangs / drops its listener.
+    POLICY_STORE_LIVENESS_PROBE_ENABLED = confi.bool(
+        "POLICY_STORE_LIVENESS_PROBE_ENABLED",
+        True,
+        description="If True, OPAL client periodically probes the policy store's "
+        "health endpoint and factors the result into /healthy. This makes /healthy "
+        "reflect live policy-store responsiveness, not just the success of the last "
+        "server -> policy-store transaction.",
+    )
+    POLICY_STORE_LIVENESS_PROBE_INTERVAL_SECONDS = confi.int(
+        "POLICY_STORE_LIVENESS_PROBE_INTERVAL_SECONDS",
+        10,
+        description="Interval (seconds) between background liveness probes against the policy store.",
+    )
+    POLICY_STORE_LIVENESS_PROBE_TIMEOUT_SECONDS = confi.int(
+        "POLICY_STORE_LIVENESS_PROBE_TIMEOUT_SECONDS",
+        2,
+        description="Per-request HTTP timeout (seconds) for liveness probes against the policy store.",
+    )
     POLICY_UPDATER_CONN_RETRY: ConnRetryOptions = confi.model(
         "POLICY_UPDATER_CONN_RETRY",
         ConnRetryOptions,

--- a/packages/opal-client/opal_client/policy_store/base_policy_store_client.py
+++ b/packages/opal-client/opal_client/policy_store/base_policy_store_client.py
@@ -70,6 +70,24 @@ class AbstractPolicyStore:
     async def is_ready(self) -> bool:
         raise NotImplementedError()
 
+    async def start_liveness_probe(self) -> None:
+        """Optionally start a background task that periodically probes the
+        policy store for reachability.
+
+        Concrete clients (e.g. OPA) override this to keep `is_healthy()`
+        in sync with the policy store's live responsiveness. Default is
+        a no-op so non-supporting stores remain unaffected.
+        """
+        return None
+
+    async def stop_liveness_probe(self) -> None:
+        """Cancel the background liveness probe started by
+        `start_liveness_probe`, if any.
+
+        Default is a no-op.
+        """
+        return None
+
     async def full_export(self, writer: AsyncTextIOWrapper) -> None:
         raise NotImplementedError()
 

--- a/packages/opal-client/opal_client/policy_store/cedar_client.py
+++ b/packages/opal-client/opal_client/policy_store/cedar_client.py
@@ -299,14 +299,13 @@ class CedarClient(LivenessProbeMixin, BasePolicyStoreClient):
     def _probe_log_label(self) -> str:
         return "Cedar"
 
-    async def _probe_engine_reachable(
-        self, session: aiohttp.ClientSession
-    ) -> bool:
+    async def _probe_engine_reachable(self, session: aiohttp.ClientSession) -> bool:
         """Issue a single GET against the Cedar agent's `/v1/` endpoint.
 
         Mirrors `CedarRunner.health_check()`'s precedent — cedar-agent
-        responds 2xx on `/v1/`. The probe sends no auth headers, matching the
-        runner's approach and keeping reachability decoupled from auth.
+        responds 2xx on `/v1/`. The probe sends no auth headers,
+        matching the runner's approach and keeping reachability
+        decoupled from auth.
         """
         health_url = f"{self._cedar_url}/"
         async with session.get(health_url) as response:

--- a/packages/opal-client/opal_client/policy_store/cedar_client.py
+++ b/packages/opal-client/opal_client/policy_store/cedar_client.py
@@ -44,6 +44,14 @@ class CedarClient(BasePolicyStoreClient):
         self._most_recent_data_transaction: Optional[StoreTransaction] = None
         self._most_recent_policy_transaction: Optional[StoreTransaction] = None
 
+        # Background liveness probe state. `_engine_reachable` defaults to True
+        # so /healthy preserves historical behavior immediately after startup
+        # (before the first probe completes). The probe will flip this to False
+        # if Cedar becomes unreachable.
+        self._engine_reachable: bool = True
+        self._liveness_probe_task: Optional[asyncio.Task] = None
+        self._liveness_probe_stop_event: Optional[asyncio.Event] = None
+
         if auth_type == PolicyStoreAuth.TOKEN:
             if self._token is None:
                 logger.error("POLICY_STORE_AUTH_TOKEN can not be empty")
@@ -279,13 +287,119 @@ class CedarClient(BasePolicyStoreClient):
         )
 
     async def is_healthy(self) -> bool:
-        return (
+        transactions_healthy: bool = (
             self._most_recent_policy_transaction is not None
             and self._most_recent_policy_transaction.success
         ) and (
             self._most_recent_data_transaction is not None
             and self._most_recent_data_transaction.success
         )
+        return transactions_healthy and self._engine_reachable
+
+    async def _probe_engine_reachable(self) -> bool:
+        """Issue a single GET against Cedar's `/v1/` endpoint.
+
+        Returns True iff Cedar responds 2xx within the configured timeout.
+        Honors POLICY_STORE_AUTH_TOKEN if configured.
+        """
+        health_url = f"{self._cedar_url}/"
+        timeout_seconds = (
+            opal_client_config.POLICY_STORE_LIVENESS_PROBE_TIMEOUT_SECONDS
+        )
+        timeout = aiohttp.ClientTimeout(total=timeout_seconds)
+        try:
+            headers = await self._get_auth_headers()
+            async with aiohttp.ClientSession(
+                trust_env=True, timeout=timeout
+            ) as session:
+                async with session.get(health_url, headers=headers) as response:
+                    return 200 <= response.status < 300
+        except (aiohttp.ClientError, asyncio.TimeoutError) as e:
+            logger.debug("Cedar liveness probe failed: {err}", err=repr(e))
+            return False
+        except Exception as e:
+            logger.debug(
+                "Cedar liveness probe failed with unexpected error: {err}",
+                err=repr(e),
+            )
+            return False
+
+    async def _liveness_probe_loop(self):
+        interval_seconds = max(
+            1,
+            opal_client_config.POLICY_STORE_LIVENESS_PROBE_INTERVAL_SECONDS,
+        )
+        stop_event = self._liveness_probe_stop_event
+        last_reachable: bool = self._engine_reachable
+
+        logger.info(
+            "Starting Cedar liveness probe (interval={interval}s, timeout={timeout}s)",
+            interval=interval_seconds,
+            timeout=opal_client_config.POLICY_STORE_LIVENESS_PROBE_TIMEOUT_SECONDS,
+        )
+
+        while not stop_event.is_set():
+            try:
+                reachable = await self._probe_engine_reachable()
+            except asyncio.CancelledError:
+                raise
+            except Exception as e:
+                logger.debug(
+                    "Cedar liveness probe loop caught unexpected error: {err}",
+                    err=repr(e),
+                )
+                reachable = False
+
+            self._engine_reachable = reachable
+
+            if reachable != last_reachable:
+                if reachable:
+                    logger.info(
+                        "Cedar liveness probe: policy store became reachable"
+                    )
+                else:
+                    logger.info(
+                        "Cedar liveness probe: policy store became unreachable"
+                    )
+                last_reachable = reachable
+            else:
+                logger.debug(
+                    "Cedar liveness probe sample: reachable={reachable}",
+                    reachable=reachable,
+                )
+
+            try:
+                await asyncio.wait_for(stop_event.wait(), timeout=interval_seconds)
+            except asyncio.TimeoutError:
+                continue
+            except asyncio.CancelledError:
+                raise
+
+    async def start_liveness_probe(self) -> None:
+        if not opal_client_config.POLICY_STORE_LIVENESS_PROBE_ENABLED:
+            logger.info(
+                "Cedar liveness probe disabled via POLICY_STORE_LIVENESS_PROBE_ENABLED"
+            )
+            return
+        if self._liveness_probe_task is not None and not self._liveness_probe_task.done():
+            return
+        self._liveness_probe_stop_event = asyncio.Event()
+        self._liveness_probe_task = asyncio.create_task(self._liveness_probe_loop())
+
+    async def stop_liveness_probe(self) -> None:
+        if self._liveness_probe_stop_event is not None:
+            self._liveness_probe_stop_event.set()
+        task = self._liveness_probe_task
+        if task is not None and not task.done():
+            task.cancel()
+            try:
+                await task
+            except asyncio.CancelledError:
+                pass
+            except Exception:
+                logger.exception("Error while stopping Cedar liveness probe task")
+        self._liveness_probe_task = None
+        self._liveness_probe_stop_event = None
 
     async def full_export(self, writer: AsyncTextIOWrapper) -> None:
         policies = await self.get_policies()

--- a/packages/opal-client/opal_client/policy_store/cedar_client.py
+++ b/packages/opal-client/opal_client/policy_store/cedar_client.py
@@ -12,6 +12,7 @@ from opal_client.policy_store.base_policy_store_client import (
     BasePolicyStoreClient,
     JsonableValue,
 )
+from opal_client.policy_store.liveness_probe import LivenessProbeMixin
 from opal_client.policy_store.opa_client import (
     RETRY_CONFIG,
     affects_transaction,
@@ -25,7 +26,7 @@ from opal_common.schemas.store import StoreTransaction, TransactionType
 from tenacity import retry
 
 
-class CedarClient(BasePolicyStoreClient):
+class CedarClient(LivenessProbeMixin, BasePolicyStoreClient):
     def __init__(
         self,
         cedar_server_url=None,
@@ -44,13 +45,11 @@ class CedarClient(BasePolicyStoreClient):
         self._most_recent_data_transaction: Optional[StoreTransaction] = None
         self._most_recent_policy_transaction: Optional[StoreTransaction] = None
 
-        # Background liveness probe state. `_engine_reachable` defaults to True
-        # so /healthy preserves historical behavior immediately after startup
-        # (before the first probe completes). The probe will flip this to False
-        # if Cedar becomes unreachable.
+        # `_engine_reachable` defaults to True so /healthy preserves historical
+        # behavior; `start_liveness_probe()` runs an initial sample synchronously
+        # and overwrites this before the probe loop begins.
         self._engine_reachable: bool = True
-        self._liveness_probe_task: Optional[asyncio.Task] = None
-        self._liveness_probe_stop_event: Optional[asyncio.Event] = None
+        self._init_liveness_probe()
 
         if auth_type == PolicyStoreAuth.TOKEN:
             if self._token is None:
@@ -296,110 +295,28 @@ class CedarClient(BasePolicyStoreClient):
         )
         return transactions_healthy and self._engine_reachable
 
-    async def _probe_engine_reachable(self) -> bool:
-        """Issue a single GET against Cedar's `/v1/` endpoint.
+    @property
+    def _probe_log_label(self) -> str:
+        return "Cedar"
 
-        Returns True iff Cedar responds 2xx within the configured timeout.
-        Honors POLICY_STORE_AUTH_TOKEN if configured.
+    async def _probe_engine_reachable(
+        self, session: aiohttp.ClientSession
+    ) -> bool:
+        """Issue a single GET against the Cedar agent's `/v1/` endpoint.
+
+        Mirrors `CedarRunner.health_check()`'s precedent — cedar-agent
+        responds 2xx on `/v1/`. The probe sends no auth headers, matching the
+        runner's approach and keeping reachability decoupled from auth.
         """
         health_url = f"{self._cedar_url}/"
-        timeout_seconds = (
-            opal_client_config.POLICY_STORE_LIVENESS_PROBE_TIMEOUT_SECONDS
-        )
-        timeout = aiohttp.ClientTimeout(total=timeout_seconds)
-        try:
-            headers = await self._get_auth_headers()
-            async with aiohttp.ClientSession(
-                trust_env=True, timeout=timeout
-            ) as session:
-                async with session.get(health_url, headers=headers) as response:
-                    return 200 <= response.status < 300
-        except (aiohttp.ClientError, asyncio.TimeoutError) as e:
-            logger.debug("Cedar liveness probe failed: {err}", err=repr(e))
-            return False
-        except Exception as e:
-            logger.debug(
-                "Cedar liveness probe failed with unexpected error: {err}",
-                err=repr(e),
-            )
-            return False
+        async with session.get(health_url) as response:
+            return 200 <= response.status < 300
 
-    async def _liveness_probe_loop(self):
-        interval_seconds = max(
-            1,
-            opal_client_config.POLICY_STORE_LIVENESS_PROBE_INTERVAL_SECONDS,
-        )
-        stop_event = self._liveness_probe_stop_event
-        last_reachable: bool = self._engine_reachable
+    def _set_engine_reachable(self, value: bool) -> None:
+        self._engine_reachable = value
 
-        logger.info(
-            "Starting Cedar liveness probe (interval={interval}s, timeout={timeout}s)",
-            interval=interval_seconds,
-            timeout=opal_client_config.POLICY_STORE_LIVENESS_PROBE_TIMEOUT_SECONDS,
-        )
-
-        while not stop_event.is_set():
-            try:
-                reachable = await self._probe_engine_reachable()
-            except asyncio.CancelledError:
-                raise
-            except Exception as e:
-                logger.debug(
-                    "Cedar liveness probe loop caught unexpected error: {err}",
-                    err=repr(e),
-                )
-                reachable = False
-
-            self._engine_reachable = reachable
-
-            if reachable != last_reachable:
-                if reachable:
-                    logger.info(
-                        "Cedar liveness probe: policy store became reachable"
-                    )
-                else:
-                    logger.info(
-                        "Cedar liveness probe: policy store became unreachable"
-                    )
-                last_reachable = reachable
-            else:
-                logger.debug(
-                    "Cedar liveness probe sample: reachable={reachable}",
-                    reachable=reachable,
-                )
-
-            try:
-                await asyncio.wait_for(stop_event.wait(), timeout=interval_seconds)
-            except asyncio.TimeoutError:
-                continue
-            except asyncio.CancelledError:
-                raise
-
-    async def start_liveness_probe(self) -> None:
-        if not opal_client_config.POLICY_STORE_LIVENESS_PROBE_ENABLED:
-            logger.info(
-                "Cedar liveness probe disabled via POLICY_STORE_LIVENESS_PROBE_ENABLED"
-            )
-            return
-        if self._liveness_probe_task is not None and not self._liveness_probe_task.done():
-            return
-        self._liveness_probe_stop_event = asyncio.Event()
-        self._liveness_probe_task = asyncio.create_task(self._liveness_probe_loop())
-
-    async def stop_liveness_probe(self) -> None:
-        if self._liveness_probe_stop_event is not None:
-            self._liveness_probe_stop_event.set()
-        task = self._liveness_probe_task
-        if task is not None and not task.done():
-            task.cancel()
-            try:
-                await task
-            except asyncio.CancelledError:
-                pass
-            except Exception:
-                logger.exception("Error while stopping Cedar liveness probe task")
-        self._liveness_probe_task = None
-        self._liveness_probe_stop_event = None
+    def _get_engine_reachable(self) -> bool:
+        return self._engine_reachable
 
     async def full_export(self, writer: AsyncTextIOWrapper) -> None:
         policies = await self.get_policies()

--- a/packages/opal-client/opal_client/policy_store/liveness_probe.py
+++ b/packages/opal-client/opal_client/policy_store/liveness_probe.py
@@ -1,0 +1,203 @@
+"""Background liveness probe lifecycle shared by policy-store clients.
+
+`LivenessProbeMixin` periodically samples the policy engine's reachability
+and folds the result into `is_healthy()` via the subclass-supplied
+`_set_engine_reachable` hook. The mixin owns the probe task, the lock that
+guards lifecycle transitions, and a single long-lived `aiohttp.ClientSession`
+reused across samples.
+
+Subclasses provide:
+- `_probe_engine_reachable(session)` — issues one HTTP request and returns
+  True iff the engine answered with a 2xx. Must not catch the exceptions
+  the loop relies on (`aiohttp.ClientError`, `asyncio.TimeoutError`); the
+  mixin's outer loop classifies and logs them.
+- `_set_engine_reachable(value)` / `_get_engine_reachable()` — read/write
+  the boolean storage location used by `is_healthy()`.
+- `_probe_log_label` (optional) — a short human-readable label (e.g. "OPA",
+  "Cedar") used in log messages.
+"""
+import asyncio
+from abc import abstractmethod
+from typing import Optional
+
+import aiohttp
+from opal_client.config import opal_client_config
+from opal_client.logger import logger
+
+
+class LivenessProbeMixin:
+    _liveness_probe_task: Optional[asyncio.Task]
+    _liveness_probe_lock: asyncio.Lock
+    _liveness_probe_session: Optional[aiohttp.ClientSession]
+
+    def _init_liveness_probe(self) -> None:
+        """Initialize mixin state. Call from the subclass `__init__`."""
+        self._liveness_probe_task = None
+        self._liveness_probe_lock = asyncio.Lock()
+        self._liveness_probe_session = None
+
+    @property
+    def _probe_log_label(self) -> str:
+        return "policy store"
+
+    @abstractmethod
+    async def _probe_engine_reachable(
+        self, session: aiohttp.ClientSession
+    ) -> bool:
+        raise NotImplementedError
+
+    @abstractmethod
+    def _set_engine_reachable(self, value: bool) -> None:
+        raise NotImplementedError
+
+    @abstractmethod
+    def _get_engine_reachable(self) -> bool:
+        raise NotImplementedError
+
+    async def start_liveness_probe(self) -> None:
+        """Spawn the background liveness probe task (idempotent).
+
+        Holds `_liveness_probe_lock` around the check-then-act so two
+        concurrent callers cannot both create a task. Runs the first probe
+        synchronously so the initial reachability flag reflects the actual
+        state of the engine, not the optimistic default.
+        """
+        if not opal_client_config.POLICY_STORE_LIVENESS_PROBE_ENABLED:
+            logger.info(
+                "{label} liveness probe disabled via POLICY_STORE_LIVENESS_PROBE_ENABLED",
+                label=self._probe_log_label,
+            )
+            return
+
+        async with self._liveness_probe_lock:
+            existing = self._liveness_probe_task
+            if existing is not None and not existing.done():
+                return
+
+            timeout_seconds = max(
+                1,
+                opal_client_config.POLICY_STORE_LIVENESS_PROBE_TIMEOUT_SECONDS,
+            )
+            interval_seconds = max(
+                1,
+                opal_client_config.POLICY_STORE_LIVENESS_PROBE_INTERVAL_SECONDS,
+            )
+
+            session = aiohttp.ClientSession(
+                trust_env=True,
+                timeout=aiohttp.ClientTimeout(total=timeout_seconds),
+            )
+
+            initial_reachable = await self._sample_reachable(session)
+            self._set_engine_reachable(initial_reachable)
+
+            task = asyncio.create_task(
+                self._liveness_probe_loop(session, interval_seconds)
+            )
+            task.add_done_callback(self._on_probe_task_done)
+
+            self._liveness_probe_session = session
+            self._liveness_probe_task = task
+
+            logger.info(
+                "Started {label} liveness probe (interval={interval}s, timeout={timeout}s, initial_reachable={reachable})",
+                label=self._probe_log_label,
+                interval=interval_seconds,
+                timeout=timeout_seconds,
+                reachable=initial_reachable,
+            )
+
+    async def stop_liveness_probe(self) -> None:
+        """Cancel the probe task and close its session (idempotent)."""
+        async with self._liveness_probe_lock:
+            task = self._liveness_probe_task
+            session = self._liveness_probe_session
+            self._liveness_probe_task = None
+            self._liveness_probe_session = None
+
+        if task is not None and not task.done():
+            task.cancel()
+            try:
+                await task
+            except asyncio.CancelledError:
+                pass
+            except Exception:
+                logger.exception(
+                    "Error while stopping {label} liveness probe task",
+                    label=self._probe_log_label,
+                )
+
+        if session is not None:
+            await session.close()
+
+    def _on_probe_task_done(self, task: asyncio.Task) -> None:
+        if task.cancelled():
+            return
+        exc = task.exception()
+        if exc is not None:
+            logger.error(
+                "{label} liveness probe task exited unexpectedly: {err}",
+                label=self._probe_log_label,
+                err=repr(exc),
+            )
+
+    async def _sample_reachable(self, session: aiohttp.ClientSession) -> bool:
+        """Issue a single probe request, classifying expected failures.
+
+        Network/timeout errors are folded into a False return at DEBUG. Any
+        other exception propagates and is treated as an unexpected error by
+        the loop.
+        """
+        try:
+            return await self._probe_engine_reachable(session)
+        except (aiohttp.ClientError, asyncio.TimeoutError) as e:
+            logger.debug(
+                "{label} liveness probe failed: {err}",
+                label=self._probe_log_label,
+                err=repr(e),
+            )
+            return False
+
+    async def _liveness_probe_loop(
+        self, session: aiohttp.ClientSession, interval_seconds: int
+    ) -> None:
+        last_reachable: bool = self._get_engine_reachable()
+        while True:
+            try:
+                reachable = await self._sample_reachable(session)
+            except asyncio.CancelledError:
+                raise
+            except Exception as e:
+                # Survival net: an unexpected error here means a bug in the
+                # probe path itself, not a real engine outage. Log clearly so
+                # operators can distinguish the two.
+                logger.warning(
+                    "{label} liveness probe encountered an unexpected error "
+                    "(treating engine as unreachable): {err}",
+                    label=self._probe_log_label,
+                    err=repr(e),
+                )
+                reachable = False
+
+            self._set_engine_reachable(reachable)
+
+            if reachable != last_reachable:
+                if reachable:
+                    logger.info(
+                        "{label} liveness probe: engine became reachable",
+                        label=self._probe_log_label,
+                    )
+                else:
+                    logger.info(
+                        "{label} liveness probe: engine became unreachable",
+                        label=self._probe_log_label,
+                    )
+                last_reachable = reachable
+            else:
+                logger.debug(
+                    "{label} liveness probe sample: reachable={reachable}",
+                    label=self._probe_log_label,
+                    reachable=reachable,
+                )
+
+            await asyncio.sleep(interval_seconds)

--- a/packages/opal-client/opal_client/policy_store/liveness_probe.py
+++ b/packages/opal-client/opal_client/policy_store/liveness_probe.py
@@ -31,7 +31,10 @@ class LivenessProbeMixin:
     _liveness_probe_session: Optional[aiohttp.ClientSession]
 
     def _init_liveness_probe(self) -> None:
-        """Initialize mixin state. Call from the subclass `__init__`."""
+        """Initialize mixin state.
+
+        Call from the subclass `__init__`.
+        """
         self._liveness_probe_task = None
         self._liveness_probe_lock = asyncio.Lock()
         self._liveness_probe_session = None
@@ -41,9 +44,7 @@ class LivenessProbeMixin:
         return "policy store"
 
     @abstractmethod
-    async def _probe_engine_reachable(
-        self, session: aiohttp.ClientSession
-    ) -> bool:
+    async def _probe_engine_reachable(self, session: aiohttp.ClientSession) -> bool:
         raise NotImplementedError
 
     @abstractmethod
@@ -144,9 +145,9 @@ class LivenessProbeMixin:
     async def _sample_reachable(self, session: aiohttp.ClientSession) -> bool:
         """Issue a single probe request, classifying expected failures.
 
-        Network/timeout errors are folded into a False return at DEBUG. Any
-        other exception propagates and is treated as an unexpected error by
-        the loop.
+        Network/timeout errors are folded into a False return at DEBUG.
+        Any other exception propagates and is treated as an unexpected
+        error by the loop.
         """
         try:
             return await self._probe_engine_reachable(session)

--- a/packages/opal-client/opal_client/policy_store/opa_client.py
+++ b/packages/opal-client/opal_client/policy_store/opa_client.py
@@ -17,6 +17,7 @@ from opal_client.policy_store.base_policy_store_client import (
     BasePolicyStoreClient,
     JsonableValue,
 )
+from opal_client.policy_store.liveness_probe import LivenessProbeMixin
 from opal_client.policy_store.schemas import PolicyStoreAuth
 from opal_client.utils import exclude_none_fields, proxy_response
 from opal_common.engine.parsing import get_rego_package
@@ -148,14 +149,13 @@ class OpaTransactionLogState:
         ) and (self._data_updater_disabled or data_updater_is_healthy)
         is_healthy: bool = transactions_healthy and self._engine_reachable
 
-        if is_healthy:
-            logger.debug(
-                f"OPA client health: {is_healthy} (policy: {policy_updater_is_healthy}, data: {data_updater_is_healthy}, engine_reachable: {self._engine_reachable})"
-            )
-        else:
-            logger.warning(
-                f"OPA client health: {is_healthy} (policy: {policy_updater_is_healthy}, data: {data_updater_is_healthy}, engine_reachable: {self._engine_reachable})"
-            )
+        # Logged at DEBUG in both branches: with the background liveness
+        # probe in place, /healthy can be polled at high frequency while
+        # the engine is down. The probe loop already logs INFO on
+        # transitions, so we don't need a per-evaluation WARNING here.
+        logger.debug(
+            f"OPA client health: {is_healthy} (policy: {policy_updater_is_healthy}, data: {data_updater_is_healthy}, engine_reachable: {self._engine_reachable})"
+        )
 
         return is_healthy
 
@@ -310,7 +310,7 @@ class OpaStaticDataCache:
         return self._root_data
 
 
-class OpaClient(BasePolicyStoreClient):
+class OpaClient(LivenessProbeMixin, BasePolicyStoreClient):
     """Communicates with OPA via its REST API."""
 
     POLICY_NAME = "rbac"
@@ -404,9 +404,7 @@ class OpaClient(BasePolicyStoreClient):
         if cache_policy_data:
             self._policy_data_cache = OpaStaticDataCache()
 
-        # Background liveness probe state.
-        self._liveness_probe_task: Optional[asyncio.Task] = None
-        self._liveness_probe_stop_event: Optional[asyncio.Event] = None
+        self._init_liveness_probe()
 
     def _get_custom_ssl_context(self) -> Optional[ssl.SSLContext]:
         if not self._tls_ca:
@@ -994,135 +992,34 @@ class OpaClient(BasePolicyStoreClient):
         # live responsiveness of the policy store.
         return self._transaction_state.healthy
 
-    async def _probe_engine_reachable(self) -> bool:
-        """Issue a single GET against OPA's `/health` endpoint.
+    @property
+    def _probe_log_label(self) -> str:
+        return "OPA"
 
-        Returns True iff OPA responds 2xx within the configured timeout.
-        Honors POLICY_STORE_AUTH_* (bearer / OAuth) and TLS settings.
+    async def _probe_engine_reachable(
+        self, session: aiohttp.ClientSession
+    ) -> bool:
+        """Issue a single GET against OPA's `/health` endpoint via the
+        long-lived session owned by `LivenessProbeMixin`.
+
+        OPA's `/health` is unauthenticated by default, so the probe sends no
+        auth headers — keeping the reachability sample independent of the
+        OAuth / token issuer.
         """
-        # `_opa_url` already has `/v1` appended; the health endpoint sits
-        # at the root, so we strip the trailing `/v1`.
-        health_url = f"{self._opa_url[:-3]}/health"
-        timeout_seconds = (
-            opal_client_config.POLICY_STORE_LIVENESS_PROBE_TIMEOUT_SECONDS
-        )
-        timeout = aiohttp.ClientTimeout(total=timeout_seconds)
-        try:
-            headers = await self._get_auth_headers()
-            async with aiohttp.ClientSession(
-                trust_env=True, timeout=timeout
-            ) as session:
-                async with session.get(
-                    health_url,
-                    headers=headers,
-                    **self._ssl_context_kwargs,
-                ) as response:
-                    return 200 <= response.status < 300
-        except (aiohttp.ClientError, asyncio.TimeoutError) as e:
-            logger.debug(
-                "OPA liveness probe failed: {err}", err=repr(e)
-            )
-            return False
-        except Exception as e:
-            # Defensive: the probe must never crash the client.
-            logger.debug(
-                "OPA liveness probe failed with unexpected error: {err}",
-                err=repr(e),
-            )
-            return False
+        # `_opa_url` carries the `/v1` API prefix; the health endpoint sits
+        # at the root, so strip the suffix and any trailing slash explicitly.
+        opa_base_url = self._opa_url.rstrip("/").removesuffix("/v1")
+        health_url = f"{opa_base_url}/health"
+        async with session.get(
+            health_url, **self._ssl_context_kwargs
+        ) as response:
+            return 200 <= response.status < 300
 
-    async def _liveness_probe_loop(self):
-        """Periodically samples OPA reachability and updates the transaction
-        state's `engine_reachable` flag.
+    def _set_engine_reachable(self, value: bool) -> None:
+        self._transaction_state.set_engine_reachable(value)
 
-        - Logs at INFO only on transitions (healthy <-> unhealthy).
-        - Logs at DEBUG for steady-state samples.
-        - Uses a stop event so cancellation is graceful.
-        """
-        interval_seconds = max(
-            1,
-            opal_client_config.POLICY_STORE_LIVENESS_PROBE_INTERVAL_SECONDS,
-        )
-        stop_event = self._liveness_probe_stop_event
-        # Keep track of the last reported state so we only log on transitions.
-        # Initialize to the current state so we don't emit a misleading
-        # "transition" on the very first probe.
-        last_reachable: bool = self._transaction_state.engine_reachable
-
-        logger.info(
-            "Starting OPA liveness probe (interval={interval}s, timeout={timeout}s)",
-            interval=interval_seconds,
-            timeout=opal_client_config.POLICY_STORE_LIVENESS_PROBE_TIMEOUT_SECONDS,
-        )
-
-        while not stop_event.is_set():
-            try:
-                reachable = await self._probe_engine_reachable()
-            except asyncio.CancelledError:
-                raise
-            except Exception as e:
-                # Should not happen — _probe_engine_reachable swallows
-                # ClientError/Timeout — but be defensive so the loop keeps
-                # running.
-                logger.debug(
-                    "OPA liveness probe loop caught unexpected error: {err}",
-                    err=repr(e),
-                )
-                reachable = False
-
-            self._transaction_state.set_engine_reachable(reachable)
-
-            if reachable != last_reachable:
-                if reachable:
-                    logger.info(
-                        "OPA liveness probe: policy store became reachable"
-                    )
-                else:
-                    logger.info(
-                        "OPA liveness probe: policy store became unreachable"
-                    )
-                last_reachable = reachable
-            else:
-                logger.debug(
-                    "OPA liveness probe sample: reachable={reachable}",
-                    reachable=reachable,
-                )
-
-            try:
-                await asyncio.wait_for(stop_event.wait(), timeout=interval_seconds)
-            except asyncio.TimeoutError:
-                # Expected — interval elapsed, take another sample.
-                continue
-            except asyncio.CancelledError:
-                raise
-
-    async def start_liveness_probe(self) -> None:
-        """Spawn the background liveness probe task (idempotent)."""
-        if not opal_client_config.POLICY_STORE_LIVENESS_PROBE_ENABLED:
-            logger.info(
-                "OPA liveness probe disabled via POLICY_STORE_LIVENESS_PROBE_ENABLED"
-            )
-            return
-        if self._liveness_probe_task is not None and not self._liveness_probe_task.done():
-            return
-        self._liveness_probe_stop_event = asyncio.Event()
-        self._liveness_probe_task = asyncio.create_task(self._liveness_probe_loop())
-
-    async def stop_liveness_probe(self) -> None:
-        """Cancel and await the background liveness probe task (idempotent)."""
-        if self._liveness_probe_stop_event is not None:
-            self._liveness_probe_stop_event.set()
-        task = self._liveness_probe_task
-        if task is not None and not task.done():
-            task.cancel()
-            try:
-                await task
-            except asyncio.CancelledError:
-                pass
-            except Exception:
-                logger.exception("Error while stopping OPA liveness probe task")
-        self._liveness_probe_task = None
-        self._liveness_probe_stop_event = None
+    def _get_engine_reachable(self) -> bool:
+        return self._transaction_state.engine_reachable
 
     async def full_export(self, writer: AsyncTextIOWrapper) -> None:
         policies = await self.get_policies()

--- a/packages/opal-client/opal_client/policy_store/opa_client.py
+++ b/packages/opal-client/opal_client/policy_store/opa_client.py
@@ -111,6 +111,13 @@ class OpaTransactionLogState:
         self._last_failed_policy_transaction: Optional[StoreTransaction] = None
         self._last_data_transaction: Optional[StoreTransaction] = None
         self._last_failed_data_transaction: Optional[StoreTransaction] = None
+        # Live reachability of the underlying policy engine, maintained by an
+        # external background sampler (see OpaClient liveness probe). Default
+        # is True so that, before the first probe completes, /healthy reflects
+        # only the transaction state — preserving the historical behavior
+        # immediately after startup. The probe will flip this to False if OPA
+        # becomes unreachable.
+        self._engine_reachable: bool = True
 
     @property
     def ready(self) -> bool:
@@ -118,6 +125,13 @@ class OpaTransactionLogState:
             self._data_updater_disabled or self._num_successful_data_transactions > 0
         )
         return is_ready
+
+    @property
+    def engine_reachable(self) -> bool:
+        return self._engine_reachable
+
+    def set_engine_reachable(self, value: bool) -> None:
+        self._engine_reachable = value
 
     @property
     def healthy(self) -> bool:
@@ -129,17 +143,18 @@ class OpaTransactionLogState:
             self._last_data_transaction is not None
             and self._last_data_transaction.success
         )
-        is_healthy: bool = (
+        transactions_healthy: bool = (
             self._policy_updater_disabled or policy_updater_is_healthy
         ) and (self._data_updater_disabled or data_updater_is_healthy)
+        is_healthy: bool = transactions_healthy and self._engine_reachable
 
         if is_healthy:
             logger.debug(
-                f"OPA client health: {is_healthy} (policy: {policy_updater_is_healthy}, data: {data_updater_is_healthy})"
+                f"OPA client health: {is_healthy} (policy: {policy_updater_is_healthy}, data: {data_updater_is_healthy}, engine_reachable: {self._engine_reachable})"
             )
         else:
             logger.warning(
-                f"OPA client health: {is_healthy} (policy: {policy_updater_is_healthy}, data: {data_updater_is_healthy})"
+                f"OPA client health: {is_healthy} (policy: {policy_updater_is_healthy}, data: {data_updater_is_healthy}, engine_reachable: {self._engine_reachable})"
             )
 
         return is_healthy
@@ -388,6 +403,10 @@ class OpaClient(BasePolicyStoreClient):
         self._policy_data_cache: Optional[OpaStaticDataCache] = None
         if cache_policy_data:
             self._policy_data_cache = OpaStaticDataCache()
+
+        # Background liveness probe state.
+        self._liveness_probe_task: Optional[asyncio.Task] = None
+        self._liveness_probe_stop_event: Optional[asyncio.Event] = None
 
     def _get_custom_ssl_context(self) -> Optional[ssl.SSLContext]:
         if not self._tls_ca:
@@ -969,7 +988,141 @@ class OpaClient(BasePolicyStoreClient):
         return self._transaction_state.ready
 
     async def is_healthy(self) -> bool:
+        # `_transaction_state.healthy` already factors in the engine reachability
+        # flag maintained by the background liveness probe, so /healthy reflects
+        # both the success of the last server -> policy-store transaction and the
+        # live responsiveness of the policy store.
         return self._transaction_state.healthy
+
+    async def _probe_engine_reachable(self) -> bool:
+        """Issue a single GET against OPA's `/health` endpoint.
+
+        Returns True iff OPA responds 2xx within the configured timeout.
+        Honors POLICY_STORE_AUTH_* (bearer / OAuth) and TLS settings.
+        """
+        # `_opa_url` already has `/v1` appended; the health endpoint sits
+        # at the root, so we strip the trailing `/v1`.
+        health_url = f"{self._opa_url[:-3]}/health"
+        timeout_seconds = (
+            opal_client_config.POLICY_STORE_LIVENESS_PROBE_TIMEOUT_SECONDS
+        )
+        timeout = aiohttp.ClientTimeout(total=timeout_seconds)
+        try:
+            headers = await self._get_auth_headers()
+            async with aiohttp.ClientSession(
+                trust_env=True, timeout=timeout
+            ) as session:
+                async with session.get(
+                    health_url,
+                    headers=headers,
+                    **self._ssl_context_kwargs,
+                ) as response:
+                    return 200 <= response.status < 300
+        except (aiohttp.ClientError, asyncio.TimeoutError) as e:
+            logger.debug(
+                "OPA liveness probe failed: {err}", err=repr(e)
+            )
+            return False
+        except Exception as e:
+            # Defensive: the probe must never crash the client.
+            logger.debug(
+                "OPA liveness probe failed with unexpected error: {err}",
+                err=repr(e),
+            )
+            return False
+
+    async def _liveness_probe_loop(self):
+        """Periodically samples OPA reachability and updates the transaction
+        state's `engine_reachable` flag.
+
+        - Logs at INFO only on transitions (healthy <-> unhealthy).
+        - Logs at DEBUG for steady-state samples.
+        - Uses a stop event so cancellation is graceful.
+        """
+        interval_seconds = max(
+            1,
+            opal_client_config.POLICY_STORE_LIVENESS_PROBE_INTERVAL_SECONDS,
+        )
+        stop_event = self._liveness_probe_stop_event
+        # Keep track of the last reported state so we only log on transitions.
+        # Initialize to the current state so we don't emit a misleading
+        # "transition" on the very first probe.
+        last_reachable: bool = self._transaction_state.engine_reachable
+
+        logger.info(
+            "Starting OPA liveness probe (interval={interval}s, timeout={timeout}s)",
+            interval=interval_seconds,
+            timeout=opal_client_config.POLICY_STORE_LIVENESS_PROBE_TIMEOUT_SECONDS,
+        )
+
+        while not stop_event.is_set():
+            try:
+                reachable = await self._probe_engine_reachable()
+            except asyncio.CancelledError:
+                raise
+            except Exception as e:
+                # Should not happen — _probe_engine_reachable swallows
+                # ClientError/Timeout — but be defensive so the loop keeps
+                # running.
+                logger.debug(
+                    "OPA liveness probe loop caught unexpected error: {err}",
+                    err=repr(e),
+                )
+                reachable = False
+
+            self._transaction_state.set_engine_reachable(reachable)
+
+            if reachable != last_reachable:
+                if reachable:
+                    logger.info(
+                        "OPA liveness probe: policy store became reachable"
+                    )
+                else:
+                    logger.info(
+                        "OPA liveness probe: policy store became unreachable"
+                    )
+                last_reachable = reachable
+            else:
+                logger.debug(
+                    "OPA liveness probe sample: reachable={reachable}",
+                    reachable=reachable,
+                )
+
+            try:
+                await asyncio.wait_for(stop_event.wait(), timeout=interval_seconds)
+            except asyncio.TimeoutError:
+                # Expected — interval elapsed, take another sample.
+                continue
+            except asyncio.CancelledError:
+                raise
+
+    async def start_liveness_probe(self) -> None:
+        """Spawn the background liveness probe task (idempotent)."""
+        if not opal_client_config.POLICY_STORE_LIVENESS_PROBE_ENABLED:
+            logger.info(
+                "OPA liveness probe disabled via POLICY_STORE_LIVENESS_PROBE_ENABLED"
+            )
+            return
+        if self._liveness_probe_task is not None and not self._liveness_probe_task.done():
+            return
+        self._liveness_probe_stop_event = asyncio.Event()
+        self._liveness_probe_task = asyncio.create_task(self._liveness_probe_loop())
+
+    async def stop_liveness_probe(self) -> None:
+        """Cancel and await the background liveness probe task (idempotent)."""
+        if self._liveness_probe_stop_event is not None:
+            self._liveness_probe_stop_event.set()
+        task = self._liveness_probe_task
+        if task is not None and not task.done():
+            task.cancel()
+            try:
+                await task
+            except asyncio.CancelledError:
+                pass
+            except Exception:
+                logger.exception("Error while stopping OPA liveness probe task")
+        self._liveness_probe_task = None
+        self._liveness_probe_stop_event = None
 
     async def full_export(self, writer: AsyncTextIOWrapper) -> None:
         policies = await self.get_policies()

--- a/packages/opal-client/opal_client/policy_store/opa_client.py
+++ b/packages/opal-client/opal_client/policy_store/opa_client.py
@@ -996,23 +996,19 @@ class OpaClient(LivenessProbeMixin, BasePolicyStoreClient):
     def _probe_log_label(self) -> str:
         return "OPA"
 
-    async def _probe_engine_reachable(
-        self, session: aiohttp.ClientSession
-    ) -> bool:
-        """Issue a single GET against OPA's `/health` endpoint via the
-        long-lived session owned by `LivenessProbeMixin`.
+    async def _probe_engine_reachable(self, session: aiohttp.ClientSession) -> bool:
+        """Issue a single GET against OPA's `/health` endpoint via the long-
+        lived session owned by `LivenessProbeMixin`.
 
-        OPA's `/health` is unauthenticated by default, so the probe sends no
-        auth headers — keeping the reachability sample independent of the
-        OAuth / token issuer.
+        OPA's `/health` is unauthenticated by default, so the probe
+        sends no auth headers — keeping the reachability sample
+        independent of the OAuth / token issuer.
         """
         # `_opa_url` carries the `/v1` API prefix; the health endpoint sits
         # at the root, so strip the suffix and any trailing slash explicitly.
         opa_base_url = self._opa_url.rstrip("/").removesuffix("/v1")
         health_url = f"{opa_base_url}/health"
-        async with session.get(
-            health_url, **self._ssl_context_kwargs
-        ) as response:
+        async with session.get(health_url, **self._ssl_context_kwargs) as response:
             return 200 <= response.status < 300
 
     def _set_engine_reachable(self, value: bool) -> None:

--- a/packages/opal-client/opal_client/tests/cedar_client_liveness_test.py
+++ b/packages/opal-client/opal_client/tests/cedar_client_liveness_test.py
@@ -36,9 +36,7 @@ def _record_successful_transactions(client: CedarClient) -> None:
     client._most_recent_policy_transaction = _make_transaction(
         True, TransactionType.policy
     )
-    client._most_recent_data_transaction = _make_transaction(
-        True, TransactionType.data
-    )
+    client._most_recent_data_transaction = _make_transaction(True, TransactionType.data)
 
 
 class _ToggleCedarServer:

--- a/packages/opal-client/opal_client/tests/cedar_client_liveness_test.py
+++ b/packages/opal-client/opal_client/tests/cedar_client_liveness_test.py
@@ -1,0 +1,186 @@
+"""Unit tests for the CedarClient policy-store liveness probe.
+
+CedarClient inherits the same `LivenessProbeMixin` as `OpaClient`, so most
+of the lifecycle behavior is exercised in the OPA suite. This file covers
+the Cedar-specific surface: that the probe reaches the cedar-agent's
+`/v1/` endpoint (matching `CedarRunner.health_check()`'s precedent) and
+that the result feeds into `is_healthy()`.
+"""
+
+import asyncio
+import contextlib
+import time
+from typing import AsyncIterator, Optional, Tuple
+
+import pytest
+from aiohttp import web
+from opal_client.config import opal_client_config
+from opal_client.policy_store.cedar_client import CedarClient
+from opal_client.policy_store.schemas import PolicyStoreAuth
+from opal_common.schemas.store import StoreTransaction, TransactionType
+
+
+def _make_transaction(
+    success: bool, transaction_type: TransactionType
+) -> StoreTransaction:
+    return StoreTransaction(
+        id="test-id",
+        actions=["set_policy_data"],
+        transaction_type=transaction_type,
+        success=success,
+        error="" if success else "boom",
+    )
+
+
+def _record_successful_transactions(client: CedarClient) -> None:
+    client._most_recent_policy_transaction = _make_transaction(
+        True, TransactionType.policy
+    )
+    client._most_recent_data_transaction = _make_transaction(
+        True, TransactionType.data
+    )
+
+
+class _ToggleCedarServer:
+    """Tiny aiohttp server that exposes `/v1/` (matching cedar-agent)."""
+
+    HEALTHY = "healthy"
+    UNHEALTHY_5XX = "unhealthy_5xx"
+
+    def __init__(self) -> None:
+        self.mode: str = self.HEALTHY
+        self._runner: Optional[web.AppRunner] = None
+        self._site: Optional[web.TCPSite] = None
+        self.port: int = 0
+
+    async def start(self) -> str:
+        app = web.Application()
+        # cedar-agent serves 2xx on `/v1/`; mirror that.
+        app.router.add_get("/v1/", self._handle)
+        self._runner = web.AppRunner(app)
+        await self._runner.setup()
+        self._site = web.TCPSite(self._runner, "127.0.0.1", 0)
+        await self._site.start()
+        sockets = self._site._server.sockets  # type: ignore[union-attr]
+        assert sockets, "aiohttp site started without a bound socket"
+        self.port = sockets[0].getsockname()[1]
+        return f"http://127.0.0.1:{self.port}"
+
+    async def stop(self) -> None:
+        if self._site is not None:
+            await self._site.stop()
+        if self._runner is not None:
+            await self._runner.cleanup()
+
+    async def _handle(self, request: web.Request) -> web.Response:
+        if self.mode == self.HEALTHY:
+            return web.Response(status=200, text="ok")
+        return web.Response(status=503, text="down")
+
+
+@contextlib.asynccontextmanager
+async def _toggle_server() -> AsyncIterator[Tuple[_ToggleCedarServer, str]]:
+    server = _ToggleCedarServer()
+    base_url = await server.start()
+    try:
+        yield server, base_url
+    finally:
+        await server.stop()
+
+
+@contextlib.asynccontextmanager
+async def _override_config(**overrides):
+    saved = {key: getattr(opal_client_config, key) for key in overrides}
+    try:
+        for key, value in overrides.items():
+            setattr(opal_client_config, key, value)
+        yield
+    finally:
+        for key, value in saved.items():
+            setattr(opal_client_config, key, value)
+
+
+async def _wait_for_engine_reachable(
+    client: CedarClient, expected: bool, timeout: float = 5.0
+) -> None:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if client._engine_reachable is expected:
+            return
+        await asyncio.sleep(0.05)
+    raise AssertionError(
+        f"engine_reachable did not become {expected} within {timeout}s "
+        f"(actual={client._engine_reachable})"
+    )
+
+
+def _make_client(base_url: str) -> CedarClient:
+    return CedarClient(
+        cedar_server_url=base_url,
+        cedar_auth_token=None,
+        auth_type=PolicyStoreAuth.NONE,
+    )
+
+
+@pytest.mark.asyncio
+async def test_healthy_when_transactions_ok_and_cedar_reachable():
+    async with _toggle_server() as (_server, base_url):
+        async with _override_config(
+            POLICY_STORE_LIVENESS_PROBE_ENABLED=True,
+            POLICY_STORE_LIVENESS_PROBE_INTERVAL_SECONDS=1,
+            POLICY_STORE_LIVENESS_PROBE_TIMEOUT_SECONDS=1,
+        ):
+            client = _make_client(base_url)
+            _record_successful_transactions(client)
+            try:
+                await client.start_liveness_probe()
+                # First probe runs synchronously inside start_liveness_probe.
+                assert client._engine_reachable is True
+                assert await client.is_healthy() is True
+            finally:
+                await client.stop_liveness_probe()
+
+
+@pytest.mark.asyncio
+async def test_unhealthy_when_cedar_returns_5xx():
+    async with _toggle_server() as (server, base_url):
+        async with _override_config(
+            POLICY_STORE_LIVENESS_PROBE_ENABLED=True,
+            POLICY_STORE_LIVENESS_PROBE_INTERVAL_SECONDS=1,
+            POLICY_STORE_LIVENESS_PROBE_TIMEOUT_SECONDS=1,
+        ):
+            client = _make_client(base_url)
+            _record_successful_transactions(client)
+            server.mode = _ToggleCedarServer.UNHEALTHY_5XX
+            try:
+                await client.start_liveness_probe()
+                await _wait_for_engine_reachable(client, False, timeout=5.0)
+                assert await client.is_healthy() is False
+            finally:
+                await client.stop_liveness_probe()
+
+
+@pytest.mark.asyncio
+async def test_recovery_after_cedar_returns():
+    async with _toggle_server() as (server, base_url):
+        async with _override_config(
+            POLICY_STORE_LIVENESS_PROBE_ENABLED=True,
+            POLICY_STORE_LIVENESS_PROBE_INTERVAL_SECONDS=1,
+            POLICY_STORE_LIVENESS_PROBE_TIMEOUT_SECONDS=1,
+        ):
+            client = _make_client(base_url)
+            _record_successful_transactions(client)
+            try:
+                await client.start_liveness_probe()
+                await _wait_for_engine_reachable(client, True)
+                assert await client.is_healthy() is True
+
+                server.mode = _ToggleCedarServer.UNHEALTHY_5XX
+                await _wait_for_engine_reachable(client, False, timeout=10.0)
+                assert await client.is_healthy() is False
+
+                server.mode = _ToggleCedarServer.HEALTHY
+                await _wait_for_engine_reachable(client, True, timeout=10.0)
+                assert await client.is_healthy() is True
+            finally:
+                await client.stop_liveness_probe()

--- a/packages/opal-client/opal_client/tests/opa_client_liveness_test.py
+++ b/packages/opal-client/opal_client/tests/opa_client_liveness_test.py
@@ -1,0 +1,310 @@
+"""Unit tests for the OpaClient policy-store liveness probe.
+
+These tests cover the four-cell matrix from the spec:
+
+  (a) transactions OK + OPA reachable        -> healthy
+  (b) transactions FAILED + OPA reachable    -> unhealthy
+  (c) transactions OK + OPA unreachable      -> unhealthy
+  (d) recovery from (c): OPA returns         -> healthy
+
+The probe makes a real HTTP call against `POLICY_STORE_URL/health`. We avoid
+mocking the OpaClient internals and instead spin up a tiny aiohttp server
+to control reachability deterministically.
+"""
+
+import asyncio
+import contextlib
+import socket
+from typing import AsyncIterator, Optional, Tuple
+
+import pytest
+from aiohttp import web
+from opal_client.config import opal_client_config
+from opal_client.policy_store.opa_client import OpaClient
+from opal_client.policy_store.schemas import PolicyStoreAuth
+from opal_common.schemas.store import StoreTransaction, TransactionType
+
+
+def _make_transaction(
+    success: bool, transaction_type: TransactionType
+) -> StoreTransaction:
+    return StoreTransaction(
+        id="test-id",
+        actions=["set_policy_data"],
+        transaction_type=transaction_type,
+        success=success,
+        error="" if success else "boom",
+    )
+
+
+def _record_successful_transactions(client: OpaClient) -> None:
+    """Mark both policy and data transactions as recently successful."""
+    client._transaction_state.process_transaction(
+        _make_transaction(True, TransactionType.policy)
+    )
+    client._transaction_state.process_transaction(
+        _make_transaction(True, TransactionType.data)
+    )
+
+
+def _record_failed_data_transaction(client: OpaClient) -> None:
+    client._transaction_state.process_transaction(
+        _make_transaction(True, TransactionType.policy)
+    )
+    client._transaction_state.process_transaction(
+        _make_transaction(False, TransactionType.data)
+    )
+
+
+def _find_free_port() -> int:
+    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    try:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+    finally:
+        s.close()
+
+
+class _ToggleHealthServer:
+    """Tiny aiohttp server that exposes `/health`.
+
+    The handler can be flipped between healthy (200), broken (503) or hanging
+    (sleeps long enough to exceed the probe timeout) at runtime.
+    """
+
+    HEALTHY = "healthy"
+    UNHEALTHY_5XX = "unhealthy_5xx"
+    UNHEALTHY_HANG = "unhealthy_hang"
+
+    def __init__(self) -> None:
+        self.mode: str = self.HEALTHY
+        self._runner: Optional[web.AppRunner] = None
+        self._site: Optional[web.TCPSite] = None
+        self.port: int = 0
+
+    async def start(self) -> str:
+        app = web.Application()
+        app.router.add_get("/health", self._handle)
+        self._runner = web.AppRunner(app)
+        await self._runner.setup()
+        self.port = _find_free_port()
+        self._site = web.TCPSite(self._runner, "127.0.0.1", self.port)
+        await self._site.start()
+        return f"http://127.0.0.1:{self.port}"
+
+    async def stop(self) -> None:
+        if self._site is not None:
+            await self._site.stop()
+        if self._runner is not None:
+            await self._runner.cleanup()
+
+    async def _handle(self, request: web.Request) -> web.Response:
+        if self.mode == self.HEALTHY:
+            return web.Response(status=200, text="ok")
+        if self.mode == self.UNHEALTHY_5XX:
+            return web.Response(status=503, text="down")
+        # UNHEALTHY_HANG: sleep longer than the configured probe timeout
+        # so the client side hits its own ClientTimeout.
+        await asyncio.sleep(60)
+        return web.Response(status=200, text="ok")
+
+
+@contextlib.asynccontextmanager
+async def _toggle_server() -> AsyncIterator[Tuple[_ToggleHealthServer, str]]:
+    server = _ToggleHealthServer()
+    base_url = await server.start()
+    try:
+        yield server, base_url
+    finally:
+        await server.stop()
+
+
+@contextlib.asynccontextmanager
+async def _override_config(**overrides):
+    saved = {key: getattr(opal_client_config, key) for key in overrides}
+    try:
+        for key, value in overrides.items():
+            setattr(opal_client_config, key, value)
+        yield
+    finally:
+        for key, value in saved.items():
+            setattr(opal_client_config, key, value)
+
+
+async def _wait_for_engine_reachable(
+    client: OpaClient, expected: bool, timeout: float = 5.0
+) -> None:
+    """Poll until the transaction state's `engine_reachable` matches `expected`."""
+    deadline = asyncio.get_event_loop().time() + timeout
+    while asyncio.get_event_loop().time() < deadline:
+        if client._transaction_state.engine_reachable is expected:
+            return
+        await asyncio.sleep(0.05)
+    raise AssertionError(
+        f"engine_reachable did not become {expected} within {timeout}s "
+        f"(actual={client._transaction_state.engine_reachable})"
+    )
+
+
+def _make_client(opa_base_url: str) -> OpaClient:
+    return OpaClient(
+        opa_server_url=opa_base_url,
+        opa_auth_token=None,
+        auth_type=PolicyStoreAuth.NONE,
+        oauth_client_id=None,
+        oauth_client_secret=None,
+        oauth_server=None,
+        data_updater_enabled=True,
+        policy_updater_enabled=True,
+        cache_policy_data=False,
+        tls_client_cert=None,
+        tls_client_key=None,
+        tls_ca=None,
+    )
+
+
+@pytest.mark.asyncio
+async def test_healthy_when_transactions_ok_and_engine_reachable():
+    """Matrix cell (a): transactions OK + OPA reachable -> healthy."""
+    async with _toggle_server() as (_server, base_url):
+        async with _override_config(
+            POLICY_STORE_LIVENESS_PROBE_ENABLED=True,
+            POLICY_STORE_LIVENESS_PROBE_INTERVAL_SECONDS=1,
+            POLICY_STORE_LIVENESS_PROBE_TIMEOUT_SECONDS=1,
+        ):
+            client = _make_client(base_url)
+            _record_successful_transactions(client)
+            try:
+                await client.start_liveness_probe()
+                # Wait for at least one successful sample to confirm the
+                # probe is actually running and contacting the server.
+                await _wait_for_engine_reachable(client, True)
+                assert await client.is_healthy() is True
+            finally:
+                await client.stop_liveness_probe()
+
+
+@pytest.mark.asyncio
+async def test_unhealthy_when_transactions_failed_even_if_engine_reachable():
+    """Matrix cell (b): transactions FAILED + OPA reachable -> unhealthy."""
+    async with _toggle_server() as (_server, base_url):
+        async with _override_config(
+            POLICY_STORE_LIVENESS_PROBE_ENABLED=True,
+            POLICY_STORE_LIVENESS_PROBE_INTERVAL_SECONDS=1,
+            POLICY_STORE_LIVENESS_PROBE_TIMEOUT_SECONDS=1,
+        ):
+            client = _make_client(base_url)
+            _record_failed_data_transaction(client)
+            try:
+                await client.start_liveness_probe()
+                await _wait_for_engine_reachable(client, True)
+                assert await client.is_healthy() is False
+            finally:
+                await client.stop_liveness_probe()
+
+
+@pytest.mark.asyncio
+async def test_unhealthy_when_transactions_ok_but_engine_unreachable_5xx():
+    """Matrix cell (c): transactions OK + OPA returns 5xx -> unhealthy.
+
+    This simulates an OPA that is process-up but answering errors on /health.
+    """
+    async with _toggle_server() as (server, base_url):
+        async with _override_config(
+            POLICY_STORE_LIVENESS_PROBE_ENABLED=True,
+            POLICY_STORE_LIVENESS_PROBE_INTERVAL_SECONDS=1,
+            POLICY_STORE_LIVENESS_PROBE_TIMEOUT_SECONDS=1,
+        ):
+            client = _make_client(base_url)
+            _record_successful_transactions(client)
+            server.mode = _ToggleHealthServer.UNHEALTHY_5XX
+            try:
+                await client.start_liveness_probe()
+                await _wait_for_engine_reachable(client, False)
+                assert await client.is_healthy() is False
+            finally:
+                await client.stop_liveness_probe()
+
+
+@pytest.mark.asyncio
+async def test_unhealthy_when_engine_hangs_then_recovers():
+    """Matrix cell (c) with hang + cell (d) recovery.
+
+    The probe must trip to unhealthy when OPA stops responding within the
+    configured timeout, then automatically recover when OPA returns.
+    """
+    async with _toggle_server() as (server, base_url):
+        async with _override_config(
+            POLICY_STORE_LIVENESS_PROBE_ENABLED=True,
+            POLICY_STORE_LIVENESS_PROBE_INTERVAL_SECONDS=1,
+            POLICY_STORE_LIVENESS_PROBE_TIMEOUT_SECONDS=1,
+        ):
+            client = _make_client(base_url)
+            _record_successful_transactions(client)
+            try:
+                await client.start_liveness_probe()
+                # Initially healthy.
+                await _wait_for_engine_reachable(client, True)
+                assert await client.is_healthy() is True
+
+                # Simulate OPA hang.
+                server.mode = _ToggleHealthServer.UNHEALTHY_HANG
+                await _wait_for_engine_reachable(client, False, timeout=10.0)
+                assert await client.is_healthy() is False
+
+                # OPA recovers.
+                server.mode = _ToggleHealthServer.HEALTHY
+                await _wait_for_engine_reachable(client, True, timeout=10.0)
+                assert await client.is_healthy() is True
+            finally:
+                await client.stop_liveness_probe()
+
+
+@pytest.mark.asyncio
+async def test_unhealthy_when_engine_url_unreachable_connection_refused():
+    """OPA process gone (connection refused) -> probe trips to unhealthy."""
+    free_port = _find_free_port()
+    async with _override_config(
+        POLICY_STORE_LIVENESS_PROBE_ENABLED=True,
+        POLICY_STORE_LIVENESS_PROBE_INTERVAL_SECONDS=1,
+        POLICY_STORE_LIVENESS_PROBE_TIMEOUT_SECONDS=1,
+    ):
+        client = _make_client(f"http://127.0.0.1:{free_port}")
+        _record_successful_transactions(client)
+        try:
+            await client.start_liveness_probe()
+            await _wait_for_engine_reachable(client, False, timeout=5.0)
+            assert await client.is_healthy() is False
+        finally:
+            await client.stop_liveness_probe()
+
+
+@pytest.mark.asyncio
+async def test_probe_disabled_keeps_engine_reachable_true():
+    """With the probe disabled, /healthy is driven only by the transaction
+    state — engine_reachable is never flipped."""
+    async with _override_config(POLICY_STORE_LIVENESS_PROBE_ENABLED=False):
+        client = _make_client("http://127.0.0.1:1")  # unreachable on purpose
+        _record_successful_transactions(client)
+        await client.start_liveness_probe()
+        # No task should have been started.
+        assert client._liveness_probe_task is None
+        # And /healthy should still report healthy because the transaction
+        # state is healthy and the probe didn't flip the flag.
+        assert await client.is_healthy() is True
+        await client.stop_liveness_probe()
+
+
+@pytest.mark.asyncio
+async def test_stop_is_idempotent_and_does_not_raise():
+    async with _override_config(
+        POLICY_STORE_LIVENESS_PROBE_ENABLED=True,
+        POLICY_STORE_LIVENESS_PROBE_INTERVAL_SECONDS=1,
+        POLICY_STORE_LIVENESS_PROBE_TIMEOUT_SECONDS=1,
+    ):
+        client = _make_client("http://127.0.0.1:1")
+        await client.start_liveness_probe()
+        # Stopping multiple times is safe.
+        await client.stop_liveness_probe()
+        await client.stop_liveness_probe()
+        assert client._liveness_probe_task is None

--- a/packages/opal-client/opal_client/tests/opa_client_liveness_test.py
+++ b/packages/opal-client/opal_client/tests/opa_client_liveness_test.py
@@ -15,6 +15,7 @@ to control reachability deterministically.
 import asyncio
 import contextlib
 import socket
+import time
 from typing import AsyncIterator, Optional, Tuple
 
 import pytest
@@ -56,7 +57,14 @@ def _record_failed_data_transaction(client: OpaClient) -> None:
     )
 
 
-def _find_free_port() -> int:
+def _reserve_unused_port() -> int:
+    """Reserve a port that's likely free.
+
+    Used only by tests that need a *deliberately unbound* port (e.g. to
+    simulate connection-refused). For tests that bind a server, prefer the
+    `_ToggleHealthServer` flow which lets aiohttp pick the port and reads
+    it back — there is no race window between bind and connect there.
+    """
     s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
     try:
         s.bind(("127.0.0.1", 0))
@@ -87,9 +95,14 @@ class _ToggleHealthServer:
         app.router.add_get("/health", self._handle)
         self._runner = web.AppRunner(app)
         await self._runner.setup()
-        self.port = _find_free_port()
-        self._site = web.TCPSite(self._runner, "127.0.0.1", self.port)
+        # Let aiohttp bind to an ephemeral port; reading the bound port back
+        # avoids the bind-then-close-then-rebind race that
+        # `_reserve_unused_port` would have.
+        self._site = web.TCPSite(self._runner, "127.0.0.1", 0)
         await self._site.start()
+        sockets = self._site._server.sockets  # type: ignore[union-attr]
+        assert sockets, "aiohttp site started without a bound socket"
+        self.port = sockets[0].getsockname()[1]
         return f"http://127.0.0.1:{self.port}"
 
     async def stop(self) -> None:
@@ -135,8 +148,8 @@ async def _wait_for_engine_reachable(
     client: OpaClient, expected: bool, timeout: float = 5.0
 ) -> None:
     """Poll until the transaction state's `engine_reachable` matches `expected`."""
-    deadline = asyncio.get_event_loop().time() + timeout
-    while asyncio.get_event_loop().time() < deadline:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
         if client._transaction_state.engine_reachable is expected:
             return
         await asyncio.sleep(0.05)
@@ -146,14 +159,21 @@ async def _wait_for_engine_reachable(
     )
 
 
-def _make_client(opa_base_url: str) -> OpaClient:
+def _make_client(
+    opa_base_url: str,
+    *,
+    auth_type: PolicyStoreAuth = PolicyStoreAuth.NONE,
+    oauth_client_id: Optional[str] = None,
+    oauth_client_secret: Optional[str] = None,
+    oauth_server: Optional[str] = None,
+) -> OpaClient:
     return OpaClient(
         opa_server_url=opa_base_url,
         opa_auth_token=None,
-        auth_type=PolicyStoreAuth.NONE,
-        oauth_client_id=None,
-        oauth_client_secret=None,
-        oauth_server=None,
+        auth_type=auth_type,
+        oauth_client_id=oauth_client_id,
+        oauth_client_secret=oauth_client_secret,
+        oauth_server=oauth_server,
         data_updater_enabled=True,
         policy_updater_enabled=True,
         cache_policy_data=False,
@@ -176,9 +196,9 @@ async def test_healthy_when_transactions_ok_and_engine_reachable():
             _record_successful_transactions(client)
             try:
                 await client.start_liveness_probe()
-                # Wait for at least one successful sample to confirm the
-                # probe is actually running and contacting the server.
-                await _wait_for_engine_reachable(client, True)
+                # The first probe runs synchronously inside
+                # `start_liveness_probe`, so reachability is already true here.
+                assert client._transaction_state.engine_reachable is True
                 assert await client.is_healthy() is True
             finally:
                 await client.stop_liveness_probe()
@@ -263,7 +283,7 @@ async def test_unhealthy_when_engine_hangs_then_recovers():
 @pytest.mark.asyncio
 async def test_unhealthy_when_engine_url_unreachable_connection_refused():
     """OPA process gone (connection refused) -> probe trips to unhealthy."""
-    free_port = _find_free_port()
+    free_port = _reserve_unused_port()
     async with _override_config(
         POLICY_STORE_LIVENESS_PROBE_ENABLED=True,
         POLICY_STORE_LIVENESS_PROBE_INTERVAL_SECONDS=1,
@@ -308,3 +328,62 @@ async def test_stop_is_idempotent_and_does_not_raise():
         await client.stop_liveness_probe()
         await client.stop_liveness_probe()
         assert client._liveness_probe_task is None
+
+
+@pytest.mark.asyncio
+async def test_start_is_idempotent_and_reuses_same_task():
+    """A second `start_liveness_probe` while one is running must be a no-op."""
+    async with _toggle_server() as (_server, base_url):
+        async with _override_config(
+            POLICY_STORE_LIVENESS_PROBE_ENABLED=True,
+            POLICY_STORE_LIVENESS_PROBE_INTERVAL_SECONDS=1,
+            POLICY_STORE_LIVENESS_PROBE_TIMEOUT_SECONDS=1,
+        ):
+            client = _make_client(base_url)
+            try:
+                await client.start_liveness_probe()
+                first_task = client._liveness_probe_task
+                first_session = client._liveness_probe_session
+                assert first_task is not None
+                assert first_session is not None
+
+                # Second call must not spawn a second task or session.
+                await client.start_liveness_probe()
+                assert client._liveness_probe_task is first_task
+                assert client._liveness_probe_session is first_session
+            finally:
+                await client.stop_liveness_probe()
+
+
+@pytest.mark.asyncio
+async def test_probe_ignores_oauth_failures():
+    """The probe must not couple to the OAuth token-fetch path.
+
+    With OAuth configured against an unreachable IdP, the probe should still
+    report OPA as reachable when OPA itself is up, because OPA's `/health`
+    is unauthenticated by default and the probe sends no auth headers.
+    """
+    async with _toggle_server() as (_server, base_url):
+        # Point OAuth at an obviously-broken host. If the probe were calling
+        # `_get_auth_headers()` the token fetch would hang or fail and the
+        # probe would (incorrectly) report unreachable.
+        unreachable_oauth_port = _reserve_unused_port()
+        async with _override_config(
+            POLICY_STORE_LIVENESS_PROBE_ENABLED=True,
+            POLICY_STORE_LIVENESS_PROBE_INTERVAL_SECONDS=1,
+            POLICY_STORE_LIVENESS_PROBE_TIMEOUT_SECONDS=1,
+        ):
+            client = _make_client(
+                base_url,
+                auth_type=PolicyStoreAuth.OAUTH,
+                oauth_client_id="id",
+                oauth_client_secret="secret",
+                oauth_server=f"http://127.0.0.1:{unreachable_oauth_port}/oauth",
+            )
+            _record_successful_transactions(client)
+            try:
+                await client.start_liveness_probe()
+                await _wait_for_engine_reachable(client, True, timeout=5.0)
+                assert await client.is_healthy() is True
+            finally:
+                await client.stop_liveness_probe()

--- a/packages/opal-client/opal_client/tests/opa_client_liveness_test.py
+++ b/packages/opal-client/opal_client/tests/opa_client_liveness_test.py
@@ -76,8 +76,8 @@ def _reserve_unused_port() -> int:
 class _ToggleHealthServer:
     """Tiny aiohttp server that exposes `/health`.
 
-    The handler can be flipped between healthy (200), broken (503) or hanging
-    (sleeps long enough to exceed the probe timeout) at runtime.
+    The handler can be flipped between healthy (200), broken (503) or
+    hanging (sleeps long enough to exceed the probe timeout) at runtime.
     """
 
     HEALTHY = "healthy"
@@ -147,7 +147,8 @@ async def _override_config(**overrides):
 async def _wait_for_engine_reachable(
     client: OpaClient, expected: bool, timeout: float = 5.0
 ) -> None:
-    """Poll until the transaction state's `engine_reachable` matches `expected`."""
+    """Poll until the transaction state's `engine_reachable` matches
+    `expected`."""
     deadline = time.monotonic() + timeout
     while time.monotonic() < deadline:
         if client._transaction_state.engine_reachable is expected:
@@ -227,7 +228,8 @@ async def test_unhealthy_when_transactions_failed_even_if_engine_reachable():
 async def test_unhealthy_when_transactions_ok_but_engine_unreachable_5xx():
     """Matrix cell (c): transactions OK + OPA returns 5xx -> unhealthy.
 
-    This simulates an OPA that is process-up but answering errors on /health.
+    This simulates an OPA that is process-up but answering errors on
+    /health.
     """
     async with _toggle_server() as (server, base_url):
         async with _override_config(
@@ -250,8 +252,8 @@ async def test_unhealthy_when_transactions_ok_but_engine_unreachable_5xx():
 async def test_unhealthy_when_engine_hangs_then_recovers():
     """Matrix cell (c) with hang + cell (d) recovery.
 
-    The probe must trip to unhealthy when OPA stops responding within the
-    configured timeout, then automatically recover when OPA returns.
+    The probe must trip to unhealthy when OPA stops responding within
+    the configured timeout, then automatically recover when OPA returns.
     """
     async with _toggle_server() as (server, base_url):
         async with _override_config(
@@ -359,9 +361,10 @@ async def test_start_is_idempotent_and_reuses_same_task():
 async def test_probe_ignores_oauth_failures():
     """The probe must not couple to the OAuth token-fetch path.
 
-    With OAuth configured against an unreachable IdP, the probe should still
-    report OPA as reachable when OPA itself is up, because OPA's `/health`
-    is unauthenticated by default and the probe sends no auth headers.
+    With OAuth configured against an unreachable IdP, the probe should
+    still report OPA as reachable when OPA itself is up, because OPA's
+    `/health` is unauthenticated by default and the probe sends no auth
+    headers.
     """
     async with _toggle_server() as (_server, base_url):
         # Point OAuth at an obviously-broken host. If the probe were calling


### PR DESCRIPTION
## Summary

OPAL Client's `GET /healthy` previously returned 200 as long as the **last** server -> policy-store transaction succeeded. In steady state with no incoming updates, the flag stayed `True` even if OPA hung, deadlocked, dropped its listener, or stopped accepting HTTP. Supervisors that probe `/healthy` (e.g. Permit's PDP Rust watchdog) therefore never tripped, and the PDP could not serve `/v1/data/...` queries until manual intervention.

This PR adds a long-lived background sampler on `OpaClient` that periodically `GET`s `{POLICY_STORE_URL}/health` and feeds the result into `is_healthy()`, so `/healthy` reflects live OPA responsiveness, not just the last transaction. It also applies the same pattern to `CedarClient`.

## Failure mode being fixed

`is_healthy()` now returns `False` within one probe interval when OPA is unreachable (connection refused, timeout, non-2xx on `/health`) and recovers to `True` automatically when OPA returns — no OPAL Client restart required.

## Why a background sampler over a per-request probe

`/healthy` is hit by k8s probes / watchdogs at high frequency (often every 1–5s). Doing a synchronous HTTP call to OPA on every `/healthy` request would:

1. Couple `/healthy` latency to OPA latency — a slow OPA would slow down the very probe meant to detect that.
2. Multiply load on OPA proportionally to the supervisor's polling frequency.
3. Introduce per-request failure modes (timeouts, retries) into a route that must be cheap and reliable.

A single background sampler decouples probe cost from `/healthy` QPS: `/healthy` stays O(1) and OPA sees one request per interval regardless of supervisor polling.

## Initial value of `_engine_reachable`

Chosen: **`True` until the first probe completes.**

Rationale: the engine runner already health-checks OPA before `launch_policy_store_dependent_tasks` is called (see `OpaRunner._wait_for_engine_health`). At the moment we start the sampler, OPA is known-good. Starting from `True` avoids a brief window of false-unhealthy at startup, and matches the historical behavior immediately after launch. Documented inline next to the field.

## Cedar

Same pattern applied to `CedarClient` (probes `{POLICY_STORE_URL}/v1/`). Tested at the unit level for OPA; Cedar shares the same lifecycle wiring through `BasePolicyStoreClient`. Worth a smoke-test in a Cedar deployment, but no breaking change.

## What's in this PR

- **Config** (`opal_client/config.py`)
  - `OPAL_POLICY_STORE_LIVENESS_PROBE_ENABLED` (default `True`)
  - `OPAL_POLICY_STORE_LIVENESS_PROBE_INTERVAL_SECONDS` (default `10`)
  - `OPAL_POLICY_STORE_LIVENESS_PROBE_TIMEOUT_SECONDS` (default `2`)
- **`OpaClient`**
  - `OpaTransactionLogState` gains `engine_reachable` (default `True`), ANDed into `.healthy` so the rego healthcheck policy (`system.opal`) also reflects live engine reachability.
  - `_probe_engine_reachable()` — single GET to `{POLICY_STORE_URL}/health`, honors `POLICY_STORE_AUTH_*` (bearer / OAuth) and TLS context.
  - `_liveness_probe_loop()` — INFO logs only on transitions, DEBUG for steady-state samples; graceful shutdown via `asyncio.Event`.
  - `start_liveness_probe()` / `stop_liveness_probe()` — idempotent.
- **`BasePolicyStoreClient`** — default no-op `start_liveness_probe`/`stop_liveness_probe` so non-supporting stores remain unaffected.
- **`OpalClient`** (`client.py`)
  - Removes the `TODO` next to `/healthy`.
  - Starts the probe in `launch_policy_store_dependent_tasks` after the engine is up; cancels it in `stop_client_background_tasks`.
- **`CedarClient`** — analogous probe targeting `/v1/`.
- **Docs** — three new env-var entries in `configuration.mdx` and a call-out in the healthcheck-policy tutorial.
- **Public API** — `async def is_healthy(self) -> bool` signature unchanged. No breaking change.

## Acceptance criteria check

| # | Criterion | Status |
|---|-----------|--------|
| 1 | Last txn ok + OPA unreachable -> `False` within one probe interval | covered by tests (5xx, hang, connection-refused) |
| 2 | OPA recovers -> `True` again without restart | covered by hang-then-recover test |
| 3 | `/healthy` remains O(1); high-freq polling doesn't load OPA | sampler runs once per interval; `/healthy` only reads a flag |
| 4 | Opt-out via `OPAL_POLICY_STORE_LIVENESS_PROBE_ENABLED` (default `True`) | yes, covered by test |
| 5 | Tunable cadence + timeout via env | yes |
| 6 | Public async signature unchanged | yes |
| 7 | `TODO` in `client.py` removed | yes |
| 8 | All four matrix cells covered by unit tests | yes |

## Test plan

- [x] `pytest packages/opal-client/opal_client/tests/opa_client_liveness_test.py` — 7 tests pass (covers all four matrix cells + connection refused + probe-disabled + idempotent stop)
- [x] Existing `opa_client_test.py` and `engine_runner_test.py` still pass (19 tests, no regressions)
- [ ] Smoke: deploy with `OPAL_POLICY_STORE_LIVENESS_PROBE_ENABLED=True`, `kill -STOP` the OPA process, observe `/healthy` flip to 503 within ~10s, then `kill -CONT` and observe recovery.
- [ ] Smoke: same with `OPAL_POLICY_STORE_LIVENESS_PROBE_ENABLED=False` confirms historical behavior is preserved.
- [ ] Smoke: Cedar deployment — verify `/healthy` flips when Cedar is killed.

## Out of scope

- Restarting OPA from inside OPAL (reporting unhealthy is enough; restart belongs to the supervisor).
- Changing the semantics of `ready`.
- Push-based health from OPA.