### PR TITLE
fix(fetcher): release fetched payload after each worker iteration

### DIFF
--- a/packages/opal-common/opal_common/fetcher/engine/fetch_worker.py
+++ b/packages/opal-common/opal_common/fetcher/engine/fetch_worker.py
@@ -25,6 +25,7 @@ async def fetch_worker(queue: asyncio.Queue, engine):
         # get a event from the queue
         event, callback = await queue.get()
         # take care of it
+        fetcher = res = data = None
         try:
             # get fetcher for the event
             fetcher = register.get_fetcher_for_event(event)
@@ -44,3 +45,10 @@ async def fetch_worker(queue: asyncio.Queue, engine):
         finally:
             # Notify the queue that the "work item" has been processed.
             queue.task_done()
+            # Drop references to the processed event and its (potentially large)
+            # fetched payload. Otherwise these locals stay bound in the worker's
+            # frame while it blocks on the next `queue.get()`, so every idle
+            # worker pins its last dataset + response in memory indefinitely
+            # (one retained copy per worker -> a memory high-water mark that only
+            # resets on process restart). See issues #770 / #844.
+            event = callback = fetcher = res = data = None

--- a/packages/opal-common/opal_common/fetcher/tests/fetch_worker_retention_test.py
+++ b/packages/opal-common/opal_common/fetcher/tests/fetch_worker_retention_test.py
@@ -1,0 +1,56 @@
+"""Regression test for fetch-worker frame retention (issues #770 / #844).
+
+A fetch worker loops `while True: event, callback = await queue.get(); ...`. Python
+keeps a frame's locals bound until they are reassigned or the frame exits, so an
+idle worker blocked on the next `queue.get()` used to keep the PREVIOUS fetch's
+locals (`event`, `fetcher`, `res`, `data`) alive — pinning the last fetched
+dataset (and its HTTP response) in memory, one retained copy per worker, until
+process restart. This test fails if that cleanup is removed.
+"""
+
+import asyncio
+import gc
+import weakref
+
+import pytest
+from opal_common.fetcher import FetchingEngine
+from opal_common.fetcher.fetch_provider import BaseFetchProvider
+
+
+class _Payload:
+    """A weakref-able stand-in for a large fetched dataset."""
+
+
+class _SentinelProvider(BaseFetchProvider):
+    async def _fetch_(self):
+        return _Payload()
+
+    async def _process_(self, data):
+        return data
+
+
+@pytest.mark.asyncio
+async def test_idle_worker_does_not_retain_last_payload():
+    async with FetchingEngine(worker_count=1) as engine:
+        engine.register.register_fetcher("SentinelProvider", _SentinelProvider)
+
+        result = await engine.handle_url("sentinel://x", fetcher="SentinelProvider")
+        assert isinstance(result, _Payload)
+
+        ref = weakref.ref(result)
+        del result  # drop the caller's reference
+
+        # The single worker is now idle, blocked on the next queue.get(). Its frame
+        # must not still bind the payload from the fetch it just completed.
+        collected = False
+        for _ in range(20):
+            await asyncio.sleep(0.02)
+            gc.collect()
+            if ref() is None:
+                collected = True
+                break
+
+        assert collected, (
+            "fetch worker retained the last fetched payload in its frame while idle "
+            "-> per-worker memory high-water mark (regression of #770/#844 fix)"
+        )


### PR DESCRIPTION
## Fixes Issue

Closes #844

Addresses #770: this removes what I measured to be the dominant contributor, per-worker frame retention. In a local repro each idle fetch worker pins its last fetched dataset, so retained copies == worker count (6 by default); this fix drops that to 0. Leaving #770 open to confirm against the reporter's environment, since I couldn't reproduce their exact data shape. Two smaller contributors remain and are tracked separately, out of scope here: an in-flight burst peak (#917) and a KB-scale reconnect task leak in fastapi_websocket_pubsub (permitio/fastapi_websocket_pubsub#98).

## Changes proposed

Fixes a memory high-water mark in the data fetching engine: a fetch worker held its last
fetched dataset (and HTTP response) in memory while it was idle.

- `opal_common/fetcher/engine/fetch_worker.py`: null all five per-iteration locals
  (`event`, `callback`, `fetcher`, `res`, `data`) in the worker's `finally` block, which runs
  after the exception handlers so they still see `event`, and pre-initialize
  `fetcher = res = data = None` before the `try` (those three may be unassigned if an early
  exception occurs). An idle worker now holds no payload between queue items.
- `opal_common/fetcher/tests/fetch_worker_retention_test.py` (new): a regression test that an
  idle worker does not retain its last fetched payload. It uses a weakref, so it fails if the
  cleanup is removed.

### Root cause

`fetch_worker` runs `while True: event, callback = await queue.get(); ...`. In CPython a frame
keeps its locals bound until they are reassigned or the frame exits, so a worker blocked on the
next `queue.get()` still referenced the previous iteration's `event`/`fetcher`/`res`/`data`,
which pins the last fetched dataset and its `aiohttp` response. With `FETCHING_WORKER_COUNT`
workers (default 6) this retained up to N full datasets, proportional to payload size, released
only on process restart. OPA's own memory was unaffected (the data is correctly stored there);
the retention was entirely client-side in the worker frames. That is also why it looked like a
leak yet heap inspection after things settle found nothing: the objects free as soon as a worker
handles a new item, but idle workers keep the last one.

This is the same mechanism behind both reports. #844 triggers a fetch on every reconnect
("Initial load"), and #770 triggers one on every periodic datasource refresh.

## Check List (Check all the applicable boxes)

- [x] I sign off on contributing this submission to open-source
- [x] My code follows the code style of this project.
- [ ] My change requires changes to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] This PR does not contain plagiarized content.
- [x] The title of my pull request is a short description of the requested changes.

## Screenshots

N/A. The behaviour is memory usage, quantified below.

## Note to reviewers

Before/after, from a local harness driving the real `DataUpdater` -> fetch -> store path (the included `fetch_worker_retention_test.py` reproduces this as a revert-failing
test; full RSS harness available on request):

| Scenario | Before fix | After fix |
|---|---|---|
| #844 reconnect loop (2 MB payload, 12 reconnects, default 6 workers) | staircase +~73 MB, ~6x payload retained per reconnect, never released | plateau, +~5 MB total; retained dataset copies 6 -> 1 |
| #770 periodic refresh (13 MB payload, real OPA, 12 cycles) | climbs to ~630 MB high-water mark (about 6 workers x ~80 MB), held until restart | flat ~159 MB (+0.11 MB/cycle, i.e. noise) |

The defining signature of the bug was that the retained-dataset count equalled the worker count.
After the fix the retained count is 1 (measured with the default `FETCHING_WORKER_COUNT` of 6),
and since the retention was structurally one dataset per worker it no longer scales with the
pool size. `malloc_trim` does not reclaim the pre-fix growth, which confirms genuine retention
rather than allocator fragmentation.

Correctness: the null-out is in `finally`, which runs after the `except` blocks that call
`engine._on_failure(err, event)`, so the failure handler still receives the real `event`. The
existing fetcher and `data_updater` tests pass (10), and with the new regression test all 11 pass.

Scope: this PR only changes the worker frame-retention behaviour. During the investigation I also
found a small, separate unbounded object accumulation in the pub/sub reconnect path
(`asyncio.as_completed` in `fastapi-websocket-pubsub`). It grows one task and one queue per
reconnect but is only KB-scale and lives in a different repository, so I've raised it separately
and it is not part of this change. The growth fixed here is a bounded high-water mark under
normal (gc-enabled) runtime.

CI note: the `security/snyk` check tends to error on fork PRs (org token/quota) rather than
indicating a code problem. Happy to have a maintainer re-run it.


