### PR TITLE
docs: add OPA playground query example

### DIFF
--- a/documentation/docs/getting-started/quickstart/opal-playground/send-queries-to-opa.mdx
+++ b/documentation/docs/getting-started/quickstart/opal-playground/send-queries-to-opa.mdx
@@ -34,6 +34,28 @@ The expected response should be like the one below.
 
 With some user data gathered, let's now issue an **authorization** query. In OPA, an authorization query is a query **with input**.
 
+You can also inspect the loaded data in the OPA playground UI at [`http://localhost:8181/`](http://localhost:8181/).
+
+For example, paste this query into the query field and click **Execute**:
+
+```rego
+data.users[i].roles[_] = "admin"
+```
+
+The expected result should show the user that has the `admin` role in the example [`data.json`](https://github.com/permitio/opal-example-policy-repo/blob/master/data.json):
+
+```json
+{
+  "result": [
+    {
+      "i": "alice"
+    }
+  ]
+}
+```
+
+This is a quick way to confirm that OPAL loaded the example data into OPA before sending authorization queries with input.
+
 This below query asks whether the user `bob` can `read` the `finance` resource, where the id of the object is `id123`.
 
 ```bash


### PR DESCRIPTION
## Fixes Issue

Closes #242

## Changes proposed

- Add an OPA playground UI query example to the OPAL Playground quickstart.
- Show the query for finding users with the `admin` role.
- Link the expected result back to the example policy repo `data.json` so readers can see where `alice` comes from.

## Check List (Check all the applicable boxes) <!-- Follow the above conventions to check the box -->

- [x] I sign off on contributing this submission to open-source
- [x] My code follows the code style of this project.
- [x] My change requires changes to the documentation.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] This PR does not contain plagiarized content.
- [x] The title of my pull request is a short description of the requested changes.

## Screenshots

Not applicable; docs text only.

## Note to reviewers

Verification:

- Checked the current `permitio/opal-example-policy-repo` `data.json` and `rbac.rego` via GitHub API before adding the query/result.
- `yarn install --frozen-lockfile` in `documentation/`
- `yarn build` in `documentation/`

The docs build passed. It still reports existing broken anchors on unrelated pages, including `#compose-recap`, `#generate-secret`, and several tutorial anchors.

This was implemented with Codex assistance and manually reviewed before opening the PR.