### PR TITLE
fix(docker): bump OPA and EOPA versions to address CVEs

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -88,7 +88,8 @@ WORKDIR /opal
 
 # copy opa from official docker image
 ARG opa_image=openpolicyagent/opa
-ARG opa_tag=1.9.0-static
+# Bumped from 1.9.0-static to fix CVE-2025-68121 (golang/stdlib@1.25.1 -> Go 1.26.2)
+ARG opa_tag=1.16.1-static
 RUN skopeo copy "docker://${opa_image}:${opa_tag}" docker-archive:./image.tar && \
   mkdir image && tar xf image.tar -C ./image && cat image/*.tar | tar xf - -C ./image -i && \
   find image/ -name "opa*" -type f -executable -print0 | xargs -0 -I "{}" cp {} ./opa && chmod 755 ./opa && \
@@ -125,7 +126,10 @@ RUN apk add --no-cache wget
 WORKDIR /download
 
 # Download pre-built EOPA binary based on architecture
-ARG eopa_tag=v1.44.0
+# Bumped from v1.44.0 to latest available release.
+# TODO: CVE-2026-33815 and CVE-2026-33816 (jackc/pgx/v5@5.7.6, fix: >= 5.9.0) are NOT resolved.
+#       EOPA v1.45.1 still ships pgx v5.7.6. Waiting for a new EOPA release from Styra with updated dependencies.
+ARG eopa_tag=v1.45.1
 ARG TARGETARCH
 RUN case "${TARGETARCH}" in \
         "amd64") EOPA_ARCH="x86_64" ;; \


### PR DESCRIPTION
## Summary
- **OPA**: `1.9.0-static` → `1.16.1-static` — fixes **CVE-2025-68121** (golang/stdlib@1.25.1, built with Go 1.26.2)
- **EOPA**: `v1.44.0` → `v1.45.1` — bumped to latest available release

## Resolved CVEs
| CVE | Image | Dependency | Fix |
|-----|-------|-----------|-----|
| CVE-2025-68121 | `permitio/opal-client` | `golang/stdlib@1.25.1` | OPA 1.16.1 built with Go 1.26.2 (>= required 1.25.7) |

## Unresolved CVEs
| CVE | Image | Dependency | Required fix |
|-----|-------|-----------|-------------|
| CVE-2026-33815 | `permitio/opal-client-eopa` | `jackc/pgx/v5@5.7.6` | pgx >= 5.9.0 |
| CVE-2026-33816 | `permitio/opal-client-eopa` | `jackc/pgx/v5@5.7.6` | pgx >= 5.9.0 |

**Why are these unresolved?**
The `pgx/v5` dependency is internal to Enterprise OPA (EOPA), which is a closed-source binary from Styra. Both EOPA v1.44.0 and v1.45.1 (latest available release with published binaries) ship `pgx v5.7.6` — confirmed by inspecting the embedded Go module info (`go version -m`) in both binaries. A new EOPA release from Styra with updated dependencies is required to resolve these CVEs.

## Test plan
- [ ] Verify opal-client image builds successfully with OPA 1.16.1
- [ ] Verify opal-client-eopa image builds successfully with EOPA v1.45.1
- [ ] Run e2e tests to confirm OPA health check and data API work as expected
- [ ] After build, rescan images with Docker Scout to confirm CVE-2025-68121 is resolved

🤖 Generated with [Claude Code](https://claude.com/claude-code)