### PR TITLE
fix(opal-server): freeze publishes during broadcaster backbone gaps to keep the fleet consistent

### DIFF
--- a/app-tests/run.sh
+++ b/app-tests/run.sh
@@ -246,22 +246,77 @@ function check_servers_logged {
   compose logs opal_server | grep -q "$1"
 }
 
+# The negative assertions capture the logs first: piped directly into grep, a
+# failing `compose logs` (daemon hiccup, renamed service) is indistinguishable
+# from "message absent" and the check silently passes. (pipefail wouldn't help —
+# the `if pipeline; then fail; fi` shape falls through on ANY pipeline failure.)
 function check_servers_not_logged {
   echo "- Ensuring msg '$1' is absent from server's logs"
-  if compose logs opal_server | grep -q "$1"; then
+  local logs
+  logs=$(compose logs opal_server)
+  if [[ -z "$logs" ]]; then
+    echo "- Could not retrieve any server logs"
+    exit 1
+  fi
+  if grep -q "$1" <<< "$logs"; then
     echo "- Unexpectedly found '$1' in server logs:"
-    compose logs opal_server | grep "$1"
+    grep "$1" <<< "$logs"
     exit 1
   fi
 }
 
 function check_clients_not_logged {
   echo "- Ensuring msg '$1' is absent from client's logs"
-  if compose logs opal_client | grep -q "$1"; then
-    echo "- Unexpectedly found '$1' in client logs:"
-    compose logs opal_client | grep "$1"
+  local logs
+  logs=$(compose logs opal_client)
+  if [[ -z "$logs" ]]; then
+    echo "- Could not retrieve any client logs"
     exit 1
   fi
+  if grep -q "$1" <<< "$logs"; then
+    echo "- Unexpectedly found '$1' in client logs:"
+    grep "$1" <<< "$logs"
+    exit 1
+  fi
+}
+
+function wait_for_servers_logged {
+  # Poll (up to $2 seconds) until a server logs $1 — for assertions whose
+  # timing depends on periodic tasks rather than the just-issued request.
+  echo "- Waiting (up to ${2}s) for msg '$1' in server's logs"
+  for _ in $(seq 1 "$2"); do
+    if compose logs opal_server 2>/dev/null | grep -q "$1"; then
+      return 0
+    fi
+    sleep 1
+  done
+  echo "- Timed out waiting for '$1' in server logs"
+  exit 1
+}
+
+function count_backbone_drops {
+  # Lines the reconnecting reader logs when an established backbone subscription
+  # ends (clean close or error) — i.e. the moments the publish-freeze gate closes.
+  compose logs opal_server 2>/dev/null \
+    | grep -cE "Broadcast subscriber ended|Broadcaster listener error" || true
+}
+
+function wait_for_backbone_drop {
+  # Wait until a server worker OBSERVES the backbone drop (a drop-log line past
+  # the pre-kill baseline in $1): the freeze only engages once the reader's read
+  # cycle exits and clears its connected flag, so publishing after a fixed sleep
+  # races that observation.
+  echo "- Waiting for a server to observe the backbone drop"
+  local baseline=$1
+  for _ in $(seq 1 30); do
+    if (( $(count_backbone_drops) > baseline )); then
+      echo "  backbone drop observed"
+      return 0
+    fi
+    sleep 1
+  done
+  echo "  no server observed the backbone drop in time"
+  exit 1
 }
 
 function wait_for_broadcaster {
@@ -422,8 +477,9 @@ function main {
   # sources, so the freeze DROPS them (documented trade); freshness is restored by
   # re-publishing after recovery, and the fleet converges together.
   echo "- Testing cross-instance consistency across a backbone outage"
+  drops_before=$(count_backbone_drops)
   compose kill broadcast_channel
-  sleep 3
+  wait_for_backbone_drop "$drops_before"
   publish_data "consistency_user"
   sleep 2
   # The receiving server must have frozen the publish at the gate...
@@ -445,8 +501,11 @@ function main {
   # (on different replicas via the VIP) converge on the value together.
   publish_data "consistency_user"
   sleep 5
-  # The freezing server's first post-gap delivery logs the freeze-episode summary.
-  check_servers_logged "publish(es) during the gap"
+  # The freeze-episode summary is logged by the WORKER that froze, on its next
+  # delivered publish — and the re-publish above lands on 1 of N workers. In
+  # practice the exempt statistics keepalive (~10s, exercising every worker)
+  # delivers it; poll rather than assume one fixed delay covers that coupling.
+  wait_for_servers_logged "publish(es) during the gap" 30
   check_clients_logged "PUT /v1/data/users/consistency_user/location -> 204"
   # TODO: Test statistics feature again after broadcaster restart (should first fix statistics bug)
 }

--- a/app-tests/run.sh
+++ b/app-tests/run.sh
@@ -117,7 +117,10 @@ function prepare_policy_repo {
 
   # Wait for Gitea to be ready and initialized
   echo "  Waiting for Gitea to be ready..."
-  timeout=120
+  # Generous budget: gitea can take minutes to bring the web listener up on slow
+  # bind-mount I/O (e.g. Docker Desktop) — the loop exits as soon as it is ready,
+  # so fast environments (CI) pay nothing for the headroom.
+  timeout=300
   counter=0
   while ! curl -sf http://localhost:3000 > /dev/null 2>&1; do
     counter=$((counter + 1))
@@ -248,6 +251,15 @@ function check_servers_not_logged {
   if compose logs opal_server | grep -q "$1"; then
     echo "- Unexpectedly found '$1' in server logs:"
     compose logs opal_server | grep "$1"
+    exit 1
+  fi
+}
+
+function check_clients_not_logged {
+  echo "- Ensuring msg '$1' is absent from client's logs"
+  if compose logs opal_client | grep -q "$1"; then
+    echo "- Unexpectedly found '$1' in client logs:"
+    compose logs opal_client | grep "$1"
     exit 1
   fi
 }
@@ -402,24 +414,39 @@ function main {
   check_servers_not_logged "list.remove(x): x not in list"
 
   # Cross-instance consistency: publish an update WHILE the backbone is down, then
-  # recover. The two clients connect to different server replicas via the service VIP,
-  # so for BOTH to end up with the value the missed cross-server update must converge
-  # after recovery (via the replay buffer and/or the resync-on-reconnect path).
+  # recover. The two clients connect to different server replicas via the service VIP.
+  # With BROADCAST_FREEZE_ON_DISCONNECT (the default), a client-facing publish that
+  # cannot fan out to the whole fleet is FROZEN — applied by NO client — so the fleet
+  # never splits (one replica's clients seeing the update while the other's don't).
+  # One-off updates like this one are not part of the clients' configured data
+  # sources, so the freeze DROPS them (documented trade); freshness is restored by
+  # re-publishing after recovery, and the fleet converges together.
   echo "- Testing cross-instance consistency across a backbone outage"
   compose kill broadcast_channel
   sleep 3
   publish_data "consistency_user"
   sleep 2
+  # The receiving server must have frozen the publish at the gate...
+  check_servers_logged "freezing publish to preserve fleet consistency"
   compose up -d broadcast_channel
   wait_for_broadcaster
-  # allow buffered replay + (if needed) client resync + full refetch to settle
+  # allow recovery: exempt-topic replay + client resync + full refetch to settle
   sleep 15
-  # The server that received the publish while the backbone was down must have
-  # buffered it and replayed it on recovery (proves the replay path actually ran,
-  # not just a client refetch).
+  # Internal (exempt) topics still ride the pre-freeze buffer+replay path during the
+  # gap — these lines prove that path stayed intact alongside the freeze.
   check_servers_logged "buffered for replay"
   check_servers_logged "Replaying"
-  # BOTH clients (on different replicas via the VIP) must end up with the value.
+  # Recovery resynced this worker's clients (the freeze's convergence path).
+  check_servers_logged "resyncing this worker's clients"
+  # THE consistency assertion: the frozen update reached NO client — neither during
+  # the gap nor via replay after it. No fleet split.
+  check_clients_not_logged "PUT /v1/data/users/consistency_user/location -> 204"
+  # After recovery the fleet is fully functional: re-publish and BOTH clients
+  # (on different replicas via the VIP) converge on the value together.
+  publish_data "consistency_user"
+  sleep 5
+  # The freezing server's first post-gap delivery logs the freeze-episode summary.
+  check_servers_logged "publish(es) during the gap"
   check_clients_logged "PUT /v1/data/users/consistency_user/location -> 204"
   # TODO: Test statistics feature again after broadcaster restart (should first fix statistics bug)
 }

--- a/app-tests/run.sh
+++ b/app-tests/run.sh
@@ -226,10 +226,17 @@ function compose {
   docker compose -f ./docker-compose-app-tests.yml --env-file .env "$@"
 }
 
+# The positive assertions must exit explicitly on a miss: `main` runs on the
+# left of `&&` (see the retry loop), which suppresses `set -e` throughout it,
+# so a helper that merely returns grep's status can never fail the run.
 function check_clients_logged {
   echo "- Looking for msg '$1' in client's logs"
-  compose logs --index 1 opal_client | grep -q "$1"
-  compose logs --index 2 opal_client | grep -q "$1"
+  for index in 1 2; do
+    if ! compose logs --index "$index" opal_client | grep -q "$1"; then
+      echo "- '$1' not found in client $index logs"
+      exit 1
+    fi
+  done
 }
 
 function check_no_error {
@@ -243,7 +250,10 @@ function check_no_error {
 
 function check_servers_logged {
   echo "- Looking for msg '$1' in server's logs"
-  compose logs opal_server | grep -q "$1"
+  if ! compose logs opal_server | grep -q "$1"; then
+    echo "- '$1' not found in server logs"
+    exit 1
+  fi
 }
 
 # The negative assertions capture the logs first: piped directly into grep, a
@@ -516,7 +526,10 @@ RETRY_COUNT=0
 
 while [ $RETRY_COUNT -lt $MAX_RETRIES ]; do
   echo "Running test (attempt $((RETRY_COUNT+1)) of $MAX_RETRIES)..."
-  main && break
+  # Run main in a subshell: the assertion helpers fail via `exit 1` (see
+  # check_clients_logged), which would otherwise terminate the whole script
+  # through the EXIT trap and skip these retries entirely.
+  (main) && break
   RETRY_COUNT=$((RETRY_COUNT + 1))
   echo "Test failed, retrying..."
   # Tear the stack down before retrying so the next attempt starts clean:

--- a/packages/opal-server/opal_server/config.py
+++ b/packages/opal-server/opal_server/config.py
@@ -106,13 +106,18 @@ class OpalServerConfig(Confi):
     BROADCAST_FREEZE_ON_DISCONNECT = confi.bool(
         "BROADCAST_FREEZE_ON_DISCONNECT",
         True,
-        description="While the broadcaster backbone is disconnected, freeze client-facing "
-        "publishes on every worker instead of applying them locally — so a write that cannot "
-        "fan out to the whole fleet is never served by just one worker (fleet consistency "
-        "over freshness). The write still lands in its datasource and is reconciled by the "
-        "reconnect resync. Applies to source-based updates and requires "
-        "BROADCAST_RECONNECT_ENABLED. Set to False for the previous behavior, where the "
-        "receiving worker's own clients update immediately and peers only after reconnect.",
+        description="During a broadcaster backbone gap, freeze client-facing publishes on "
+        "every worker instead of applying them locally — so a write that cannot fan out to "
+        "the whole fleet is never served by just one worker (fleet consistency over "
+        "freshness). Recovery is the reconnect resync: clients re-fetch their configured "
+        "data sources and policy, so updates covered by those are reconciled; one-off "
+        "updates outside them (inline data payloads, ad-hoc fetch URLs) are DROPPED by a "
+        "freeze, not deferred. Internal coordination topics (statistics, keepalive, the git "
+        "webhook trigger) are exempt and keep the deliver-locally + buffer-for-replay "
+        "behavior. Requires BROADCAST_RECONNECT_ENABLED and BROADCAST_RESYNC_ON_RECONNECT "
+        "(if the resync is disabled, freezing is refused with a warning). Set to False for "
+        "the previous behavior, where the receiving worker's own clients update immediately "
+        "and peers only after reconnect.",
     )
 
     # server security

--- a/packages/opal-server/opal_server/config.py
+++ b/packages/opal-server/opal_server/config.py
@@ -103,6 +103,17 @@ class OpalServerConfig(Confi):
         "reader is wedged while clients depend on it. Set to False to revert "
         "/healthcheck to always returning ok.",
     )
+    BROADCAST_FREEZE_ON_DISCONNECT = confi.bool(
+        "BROADCAST_FREEZE_ON_DISCONNECT",
+        True,
+        description="While the broadcaster backbone is disconnected, freeze client-facing "
+        "publishes on every worker instead of applying them locally — so a write that cannot "
+        "fan out to the whole fleet is never served by just one worker (fleet consistency "
+        "over freshness). The write still lands in its datasource and is reconciled by the "
+        "reconnect resync. Applies to source-based updates and requires "
+        "BROADCAST_RECONNECT_ENABLED. Set to False for the previous behavior, where the "
+        "receiving worker's own clients update immediately and peers only after reconnect.",
+    )
 
     # server security
     AUTH_PRIVATE_KEY_FORMAT = confi.enum(

--- a/packages/opal-server/opal_server/config.py
+++ b/packages/opal-server/opal_server/config.py
@@ -114,8 +114,10 @@ class OpalServerConfig(Confi):
         "updates outside them (inline data payloads, ad-hoc fetch URLs) are DROPPED by a "
         "freeze, not deferred. Internal coordination topics (statistics, keepalive, the git "
         "webhook trigger) are exempt and keep the deliver-locally + buffer-for-replay "
-        "behavior. Requires BROADCAST_RECONNECT_ENABLED and BROADCAST_RESYNC_ON_RECONNECT "
-        "(if the resync is disabled, freezing is refused with a warning). Set to False for "
+        "behavior. Engages only with BROADCAST_RECONNECT_ENABLED (without the reconnecting "
+        "broadcaster there is no gap signal, so the flag is a no-op) and requires "
+        "BROADCAST_RESYNC_ON_RECONNECT (if the resync is disabled, freezing is refused "
+        "with a warning). Set to False for "
         "the previous behavior, where the receiving worker's own clients update immediately "
         "and peers only after reconnect.",
     )

--- a/packages/opal-server/opal_server/pubsub.py
+++ b/packages/opal-server/opal_server/pubsub.py
@@ -31,7 +31,11 @@ from opal_common.confi.confi import load_conf_if_none
 from opal_common.config import opal_common_config
 from opal_common.logger import logger
 from opal_server.config import opal_server_config
-from opal_server.pubsub_resilience import ReconnectingBroadcaster, SafeConnectionManager
+from opal_server.pubsub_resilience import (
+    FreezablePubSubEndpoint,
+    ReconnectingBroadcaster,
+    SafeConnectionManager,
+)
 from pydantic import BaseModel
 from starlette.datastructures import QueryParams
 
@@ -181,13 +185,17 @@ class PubSub:
         # we keep the library-safe default (True) to degrade to "stale but connected"
         # rather than the fleet-wide drop storm. (Replaces an earlier experimental
         # broadcast-connection-loss flag.)
-        self.endpoint = PubSubEndpoint(
+        self.endpoint = FreezablePubSubEndpoint(
             broadcaster=self.broadcaster,
             notifier=self.notifier,
             rpc_channel_get_remote_id=opal_common_config.STATISTICS_ENABLED,
             ignore_broadcaster_disconnected=not isinstance(
                 self.broadcaster, ReconnectingBroadcaster
             ),
+            # Freeze client-facing publishes while the backbone is down so a write that
+            # cannot reach the whole fleet is not applied on a single worker (see
+            # FreezablePubSubEndpoint). No-op unless the reconnecting broadcaster is in use.
+            freeze_on_disconnect=opal_server_config.BROADCAST_FREEZE_ON_DISCONNECT,
         )
         # fastapi_websocket_rpc's ConnectionManager.disconnect is not idempotent: the RPC
         # endpoint can call it twice for one socket (handle_disconnect plus the outer

--- a/packages/opal-server/opal_server/pubsub.py
+++ b/packages/opal-server/opal_server/pubsub.py
@@ -185,6 +185,21 @@ class PubSub:
         # we keep the library-safe default (True) to degrade to "stale but connected"
         # rather than the fleet-wide drop storm. (Replaces an earlier experimental
         # broadcast-connection-loss flag.)
+        # The reconnect resync is the freeze's ONLY recovery path (frozen publishes are
+        # dropped, not buffered) — with the resync disabled the combination would silently
+        # lose every update published during every gap, so refuse it rather than honor it.
+        freeze_on_disconnect = opal_server_config.BROADCAST_FREEZE_ON_DISCONNECT
+        if (
+            freeze_on_disconnect
+            and not opal_server_config.BROADCAST_RESYNC_ON_RECONNECT
+        ):
+            logger.warning(
+                "BROADCAST_FREEZE_ON_DISCONNECT is enabled but BROADCAST_RESYNC_ON_RECONNECT "
+                "is disabled — the resync is the freeze's only recovery path, so freezing is "
+                "DISABLED to avoid silently losing updates published during a backbone gap. "
+                "Re-enable BROADCAST_RESYNC_ON_RECONNECT to get the fleet-consistency freeze."
+            )
+            freeze_on_disconnect = False
         self.endpoint = FreezablePubSubEndpoint(
             broadcaster=self.broadcaster,
             notifier=self.notifier,
@@ -192,10 +207,14 @@ class PubSub:
             ignore_broadcaster_disconnected=not isinstance(
                 self.broadcaster, ReconnectingBroadcaster
             ),
-            # Freeze client-facing publishes while the backbone is down so a write that
-            # cannot reach the whole fleet is not applied on a single worker (see
+            # Freeze client-facing publishes during a backbone gap so a write that cannot
+            # reach the whole fleet is not applied on a single worker (see
             # FreezablePubSubEndpoint). No-op unless the reconnecting broadcaster is in use.
-            freeze_on_disconnect=opal_server_config.BROADCAST_FREEZE_ON_DISCONNECT,
+            freeze_on_disconnect=freeze_on_disconnect,
+            # The git-webhook trigger targets the server-side policy watcher, not clients —
+            # freezing it would drop repo-pull triggers with nothing to replay them (topics
+            # prefixed "__", i.e. statistics/keepalive, are exempted by the endpoint itself).
+            freeze_exempt_topics=[opal_server_config.POLICY_REPO_WEBHOOK_TOPIC],
         )
         # fastapi_websocket_rpc's ConnectionManager.disconnect is not idempotent: the RPC
         # endpoint can call it twice for one socket (handle_disconnect plus the outer

--- a/packages/opal-server/opal_server/pubsub.py
+++ b/packages/opal-server/opal_server/pubsub.py
@@ -188,18 +188,27 @@ class PubSub:
         # The reconnect resync is the freeze's ONLY recovery path (frozen publishes are
         # dropped, not buffered) — with the resync disabled the combination would silently
         # lose every update published during every gap, so refuse it rather than honor it.
+        # Both guardrails apply only where a freeze can actually engage, i.e. when the
+        # reconnecting broadcaster (the gap signal) was built above — warning a single-
+        # worker or reconnect-disabled deployment about the resync would be misdirection.
         freeze_on_disconnect = opal_server_config.BROADCAST_FREEZE_ON_DISCONNECT
-        if (
-            freeze_on_disconnect
-            and not opal_server_config.BROADCAST_RESYNC_ON_RECONNECT
+        if freeze_on_disconnect and isinstance(
+            self.broadcaster, ReconnectingBroadcaster
         ):
-            logger.warning(
-                "BROADCAST_FREEZE_ON_DISCONNECT is enabled but BROADCAST_RESYNC_ON_RECONNECT "
-                "is disabled — the resync is the freeze's only recovery path, so freezing is "
-                "DISABLED to avoid silently losing updates published during a backbone gap. "
-                "Re-enable BROADCAST_RESYNC_ON_RECONNECT to get the fleet-consistency freeze."
+            if not opal_server_config.BROADCAST_RESYNC_ON_RECONNECT:
+                logger.warning(
+                    "BROADCAST_FREEZE_ON_DISCONNECT is enabled but BROADCAST_RESYNC_ON_RECONNECT "
+                    "is disabled — the resync is the freeze's only recovery path, so freezing is "
+                    "DISABLED to avoid silently losing updates published during a backbone gap. "
+                    "Re-enable BROADCAST_RESYNC_ON_RECONNECT to get the fleet-consistency freeze."
+                )
+                freeze_on_disconnect = False
+        elif freeze_on_disconnect and self.broadcaster is not None:
+            logger.info(
+                "BROADCAST_FREEZE_ON_DISCONNECT is enabled but BROADCAST_RECONNECT_ENABLED "
+                "is disabled — the freeze engages only on the reconnecting broadcaster's "
+                "backbone-gap signal, so it is a no-op with the stock broadcaster."
             )
-            freeze_on_disconnect = False
         self.endpoint = FreezablePubSubEndpoint(
             broadcaster=self.broadcaster,
             notifier=self.notifier,
@@ -211,10 +220,21 @@ class PubSub:
             # reach the whole fleet is not applied on a single worker (see
             # FreezablePubSubEndpoint). No-op unless the reconnecting broadcaster is in use.
             freeze_on_disconnect=freeze_on_disconnect,
-            # The git-webhook trigger targets the server-side policy watcher, not clients —
-            # freezing it would drop repo-pull triggers with nothing to replay them (topics
-            # prefixed "__", i.e. statistics/keepalive, are exempted by the endpoint itself).
-            freeze_exempt_topics=[opal_server_config.POLICY_REPO_WEBHOOK_TOPIC],
+            # Exempt: the git-webhook trigger (targets the server-side policy watcher, not
+            # clients — freezing it would drop repo-pull triggers with nothing to replay
+            # them) and the server-to-server coordination channels (statistics + broadcaster
+            # keepalive — dropping those corrupts state no resync rebuilds). The coordination
+            # channels are exempted by their CONFIGURED names: the endpoint's own "__" prefix
+            # rule covers only the defaults, and every one of these is operator-overridable.
+            freeze_exempt_topics=[
+                opal_server_config.POLICY_REPO_WEBHOOK_TOPIC,
+                opal_server_config.BROADCAST_KEEPALIVE_TOPIC,
+                opal_server_config.STATISTICS_WAKEUP_CHANNEL,
+                opal_server_config.STATISTICS_STATE_SYNC_CHANNEL,
+                opal_server_config.STATISTICS_SERVER_KEEPALIVE_CHANNEL,
+                opal_common_config.STATISTICS_ADD_CLIENT_CHANNEL,
+                opal_common_config.STATISTICS_REMOVE_CLIENT_CHANNEL,
+            ],
         )
         # fastapi_websocket_rpc's ConnectionManager.disconnect is not idempotent: the RPC
         # endpoint can call it twice for one socket (handle_disconnect plus the outer

--- a/packages/opal-server/opal_server/pubsub_resilience.py
+++ b/packages/opal-server/opal_server/pubsub_resilience.py
@@ -42,7 +42,7 @@ from collections import deque
 from typing import Awaitable, Callable, Optional
 
 from fastapi import WebSocket
-from fastapi_websocket_pubsub import EventBroadcaster
+from fastapi_websocket_pubsub import EventBroadcaster, PubSubEndpoint
 from fastapi_websocket_pubsub.event_broadcaster import BroadcastNotification
 from fastapi_websocket_pubsub.event_notifier import Subscription
 from fastapi_websocket_pubsub.util import pydantic_serialize
@@ -154,6 +154,15 @@ class ReconnectingBroadcaster(EventBroadcaster):
         # Fired once if the reader gives up (exhausts reconnect retries) and returns,
         # so OPAL can graceful-restart the worker even with statistics disabled.
         self._on_give_up: Optional[ReconnectCallback] = None
+        # Live backbone-subscription state — True only while actively subscribed, so a
+        # publish right now would actually reach peer workers. Deliberately distinct from
+        # is_reader_healthy() (which stays True across a transient reconnect so the k8s probe
+        # doesn't flap): this flips False the instant the subscription drops. Read by
+        # FreezablePubSubEndpoint to freeze client-facing publishes during a gap, so a write
+        # that can't fan out to the fleet is never applied on just one worker (fleet
+        # consistency). Instance attr (not task-local): the endpoint reads it from outside
+        # the reader task.
+        self._backbone_connected = False
 
     def set_reconnect_callback(self, callback: Optional[ReconnectCallback]):
         """Register an ``async () -> None`` callback fired once after each gap
@@ -221,6 +230,22 @@ class ReconnectingBroadcaster(EventBroadcaster):
             self._subscription_task is not None and not self._subscription_task.done()
         )
 
+    def is_backbone_connected(self) -> bool:
+        """Whether the reader currently holds a live backbone subscription.
+
+        True only while actively subscribed — i.e. a publish right now would actually
+        reach peer workers. Flips False the instant the subscription drops and back to
+        True only once re-subscribed.
+
+        This is intentionally NOT ``is_reader_healthy()``: that one stays True across a
+        transient reconnect (so the k8s probe does not flap the pod), which is exactly the
+        wrong signal for gating delivery. ``FreezablePubSubEndpoint`` reads this to freeze
+        client-facing publishes while the backbone is down, so a write that cannot fan out
+        to the whole fleet is never applied on a single worker (fleet consistency; the
+        write still lands in the source of truth and is picked up by the reconnect resync).
+        """
+        return self._backbone_connected
+
     async def __broadcast_notifications__(self, subscription: Subscription, data):
         """Share a local notification with the backbone; buffer it on failure.
 
@@ -277,6 +302,9 @@ class ReconnectingBroadcaster(EventBroadcaster):
                     f"Broadcaster listener connected to channel '{self._channel}'"
                 )
                 async with channel.subscribe(channel=self._channel) as subscriber:
+                    # Subscribed: the backbone is reachable, so publishes will fan out to
+                    # peers again — reopen the publish gate (see FreezablePubSubEndpoint).
+                    self._backbone_connected = True
                     # We are subscribed again; recover concurrently so we keep reading
                     # (and can receive peers' replays) during the settle window.
                     if had_prior_connection:
@@ -317,6 +345,10 @@ class ReconnectingBroadcaster(EventBroadcaster):
                     await self._fire_give_up()
                     return
             finally:
+                # Any exit from the read cycle (backbone closed, error, or cancel) means we
+                # are no longer subscribed — close the publish gate until we re-subscribe, so
+                # a write during the gap is not applied on this worker alone.
+                self._backbone_connected = False
                 await self._safe_disconnect_channel()
             await asyncio.sleep(self._backoff_seconds(attempt))
 
@@ -532,3 +564,59 @@ class ReconnectingBroadcaster(EventBroadcaster):
         base = min(base, self._reconnect_backoff_max)
         # Equal jitter, so a fleet of pods does not reconnect to the backbone in lockstep.
         return base / 2 + random.uniform(0, base / 2)
+
+
+class FreezablePubSubEndpoint(PubSubEndpoint):
+    """A ``PubSubEndpoint`` that *freezes* client-facing publishes while the broadcaster
+    backbone is disconnected, to keep a multi-worker fleet consistent during an outage.
+
+    The problem: a server-side ``publish`` fans out two independent ways — local in-process
+    delivery to *this* worker's own clients, and (via the broadcaster) to peer workers. Only
+    the outbound path is buffered when the backbone is down; local delivery still fires. So a
+    data/policy update that reaches one worker during a backbone gap is applied to that
+    worker's clients but not the fleet — a transient split (some PDPs new, others old) that
+    lasts the whole outage.
+
+    With freeze enabled, when the broadcaster is a ``ReconnectingBroadcaster`` that is
+    currently disconnected (``is_backbone_connected()`` is False), ``publish`` is skipped
+    entirely: neither local clients nor the outbound buffer see it. The write still lands in
+    the source of truth (the datasource the update points at), and the reconnect *resync*
+    makes every worker refetch it on recovery — so the whole fleet moves together instead of
+    diverging mid-outage.
+
+    Skipping the *whole* publish (not just local delivery) also means nothing is buffered for
+    replay during the freeze, so recovery converges purely via the resync refetch with no
+    partial replayed state racing ahead of it.
+
+    Delegates straight to the base (no freeze) when: freeze is disabled; there is no
+    broadcaster (single worker — no fleet to keep consistent); or the broadcaster is the
+    stock ``EventBroadcaster`` (reconnect disabled — the legacy drop-on-disconnect path).
+
+    Scope: designed for *source-based* updates (the entry carries a URL the client refetches,
+    which is how permit's data flows). An *inline* update (data embedded in the broadcast) has
+    no source to refetch, so an inline update issued during a freeze is dropped rather than
+    deferred — accepted, since inline is legacy/unused.
+    """
+
+    def __init__(self, *args, freeze_on_disconnect: bool = True, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._freeze_on_disconnect = freeze_on_disconnect
+
+    def _should_freeze(self) -> bool:
+        broadcaster = self.broadcaster
+        return (
+            self._freeze_on_disconnect
+            and isinstance(broadcaster, ReconnectingBroadcaster)
+            and not broadcaster.is_backbone_connected()
+        )
+
+    async def publish(self, topics, data=None):
+        if self._should_freeze():
+            logger.warning(
+                "Broadcaster backbone disconnected; freezing publish to preserve fleet "
+                "consistency (not delivered to clients; reconciled via resync on reconnect). "
+                "topics={topics}",
+                topics=topics,
+            )
+            return
+        return await super().publish(topics, data)

--- a/packages/opal-server/opal_server/pubsub_resilience.py
+++ b/packages/opal-server/opal_server/pubsub_resilience.py
@@ -598,8 +598,9 @@ class ReconnectingBroadcaster(EventBroadcaster):
 
 
 class FreezablePubSubEndpoint(PubSubEndpoint):
-    """A ``PubSubEndpoint`` that *freezes* client-facing publishes during a broadcaster
-    backbone GAP, to keep a multi-worker fleet consistent through an outage.
+    """A ``PubSubEndpoint`` that *freezes* client-facing publishes during a
+    broadcaster backbone GAP, to keep a multi-worker fleet consistent through
+    an outage.
 
     The problem: a server-side ``publish`` fans out two independent ways — local in-process
     delivery to *this* worker's own clients, and (via the broadcaster) to peer workers. Only

--- a/packages/opal-server/opal_server/pubsub_resilience.py
+++ b/packages/opal-server/opal_server/pubsub_resilience.py
@@ -154,15 +154,15 @@ class ReconnectingBroadcaster(EventBroadcaster):
         # Fired once if the reader gives up (exhausts reconnect retries) and returns,
         # so OPAL can graceful-restart the worker even with statistics disabled.
         self._on_give_up: Optional[ReconnectCallback] = None
-        # Live backbone-subscription state — True only while actively subscribed, so a
-        # publish right now would actually reach peer workers. Deliberately distinct from
-        # is_reader_healthy() (which stays True across a transient reconnect so the k8s probe
-        # doesn't flap): this flips False the instant the subscription drops. Read by
-        # FreezablePubSubEndpoint to freeze client-facing publishes during a gap, so a write
-        # that can't fan out to the fleet is never applied on just one worker (fleet
-        # consistency). Instance attr (not task-local): the endpoint reads it from outside
+        # Live backbone-subscription state; see is_backbone_connected() / is_in_backbone_gap().
+        # Instance attrs (not task-local): FreezablePubSubEndpoint reads them from outside
         # the reader task.
         self._backbone_connected = False
+        # Whether this broadcaster ever held a backbone subscription — distinguishes a real
+        # GAP (had a session, lost it) from "never connected yet" (boot, or backbone down
+        # from the start), where freezing would be wrong: no resync fires on a FIRST
+        # connect, so anything frozen before it would be lost, not deferred.
+        self._had_backbone_connection = False
 
     def set_reconnect_callback(self, callback: Optional[ReconnectCallback]):
         """Register an ``async () -> None`` callback fired once after each gap
@@ -192,6 +192,13 @@ class ReconnectingBroadcaster(EventBroadcaster):
             logger.debug("No need for listen task, already started")
             return self._subscription_task
         logger.debug("Spawning reconnecting broadcast listen task")
+        # Scope gap detection to THIS reader task: a stale True from a previous task
+        # (reader cancelled when the last listener left, then restarted later) would make
+        # is_in_backbone_gap() freeze publishes before the new task's FIRST subscribe —
+        # but a first connect fires no resync, so those publishes would be lost, not
+        # deferred. Same task-scoping rationale as ``had_prior_connection`` in
+        # ``__read_notifications__``.
+        self._had_backbone_connection = False
         self._subscription_task = asyncio.create_task(self.__read_notifications__())
         return self._subscription_task
 
@@ -239,12 +246,35 @@ class ReconnectingBroadcaster(EventBroadcaster):
 
         This is intentionally NOT ``is_reader_healthy()``: that one stays True across a
         transient reconnect (so the k8s probe does not flap the pod), which is exactly the
-        wrong signal for gating delivery. ``FreezablePubSubEndpoint`` reads this to freeze
-        client-facing publishes while the backbone is down, so a write that cannot fan out
-        to the whole fleet is never applied on a single worker (fleet consistency; the
-        write still lands in the source of truth and is picked up by the reconnect resync).
+        wrong signal for gating delivery.
         """
         return self._backbone_connected
+
+    def is_in_backbone_gap(self) -> bool:
+        """Whether the broadcaster is mid-GAP: it *had* a live backbone subscription,
+        lost it, and the reader is still trying to get it back.
+
+        This — not mere "not connected" — is the publish-freeze condition used by
+        ``FreezablePubSubEndpoint``, because only a real gap has the recovery path the
+        freeze relies on (the ``on_reconnect`` resync fires exclusively for reconnects
+        that follow an established session). The two excluded states must NOT freeze:
+
+        * **Reader not running** (no listeners yet / worker idle / last client left and
+          the upstream cancelled the reader): the backbone may be perfectly healthy —
+          freezing here would silently drop publishes fleet-wide with nothing to ever
+          reconcile them. Delegating preserves the pre-freeze behavior (share-context
+          broadcast + local delivery).
+        * **Never connected in this reader's lifetime** (boot, or backbone already down
+          at startup): a FIRST successful connect fires no gap recovery, so a publish
+          frozen in this window would be lost, not deferred. Pre-freeze behavior
+          (deliver locally, buffer outbound for replay) is strictly better here.
+        """
+        return (
+            self._subscription_task is not None
+            and not self._subscription_task.done()
+            and self._had_backbone_connection
+            and not self._backbone_connected
+        )
 
     async def __broadcast_notifications__(self, subscription: Subscription, data):
         """Share a local notification with the backbone; buffer it on failure.
@@ -305,6 +335,7 @@ class ReconnectingBroadcaster(EventBroadcaster):
                     # Subscribed: the backbone is reachable, so publishes will fan out to
                     # peers again — reopen the publish gate (see FreezablePubSubEndpoint).
                     self._backbone_connected = True
+                    self._had_backbone_connection = True
                     # We are subscribed again; recover concurrently so we keep reading
                     # (and can receive peers' replays) during the settle window.
                     if had_prior_connection:
@@ -567,8 +598,8 @@ class ReconnectingBroadcaster(EventBroadcaster):
 
 
 class FreezablePubSubEndpoint(PubSubEndpoint):
-    """A ``PubSubEndpoint`` that *freezes* client-facing publishes while the broadcaster
-    backbone is disconnected, to keep a multi-worker fleet consistent during an outage.
+    """A ``PubSubEndpoint`` that *freezes* client-facing publishes during a broadcaster
+    backbone GAP, to keep a multi-worker fleet consistent through an outage.
 
     The problem: a server-side ``publish`` fans out two independent ways — local in-process
     delivery to *this* worker's own clients, and (via the broadcaster) to peer workers. Only
@@ -577,46 +608,100 @@ class FreezablePubSubEndpoint(PubSubEndpoint):
     worker's clients but not the fleet — a transient split (some PDPs new, others old) that
     lasts the whole outage.
 
-    With freeze enabled, when the broadcaster is a ``ReconnectingBroadcaster`` that is
-    currently disconnected (``is_backbone_connected()`` is False), ``publish`` is skipped
-    entirely: neither local clients nor the outbound buffer see it. The write still lands in
-    the source of truth (the datasource the update points at), and the reconnect *resync*
-    makes every worker refetch it on recovery — so the whole fleet moves together instead of
-    diverging mid-outage.
+    With freeze enabled, while the ``ReconnectingBroadcaster`` reports a real gap
+    (``is_in_backbone_gap()`` — an established backbone session was lost and is being
+    re-acquired; see its docstring for why "never connected" and "reader not running" must
+    NOT freeze), ``publish`` is skipped entirely: neither local clients nor the outbound
+    buffer see it. The write still lands in the source of truth, and the reconnect *resync*
+    makes every worker's clients refetch on recovery — the whole fleet moves together.
+    Skipping the whole publish also means nothing is buffered for replay during the freeze,
+    so recovery converges purely via the resync refetch.
 
-    Skipping the *whole* publish (not just local delivery) also means nothing is buffered for
-    replay during the freeze, so recovery converges purely via the resync refetch with no
-    partial replayed state racing ahead of it.
+    **Exempt topics** keep the pre-freeze behavior (local delivery + outbound replay buffer)
+    even mid-gap: topics prefixed ``__`` (the statistics protocol and the broadcaster
+    keepalive — dropping those corrupts server-to-server state that no resync rebuilds:
+    ghost clients, workers that never stat-sync) and any topic in ``freeze_exempt_topics``
+    (OPAL passes the git-webhook trigger topic: it targets the server-side policy watcher,
+    not clients, and a dropped trigger means the repo pull it requests simply never happens
+    — the resync would then refetch from a clone that was never advanced).
 
-    Delegates straight to the base (no freeze) when: freeze is disabled; there is no
-    broadcaster (single worker — no fleet to keep consistent); or the broadcaster is the
-    stock ``EventBroadcaster`` (reconnect disabled — the legacy drop-on-disconnect path).
+    Delegates straight to the base when: freeze is disabled; there is no broadcaster
+    (single worker); or the broadcaster is the stock ``EventBroadcaster``.
 
-    Scope: designed for *source-based* updates (the entry carries a URL the client refetches,
-    which is how permit's data flows). An *inline* update (data embedded in the broadcast) has
-    no source to refetch, so an inline update issued during a freeze is dropped rather than
-    deferred — accepted, since inline is legacy/unused.
+    **Recovery scope** (what "reconciled by the resync" actually covers): data the clients
+    re-fetch on reconnect, i.e. their configured data sources (``OPAL_DATA_CONFIG_SOURCES``
+    or scope config) and the policy bundle. One-off updates outside that set — an inline
+    ``data`` payload, or a fetch URL that is not part of the configured sources — are
+    dropped by a freeze, not deferred. Accepted trade: consistency over freshness, and such
+    updates are the legacy path.
+
+    **Known limitations** (all degrade to the PRE-freeze behavior, never worse):
+    * If the reader's subscription is alive but an individual outbound broadcast fails
+      (separate per-publish channel), the gate does not engage — that publish is delivered
+      locally and buffered for replay, the pre-existing split-until-replay behavior.
+    * The gate reopens when the subscription is re-established, before the session proves
+      "sustained" — during a rare connect-then-instant-close flap a publish can slip
+      through (deliver locally + buffer). Gating on sustained instead would wrongly freeze
+      quiet channels forever (a session only proves sustained on its first inbound event).
+    * Client-originated RPC publishes (``RpcEventServerMethods.publish``) notify the local
+      subscribers directly, bypassing this override.
     """
 
-    def __init__(self, *args, freeze_on_disconnect: bool = True, **kwargs):
+    def __init__(
+        self,
+        *args,
+        freeze_on_disconnect: bool = True,
+        freeze_exempt_topics=(),
+        **kwargs,
+    ):
         super().__init__(*args, **kwargs)
         self._freeze_on_disconnect = freeze_on_disconnect
+        self._freeze_exempt_topics = frozenset(freeze_exempt_topics)
+        # Publishes suppressed in the current freeze episode — first one logs at WARNING,
+        # the rest at DEBUG (a long outage would otherwise emit an unbounded WARNING per
+        # frozen stats keepalive), and the first delivered publish afterwards logs a
+        # summary count.
+        self._frozen_in_episode = 0
 
-    def _should_freeze(self) -> bool:
+    def _is_exempt(self, topics) -> bool:
+        if isinstance(topics, str):
+            topics = [topics]
+        return all(
+            topic.startswith("__") or topic in self._freeze_exempt_topics
+            for topic in topics
+        )
+
+    def _should_freeze(self, topics) -> bool:
         broadcaster = self.broadcaster
         return (
             self._freeze_on_disconnect
             and isinstance(broadcaster, ReconnectingBroadcaster)
-            and not broadcaster.is_backbone_connected()
+            and broadcaster.is_in_backbone_gap()
+            and not self._is_exempt(topics)
         )
 
     async def publish(self, topics, data=None):
-        if self._should_freeze():
-            logger.warning(
-                "Broadcaster backbone disconnected; freezing publish to preserve fleet "
-                "consistency (not delivered to clients; reconciled via resync on reconnect). "
-                "topics={topics}",
+        if self._should_freeze(topics):
+            self._frozen_in_episode += 1
+            log = logger.warning if self._frozen_in_episode == 1 else logger.debug
+            log(
+                "Broadcaster backbone gap; freezing publish to preserve fleet consistency "
+                "(not delivered to clients; reconciled via resync on reconnect). "
+                "topics={topics} (suppressed {count} so far this gap)",
                 topics=topics,
+                count=self._frozen_in_episode,
             )
             return
+        if self._frozen_in_episode:
+            count, self._frozen_in_episode = self._frozen_in_episode, 0
+            logger.warning(
+                "Backbone recovered; froze {count} publish(es) during the gap — clients "
+                "reconcile via the reconnect resync",
+                count=count,
+            )
         return await super().publish(topics, data)
+
+    # The library aliases ``notify = publish`` at class level (backward-compat canonical
+    # name), which binds the BASE publish — re-bind it here or ``endpoint.notify(...)``
+    # would silently bypass the freeze gate.
+    notify = publish

--- a/packages/opal-server/opal_server/pubsub_resilience.py
+++ b/packages/opal-server/opal_server/pubsub_resilience.py
@@ -154,10 +154,17 @@ class ReconnectingBroadcaster(EventBroadcaster):
         # Fired once if the reader gives up (exhausts reconnect retries) and returns,
         # so OPAL can graceful-restart the worker even with statistics disabled.
         self._on_give_up: Optional[ReconnectCallback] = None
-        # Live backbone-subscription state; see is_backbone_connected() / is_in_backbone_gap().
+        # Live backbone-subscription state; see is_in_backbone_gap(). True only while
+        # actively subscribed — i.e. a publish right now would actually reach peer
+        # workers. Deliberately a separate signal from is_reader_healthy(): that one
+        # stays True across a transient reconnect (so the k8s probe does not flap the
+        # pod), which is exactly the wrong signal for gating delivery.
         # Instance attrs (not task-local): FreezablePubSubEndpoint reads them from outside
         # the reader task.
         self._backbone_connected = False
+        # Monotonic gap counter, bumped on every connected -> disconnected edge in the
+        # reader; see backbone_gap_generation().
+        self._gap_generation = 0
         # Whether this broadcaster ever held a backbone subscription — distinguishes a real
         # GAP (had a session, lost it) from "never connected yet" (boot, or backbone down
         # from the start), where freezing would be wrong: no resync fires on a FIRST
@@ -237,18 +244,16 @@ class ReconnectingBroadcaster(EventBroadcaster):
             self._subscription_task is not None and not self._subscription_task.done()
         )
 
-    def is_backbone_connected(self) -> bool:
-        """Whether the reader currently holds a live backbone subscription.
+    def backbone_gap_generation(self) -> int:
+        """Monotonic count of backbone gaps: bumped each time an established
+        subscription drops (the connected -> disconnected edge in the reader).
 
-        True only while actively subscribed — i.e. a publish right now would actually
-        reach peer workers. Flips False the instant the subscription drops and back to
-        True only once re-subscribed.
-
-        This is intentionally NOT ``is_reader_healthy()``: that one stays True across a
-        transient reconnect (so the k8s probe does not flap the pod), which is exactly the
-        wrong signal for gating delivery.
+        Lets ``FreezablePubSubEndpoint`` tell two back-to-back gaps apart even when no
+        publish is delivered between them (recovery itself never publishes — the resync
+        closes client sockets and clients refetch), so each gap opens its own freeze
+        episode instead of merging into the previous one.
         """
-        return self._backbone_connected
+        return self._gap_generation
 
     def is_in_backbone_gap(self) -> bool:
         """Whether the broadcaster is mid-GAP: it *had* a live backbone subscription,
@@ -378,7 +383,11 @@ class ReconnectingBroadcaster(EventBroadcaster):
             finally:
                 # Any exit from the read cycle (backbone closed, error, or cancel) means we
                 # are no longer subscribed — close the publish gate until we re-subscribe, so
-                # a write during the gap is not applied on this worker alone.
+                # a write during the gap is not applied on this worker alone. An established
+                # subscription ending here is a NEW gap: bump the generation so freeze
+                # episodes never span two gaps.
+                if self._backbone_connected:
+                    self._gap_generation += 1
                 self._backbone_connected = False
                 await self._safe_disconnect_channel()
             await asyncio.sleep(self._backoff_seconds(attempt))
@@ -620,11 +629,13 @@ class FreezablePubSubEndpoint(PubSubEndpoint):
 
     **Exempt topics** keep the pre-freeze behavior (local delivery + outbound replay buffer)
     even mid-gap: topics prefixed ``__`` (the statistics protocol and the broadcaster
-    keepalive — dropping those corrupts server-to-server state that no resync rebuilds:
-    ghost clients, workers that never stat-sync) and any topic in ``freeze_exempt_topics``
-    (OPAL passes the git-webhook trigger topic: it targets the server-side policy watcher,
-    not clients, and a dropped trigger means the repo pull it requests simply never happens
-    — the resync would then refetch from a clone that was never advanced).
+    keepalive under their default names — dropping those corrupts server-to-server state
+    that no resync rebuilds: ghost clients, workers that never stat-sync) and any topic in
+    ``freeze_exempt_topics``. OPAL passes the git-webhook trigger topic (it targets the
+    server-side policy watcher, not clients, and a dropped trigger means the repo pull it
+    requests simply never happens — the resync would then refetch from a clone that was
+    never advanced) plus the *configured* statistics/keepalive channel names, since those
+    are operator-overridable and the ``__`` prefix rule only covers the defaults.
 
     Delegates straight to the base when: freeze is disabled; there is no broadcaster
     (single worker); or the broadcaster is the stock ``EventBroadcaster``.
@@ -663,10 +674,19 @@ class FreezablePubSubEndpoint(PubSubEndpoint):
         # frozen stats keepalive), and the first delivered publish afterwards logs a
         # summary count.
         self._frozen_in_episode = 0
+        # Which backbone gap (backbone_gap_generation()) the open episode belongs to:
+        # a gap can end and a NEW one open before any out-of-gap publish is delivered
+        # (recovery itself never publishes), so publish() flushes the previous gap's
+        # pending summary when it sees a frozen publish from a different generation.
+        self._frozen_gap_generation: Optional[int] = None
 
     def _is_exempt(self, topics) -> bool:
         if isinstance(topics, str):
             topics = [topics]
+        if not topics:
+            # all([]) is True — an empty (or None) topic list must not slip past the
+            # gate as "exempt".
+            return False
         return all(
             topic.startswith("__") or topic in self._freeze_exempt_topics
             for topic in topics
@@ -685,7 +705,14 @@ class FreezablePubSubEndpoint(PubSubEndpoint):
 
     async def publish(self, topics, data=None):
         in_gap = self._in_frozen_gap()
-        if in_gap and not self._is_exempt(topics):
+        if self._should_freeze(topics):
+            # A new gap can open before the previous episode's summary got out
+            # (recovery itself never publishes) — flush it first, so each gap gets
+            # its own leading WARNING and its own summary count.
+            generation = self.broadcaster.backbone_gap_generation()
+            if self._frozen_in_episode and generation != self._frozen_gap_generation:
+                self._log_episode_summary()
+            self._frozen_gap_generation = generation
             self._frozen_in_episode += 1
             log = logger.warning if self._frozen_in_episode == 1 else logger.debug
             log(
@@ -699,13 +726,16 @@ class FreezablePubSubEndpoint(PubSubEndpoint):
         # Emit the episode summary only once the gap is actually over — an EXEMPT publish
         # mid-gap also reaches this point and must not reset the counter or claim recovery.
         if self._frozen_in_episode and not in_gap:
-            count, self._frozen_in_episode = self._frozen_in_episode, 0
-            logger.warning(
-                "Backbone recovered; froze {count} publish(es) during the gap — clients "
-                "reconcile via the reconnect resync",
-                count=count,
-            )
+            self._log_episode_summary()
         return await super().publish(topics, data)
+
+    def _log_episode_summary(self):
+        count, self._frozen_in_episode = self._frozen_in_episode, 0
+        logger.warning(
+            "Backbone recovered; froze {count} publish(es) during the gap — clients "
+            "reconcile via the reconnect resync",
+            count=count,
+        )
 
     # The library aliases ``notify = publish`` at class level (backward-compat canonical
     # name), which binds the BASE publish — re-bind it here or ``endpoint.notify(...)``

--- a/packages/opal-server/opal_server/pubsub_resilience.py
+++ b/packages/opal-server/opal_server/pubsub_resilience.py
@@ -673,16 +673,19 @@ class FreezablePubSubEndpoint(PubSubEndpoint):
         )
 
     def _should_freeze(self, topics) -> bool:
+        return self._in_frozen_gap() and not self._is_exempt(topics)
+
+    def _in_frozen_gap(self) -> bool:
         broadcaster = self.broadcaster
         return (
             self._freeze_on_disconnect
             and isinstance(broadcaster, ReconnectingBroadcaster)
             and broadcaster.is_in_backbone_gap()
-            and not self._is_exempt(topics)
         )
 
     async def publish(self, topics, data=None):
-        if self._should_freeze(topics):
+        in_gap = self._in_frozen_gap()
+        if in_gap and not self._is_exempt(topics):
             self._frozen_in_episode += 1
             log = logger.warning if self._frozen_in_episode == 1 else logger.debug
             log(
@@ -693,7 +696,9 @@ class FreezablePubSubEndpoint(PubSubEndpoint):
                 count=self._frozen_in_episode,
             )
             return
-        if self._frozen_in_episode:
+        # Emit the episode summary only once the gap is actually over — an EXEMPT publish
+        # mid-gap also reaches this point and must not reset the counter or claim recovery.
+        if self._frozen_in_episode and not in_gap:
             count, self._frozen_in_episode = self._frozen_in_episode, 0
             logger.warning(
                 "Backbone recovered; froze {count} publish(es) during the gap — clients "

--- a/packages/opal-server/opal_server/tests/reconnecting_broadcaster_test.py
+++ b/packages/opal-server/opal_server/tests/reconnecting_broadcaster_test.py
@@ -49,6 +49,11 @@ class FakeNotifier:
         # PubSubEndpoint.__init__ mints a server id from the notifier.
         return "fake-subscriber-id"
 
+    async def subscribe(self, *args, **kwargs):
+        # The broadcaster's sharing context registers itself on the notifier
+        # (EventBroadcaster._subscribe_to_all_topics); a no-op suffices here.
+        pass
+
 
 class FakeBus:
     """A controllable in-memory broadcast backbone for a single channel."""
@@ -859,15 +864,13 @@ def _reconnecting(bus, notifier=None):
 @pytest.mark.asyncio
 async def test_is_backbone_connected_tracks_subscription():
     """The flag is False before the reader subscribes, True while subscribed, and
-    False again once the reader stops — the exact signal the publish gate needs."""
+    False again once the reader stops."""
     bus = FakeBus()
     broadcaster = _reconnecting(bus)
     assert not broadcaster.is_backbone_connected()  # not started -> disconnected
     task = await broadcaster.start_reader_task()
     try:
-        await _wait_for(lambda: bus.subscribes >= 1)
-        await _wait_for(broadcaster.is_backbone_connected)
-        assert broadcaster.is_backbone_connected()  # subscribed -> connected
+        await _wait_for(broadcaster.is_backbone_connected)  # subscribed -> connected
     finally:
         task.cancel()
         with pytest.raises(asyncio.CancelledError):
@@ -875,29 +878,120 @@ async def test_is_backbone_connected_tracks_subscription():
     assert not broadcaster.is_backbone_connected()  # reader gone -> disconnected
 
 
-def _endpoint(broadcaster, notifier, freeze=True):
+@pytest.mark.asyncio
+async def test_is_in_backbone_gap_lifecycle():
+    """A GAP is: had a live subscription, lost it, reader still retrying. Neither
+    'never started' nor 'never yet connected' nor 'reconnected' is a gap."""
+    bus = FakeBus()
+    broadcaster = _reconnecting(bus)
+    assert not broadcaster.is_in_backbone_gap()  # never started -> not a gap
+    task = await broadcaster.start_reader_task()
+    try:
+        await _wait_for(broadcaster.is_backbone_connected)
+        assert not broadcaster.is_in_backbone_gap()  # subscribed -> not a gap
+
+        # Backbone drops and stays unavailable: block re-subscribes, then close the read.
+        bus.fail_subscribe_times = 10_000
+        await bus.drop()
+        await _wait_for(broadcaster.is_in_backbone_gap)  # GAP: had one, lost it
+
+        # Backbone returns: allow re-subscribes -> gap ends.
+        bus.fail_subscribe_times = 0
+        await _wait_for(lambda: not broadcaster.is_in_backbone_gap())
+        assert broadcaster.is_backbone_connected()
+    finally:
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+
+@pytest.mark.asyncio
+async def test_reader_restart_does_not_inherit_gap_state():
+    """A RESTARTED reader (previous one cancelled when the last listener left) must
+    start with a clean slate: its pre-first-subscribe window is 'never connected',
+    not a gap — a first connect fires no resync, so freezing there would LOSE
+    publishes rather than defer them."""
+    bus = FakeBus()
+    broadcaster = _reconnecting(bus)
+    task = await broadcaster.start_reader_task()
+    await _wait_for(broadcaster.is_backbone_connected)  # session established
+    # Last listener leaves: upstream cancels the reader and clears the task slot.
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+    broadcaster._subscription_task = None
+    # Backbone is down when a new listener restarts the reader.
+    bus.fail_subscribe_times = 10_000
+    task2 = await broadcaster.start_reader_task()
+    try:
+        await _wait_for(lambda: bus.subscribes >= 2)  # new reader is retrying
+        assert not broadcaster.is_in_backbone_gap()  # clean slate: NOT a gap
+    finally:
+        task2.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task2
+
+
+def _endpoint(broadcaster, notifier, freeze=True, exempt=()):
     return FreezablePubSubEndpoint(
-        broadcaster=broadcaster, notifier=notifier, freeze_on_disconnect=freeze
+        broadcaster=broadcaster,
+        notifier=notifier,
+        freeze_on_disconnect=freeze,
+        freeze_exempt_topics=exempt,
     )
+
+
+def _fabricate_gap(broadcaster):
+    """Put a broadcaster into the mid-gap state (had a session, lost it, reader
+    pending) without driving a real backbone. Returns the dummy reader task —
+    cancel it in the test's cleanup."""
+    dummy = asyncio.get_event_loop().create_task(asyncio.sleep(60))
+    broadcaster._subscription_task = dummy
+    broadcaster._had_backbone_connection = True
+    broadcaster._backbone_connected = False
+    return dummy
 
 
 @pytest.mark.asyncio
 async def test_should_freeze_matrix():
-    """The gate freezes only when: freeze enabled AND a ReconnectingBroadcaster AND the
-    backbone is currently disconnected. Every other combination delegates normally."""
+    """Freeze only when: enabled AND ReconnectingBroadcaster AND mid-GAP AND a
+    non-exempt topic. Everything else delegates normally."""
     bus = FakeBus()
-    b = _reconnecting(bus)  # not started -> is_backbone_connected() is False
+    topics = ["policy_data"]
 
-    # disconnected reconnecting broadcaster + freeze on -> FREEZE
-    assert _endpoint(b, FakeNotifier(), freeze=True)._should_freeze() is True
-    # freeze disabled -> never
-    assert _endpoint(b, FakeNotifier(), freeze=False)._should_freeze() is False
-    # connected -> never
-    b._backbone_connected = True
-    assert _endpoint(b, FakeNotifier(), freeze=True)._should_freeze() is False
-    b._backbone_connected = False
+    # never-started reader -> NOT a gap -> no freeze (healthy idle worker must not drop)
+    b = _reconnecting(bus)
+    assert _endpoint(b, FakeNotifier())._should_freeze(topics) is False
+    # reader running but never yet connected (boot / backbone down from the start) -> no
+    # freeze: no resync fires on a FIRST connect, so a frozen publish would be lost.
+    dummy = _fabricate_gap(b)
+    b._had_backbone_connection = False
+    try:
+        assert _endpoint(b, FakeNotifier())._should_freeze(topics) is False
+        # a real gap (had a session, lost it) -> FREEZE
+        b._had_backbone_connection = True
+        endpoint = _endpoint(b, FakeNotifier())
+        assert endpoint._should_freeze(topics) is True
+        # exempt topics keep flowing mid-gap: "__" internals and the explicit exempt set
+        assert endpoint._should_freeze(["__opal_stats_server_keepalive"]) is False
+        assert (
+            _endpoint(b, FakeNotifier(), exempt=["webhook"])._should_freeze(["webhook"])
+            is False
+        )
+        # a mixed list containing any non-exempt topic still freezes (consistency wins)
+        assert endpoint._should_freeze(["__opal_stats_wakeup", "policy_data"]) is True
+        # freeze disabled -> never
+        assert (
+            _endpoint(b, FakeNotifier(), freeze=False)._should_freeze(topics) is False
+        )
+        # reconnected -> never
+        b._backbone_connected = True
+        assert _endpoint(b, FakeNotifier())._should_freeze(topics) is False
+        b._backbone_connected = False
+    finally:
+        dummy.cancel()
     # no broadcaster (single worker) -> never
-    assert _endpoint(None, FakeNotifier(), freeze=True)._should_freeze() is False
+    assert _endpoint(None, FakeNotifier())._should_freeze(topics) is False
     # stock (non-reconnecting) broadcaster -> never (legacy drop-on-disconnect path)
     stock = EventBroadcaster(
         "memory://",
@@ -905,23 +999,42 @@ async def test_should_freeze_matrix():
         channel="test",
         broadcast_type=bus.channel_factory,
     )
-    assert _endpoint(stock, FakeNotifier(), freeze=True)._should_freeze() is False
+    assert _endpoint(stock, FakeNotifier())._should_freeze(topics) is False
 
 
 @pytest.mark.asyncio
-async def test_publish_is_suppressed_while_backbone_down():
-    """When frozen, publish must not deliver to clients at all (notifier untouched)."""
+async def test_publish_is_suppressed_during_gap():
+    """Mid-gap, publish must not deliver to clients at all (notifier untouched);
+    after the gap the next publish delivers and resets the episode counter."""
     notifier = FakeNotifier()
-    b = _reconnecting(bus := FakeBus())  # disconnected
-    endpoint = _endpoint(b, notifier, freeze=True)
-    await endpoint.publish(["policy_data"], {"x": 1})
-    assert notifier.notified == []  # frozen: nothing reached the clients
+    b = _reconnecting(FakeBus())
+    dummy = _fabricate_gap(b)
+    endpoint = _endpoint(b, notifier)
+    try:
+        await endpoint.publish(["policy_data"], {"x": 1})
+        await endpoint.publish(["policy_data"], {"x": 2})
+        assert notifier.notified == []  # frozen: nothing reached the clients
+        assert endpoint._frozen_in_episode == 2
+        # gap ends -> publish flows again and the episode counter resets
+        b._backbone_connected = True
+        await endpoint.publish(["policy_data"], {"x": 3})
+        assert [d for _, d, _ in notifier.notified] == [{"x": 3}]
+        assert endpoint._frozen_in_episode == 0
+    finally:
+        dummy.cancel()
 
 
 @pytest.mark.asyncio
 async def test_publish_delivers_when_not_freezing():
     """With no broadcaster (nothing to freeze), publish delegates and delivers."""
     notifier = FakeNotifier()
-    endpoint = _endpoint(None, notifier, freeze=True)
+    endpoint = _endpoint(None, notifier)
     await endpoint.publish(["policy_data"], {"x": 1})
     assert notifier.notified and notifier.notified[0][0] == ["policy_data"]
+
+
+def test_notify_alias_is_frozen():
+    """The library aliases ``notify = publish`` at class level (binding the BASE
+    publish); the subclass must re-bind it or ``endpoint.notify(...)`` bypasses
+    the freeze gate."""
+    assert FreezablePubSubEndpoint.notify is FreezablePubSubEndpoint.publish

--- a/packages/opal-server/opal_server/tests/reconnecting_broadcaster_test.py
+++ b/packages/opal-server/opal_server/tests/reconnecting_broadcaster_test.py
@@ -863,8 +863,8 @@ def _reconnecting(bus, notifier=None):
 
 @pytest.mark.asyncio
 async def test_is_backbone_connected_tracks_subscription():
-    """The flag is False before the reader subscribes, True while subscribed, and
-    False again once the reader stops."""
+    """The flag is False before the reader subscribes, True while subscribed,
+    and False again once the reader stops."""
     bus = FakeBus()
     broadcaster = _reconnecting(bus)
     assert not broadcaster.is_backbone_connected()  # not started -> disconnected
@@ -943,8 +943,10 @@ def _endpoint(broadcaster, notifier, freeze=True, exempt=()):
 
 def _fabricate_gap(broadcaster):
     """Put a broadcaster into the mid-gap state (had a session, lost it, reader
-    pending) without driving a real backbone. Returns the dummy reader task —
-    cancel it in the test's cleanup."""
+    pending) without driving a real backbone.
+
+    Returns the dummy reader task — cancel it in the test's cleanup.
+    """
     dummy = asyncio.get_event_loop().create_task(asyncio.sleep(60))
     broadcaster._subscription_task = dummy
     broadcaster._had_backbone_connection = True
@@ -1004,8 +1006,9 @@ async def test_should_freeze_matrix():
 
 @pytest.mark.asyncio
 async def test_publish_is_suppressed_during_gap():
-    """Mid-gap, publish must not deliver to clients at all (notifier untouched);
-    after the gap the next publish delivers and resets the episode counter."""
+    """Mid-gap, publish must not deliver to clients at all (notifier
+    untouched); after the gap the next publish delivers and resets the episode
+    counter."""
     notifier = FakeNotifier()
     b = _reconnecting(FakeBus())
     dummy = _fabricate_gap(b)
@@ -1026,7 +1029,8 @@ async def test_publish_is_suppressed_during_gap():
 
 @pytest.mark.asyncio
 async def test_publish_delivers_when_not_freezing():
-    """With no broadcaster (nothing to freeze), publish delegates and delivers."""
+    """With no broadcaster (nothing to freeze), publish delegates and
+    delivers."""
     notifier = FakeNotifier()
     endpoint = _endpoint(None, notifier)
     await endpoint.publish(["policy_data"], {"x": 1})
@@ -1034,7 +1038,7 @@ async def test_publish_delivers_when_not_freezing():
 
 
 def test_notify_alias_is_frozen():
-    """The library aliases ``notify = publish`` at class level (binding the BASE
-    publish); the subclass must re-bind it or ``endpoint.notify(...)`` bypasses
-    the freeze gate."""
+    """The library aliases ``notify = publish`` at class level (binding the
+    BASE publish); the subclass must re-bind it or ``endpoint.notify(...)``
+    bypasses the freeze gate."""
     assert FreezablePubSubEndpoint.notify is FreezablePubSubEndpoint.publish

--- a/packages/opal-server/opal_server/tests/reconnecting_broadcaster_test.py
+++ b/packages/opal-server/opal_server/tests/reconnecting_broadcaster_test.py
@@ -13,7 +13,10 @@ from contextlib import asynccontextmanager
 import pytest
 from fastapi_websocket_pubsub import EventBroadcaster
 from fastapi_websocket_pubsub.event_broadcaster import BroadcastNotification
-from opal_server.pubsub_resilience import ReconnectingBroadcaster
+from opal_server.pubsub_resilience import (
+    FreezablePubSubEndpoint,
+    ReconnectingBroadcaster,
+)
 
 _END = object()
 
@@ -41,6 +44,10 @@ class FakeNotifier:
 
     async def notify(self, topics, data, notifier_id=None):
         self.notified.append((list(topics), data, notifier_id))
+
+    def gen_subscriber_id(self):
+        # PubSubEndpoint.__init__ mints a server id from the notifier.
+        return "fake-subscriber-id"
 
 
 class FakeBus:
@@ -831,3 +838,90 @@ async def test_partial_replay_requeue_preserves_drop_oldest():
         "refill-2",
     ]
     # The OLDEST (unsent-1) was dropped from the front, NOT the newest refill.
+
+
+# ---------------------------------------------------------------------------
+# Fleet-consistency freeze (is_backbone_connected + FreezablePubSubEndpoint)
+# ---------------------------------------------------------------------------
+
+
+def _reconnecting(bus, notifier=None):
+    return ReconnectingBroadcaster(
+        "memory://",
+        notifier=notifier or FakeNotifier(),
+        channel="test",
+        broadcast_type=bus.channel_factory,
+        reconnect_backoff_min=0,
+        reconnect_backoff_max=0,
+    )
+
+
+@pytest.mark.asyncio
+async def test_is_backbone_connected_tracks_subscription():
+    """The flag is False before the reader subscribes, True while subscribed, and
+    False again once the reader stops — the exact signal the publish gate needs."""
+    bus = FakeBus()
+    broadcaster = _reconnecting(bus)
+    assert not broadcaster.is_backbone_connected()  # not started -> disconnected
+    task = await broadcaster.start_reader_task()
+    try:
+        await _wait_for(lambda: bus.subscribes >= 1)
+        await _wait_for(broadcaster.is_backbone_connected)
+        assert broadcaster.is_backbone_connected()  # subscribed -> connected
+    finally:
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+    assert not broadcaster.is_backbone_connected()  # reader gone -> disconnected
+
+
+def _endpoint(broadcaster, notifier, freeze=True):
+    return FreezablePubSubEndpoint(
+        broadcaster=broadcaster, notifier=notifier, freeze_on_disconnect=freeze
+    )
+
+
+@pytest.mark.asyncio
+async def test_should_freeze_matrix():
+    """The gate freezes only when: freeze enabled AND a ReconnectingBroadcaster AND the
+    backbone is currently disconnected. Every other combination delegates normally."""
+    bus = FakeBus()
+    b = _reconnecting(bus)  # not started -> is_backbone_connected() is False
+
+    # disconnected reconnecting broadcaster + freeze on -> FREEZE
+    assert _endpoint(b, FakeNotifier(), freeze=True)._should_freeze() is True
+    # freeze disabled -> never
+    assert _endpoint(b, FakeNotifier(), freeze=False)._should_freeze() is False
+    # connected -> never
+    b._backbone_connected = True
+    assert _endpoint(b, FakeNotifier(), freeze=True)._should_freeze() is False
+    b._backbone_connected = False
+    # no broadcaster (single worker) -> never
+    assert _endpoint(None, FakeNotifier(), freeze=True)._should_freeze() is False
+    # stock (non-reconnecting) broadcaster -> never (legacy drop-on-disconnect path)
+    stock = EventBroadcaster(
+        "memory://",
+        notifier=FakeNotifier(),
+        channel="test",
+        broadcast_type=bus.channel_factory,
+    )
+    assert _endpoint(stock, FakeNotifier(), freeze=True)._should_freeze() is False
+
+
+@pytest.mark.asyncio
+async def test_publish_is_suppressed_while_backbone_down():
+    """When frozen, publish must not deliver to clients at all (notifier untouched)."""
+    notifier = FakeNotifier()
+    b = _reconnecting(bus := FakeBus())  # disconnected
+    endpoint = _endpoint(b, notifier, freeze=True)
+    await endpoint.publish(["policy_data"], {"x": 1})
+    assert notifier.notified == []  # frozen: nothing reached the clients
+
+
+@pytest.mark.asyncio
+async def test_publish_delivers_when_not_freezing():
+    """With no broadcaster (nothing to freeze), publish delegates and delivers."""
+    notifier = FakeNotifier()
+    endpoint = _endpoint(None, notifier, freeze=True)
+    await endpoint.publish(["policy_data"], {"x": 1})
+    assert notifier.notified and notifier.notified[0][0] == ["policy_data"]

--- a/packages/opal-server/opal_server/tests/reconnecting_broadcaster_test.py
+++ b/packages/opal-server/opal_server/tests/reconnecting_broadcaster_test.py
@@ -8,7 +8,7 @@ control: the stock EventBroadcaster reader DOES complete on the same disconnect,
 proving these tests actually catch the regression.
 """
 import asyncio
-from contextlib import asynccontextmanager
+from contextlib import asynccontextmanager, suppress
 
 import pytest
 from fastapi_websocket_pubsub import EventBroadcaster
@@ -52,6 +52,12 @@ class FakeNotifier:
     async def subscribe(self, *args, **kwargs):
         # The broadcaster's sharing context registers itself on the notifier
         # (EventBroadcaster._subscribe_to_all_topics); a no-op suffices here.
+        pass
+
+    async def unsubscribe(self, *args, **kwargs):
+        # The sharing context's __aexit__ unsubscribes after every delivered
+        # publish; without this the teardown path raises AttributeError (swallowed
+        # upstream) instead of unwinding cleanly.
         pass
 
 
@@ -846,7 +852,7 @@ async def test_partial_replay_requeue_preserves_drop_oldest():
 
 
 # ---------------------------------------------------------------------------
-# Fleet-consistency freeze (is_backbone_connected + FreezablePubSubEndpoint)
+# Fleet-consistency freeze (backbone gap tracking + FreezablePubSubEndpoint)
 # ---------------------------------------------------------------------------
 
 
@@ -862,20 +868,21 @@ def _reconnecting(bus, notifier=None):
 
 
 @pytest.mark.asyncio
-async def test_is_backbone_connected_tracks_subscription():
+async def test_backbone_connected_tracks_subscription():
     """The flag is False before the reader subscribes, True while subscribed,
     and False again once the reader stops."""
     bus = FakeBus()
     broadcaster = _reconnecting(bus)
-    assert not broadcaster.is_backbone_connected()  # not started -> disconnected
+    assert not broadcaster._backbone_connected  # not started -> disconnected
     task = await broadcaster.start_reader_task()
     try:
-        await _wait_for(broadcaster.is_backbone_connected)  # subscribed -> connected
+        # subscribed -> connected
+        await _wait_for(lambda: broadcaster._backbone_connected)
     finally:
         task.cancel()
         with pytest.raises(asyncio.CancelledError):
             await task
-    assert not broadcaster.is_backbone_connected()  # reader gone -> disconnected
+    assert not broadcaster._backbone_connected  # reader gone -> disconnected
 
 
 @pytest.mark.asyncio
@@ -887,7 +894,7 @@ async def test_is_in_backbone_gap_lifecycle():
     assert not broadcaster.is_in_backbone_gap()  # never started -> not a gap
     task = await broadcaster.start_reader_task()
     try:
-        await _wait_for(broadcaster.is_backbone_connected)
+        await _wait_for(lambda: broadcaster._backbone_connected)
         assert not broadcaster.is_in_backbone_gap()  # subscribed -> not a gap
 
         # Backbone drops and stays unavailable: block re-subscribes, then close the read.
@@ -898,7 +905,7 @@ async def test_is_in_backbone_gap_lifecycle():
         # Backbone returns: allow re-subscribes -> gap ends.
         bus.fail_subscribe_times = 0
         await _wait_for(lambda: not broadcaster.is_in_backbone_gap())
-        assert broadcaster.is_backbone_connected()
+        assert broadcaster._backbone_connected
     finally:
         task.cancel()
         with pytest.raises(asyncio.CancelledError):
@@ -914,7 +921,7 @@ async def test_reader_restart_does_not_inherit_gap_state():
     bus = FakeBus()
     broadcaster = _reconnecting(bus)
     task = await broadcaster.start_reader_task()
-    await _wait_for(broadcaster.is_backbone_connected)  # session established
+    await _wait_for(lambda: broadcaster._backbone_connected)  # session established
     # Last listener leaves: upstream cancels the reader and clears the task slot.
     task.cancel()
     with pytest.raises(asyncio.CancelledError):
@@ -945,13 +952,25 @@ def _fabricate_gap(broadcaster):
     """Put a broadcaster into the mid-gap state (had a session, lost it, reader
     pending) without driving a real backbone.
 
-    Returns the dummy reader task — cancel it in the test's cleanup.
+    Returns the dummy reader task — pass it to ``_unwind_gap`` in the test's
+    cleanup.
     """
-    dummy = asyncio.get_event_loop().create_task(asyncio.sleep(60))
+    dummy = asyncio.get_running_loop().create_task(asyncio.sleep(60))
     broadcaster._subscription_task = dummy
     broadcaster._had_backbone_connection = True
     broadcaster._backbone_connected = False
+    # In the real reader every gap opens on a connected -> disconnected edge, which
+    # bumps the generation — mirror that so episode accounting sees a distinct gap.
+    broadcaster._gap_generation += 1
     return dummy
+
+
+async def _unwind_gap(dummy):
+    """Cancel the fabricated dummy reader task AND await it, so no cancelled
+    task outlives the test (pytest-asyncio teardown warnings)."""
+    dummy.cancel()
+    with suppress(asyncio.CancelledError):
+        await dummy
 
 
 @pytest.mark.asyncio
@@ -982,6 +1001,9 @@ async def test_should_freeze_matrix():
         )
         # a mixed list containing any non-exempt topic still freezes (consistency wins)
         assert endpoint._should_freeze(["__opal_stats_wakeup", "policy_data"]) is True
+        # an EMPTY topic list must not slip past the gate (all([]) is True)
+        assert endpoint._should_freeze([]) is True
+        assert endpoint._should_freeze(None) is True
         # freeze disabled -> never
         assert (
             _endpoint(b, FakeNotifier(), freeze=False)._should_freeze(topics) is False
@@ -991,7 +1013,7 @@ async def test_should_freeze_matrix():
         assert _endpoint(b, FakeNotifier())._should_freeze(topics) is False
         b._backbone_connected = False
     finally:
-        dummy.cancel()
+        await _unwind_gap(dummy)
     # no broadcaster (single worker) -> never
     assert _endpoint(None, FakeNotifier())._should_freeze(topics) is False
     # stock (non-reconnecting) broadcaster -> never (legacy drop-on-disconnect path)
@@ -1024,7 +1046,7 @@ async def test_publish_is_suppressed_during_gap():
         assert [d for _, d, _ in notifier.notified] == [{"x": 3}]
         assert endpoint._frozen_in_episode == 0
     finally:
-        dummy.cancel()
+        await _unwind_gap(dummy)
 
 
 @pytest.mark.asyncio
@@ -1048,7 +1070,36 @@ async def test_exempt_publish_mid_gap_delivers_without_ending_episode():
         # episode still open: exempt deliveries mid-gap must not end it
         assert endpoint._frozen_in_episode == 1
     finally:
-        dummy.cancel()
+        await _unwind_gap(dummy)
+
+
+@pytest.mark.asyncio
+async def test_back_to_back_gaps_get_separate_episodes():
+    """Gap A ends and gap B opens before any out-of-gap publish is delivered
+    (recovery itself never publishes — the resync closes client sockets and
+    clients refetch): the first frozen publish of gap B must open a FRESH
+    episode (flushing A's pending summary), not inherit A's count and log the
+    gap-B WARNING at DEBUG."""
+    notifier = FakeNotifier()
+    b = _reconnecting(FakeBus())
+    endpoint = _endpoint(b, notifier)
+    dummy = _fabricate_gap(b)
+    try:
+        await endpoint.publish(["policy_data"], {"x": 1})  # frozen in gap A
+        await endpoint.publish(["policy_data"], {"x": 2})  # frozen in gap A
+        assert endpoint._frozen_in_episode == 2
+        # Gap A recovers, then gap B opens, with NO publish delivered in between —
+        # as in the real reader, the connected -> disconnected edge bumps the
+        # generation.
+        b._backbone_connected = True
+        b._backbone_connected = False
+        b._gap_generation += 1
+        await endpoint.publish(["policy_data"], {"x": 3})  # first freeze of gap B
+        # Fresh episode: gap B's first freeze counts as #1 (WARNING), not #3.
+        assert endpoint._frozen_in_episode == 1
+        assert notifier.notified == []  # nothing was ever delivered to clients
+    finally:
+        await _unwind_gap(dummy)
 
 
 @pytest.mark.asyncio

--- a/packages/opal-server/opal_server/tests/reconnecting_broadcaster_test.py
+++ b/packages/opal-server/opal_server/tests/reconnecting_broadcaster_test.py
@@ -1028,6 +1028,30 @@ async def test_publish_is_suppressed_during_gap():
 
 
 @pytest.mark.asyncio
+async def test_exempt_publish_mid_gap_delivers_without_ending_episode():
+    """An exempt (internal/webhook) publish during the gap is delivered but
+    must NOT reset the freeze-episode counter or log the 'recovered' summary —
+    the gap is still open."""
+    notifier = FakeNotifier()
+    b = _reconnecting(FakeBus())
+    dummy = _fabricate_gap(b)
+    endpoint = _endpoint(b, notifier, exempt=["webhook"])
+    try:
+        await endpoint.publish(["policy_data"], {"x": 1})  # frozen
+        assert endpoint._frozen_in_episode == 1
+        await endpoint.publish(["webhook"], {"w": 1})  # exempt -> delivered
+        await endpoint.publish(["__opal_stats_wakeup"], {"s": 1})  # exempt
+        assert [t for t, _, _ in notifier.notified] == [
+            ["webhook"],
+            ["__opal_stats_wakeup"],
+        ]
+        # episode still open: exempt deliveries mid-gap must not end it
+        assert endpoint._frozen_in_episode == 1
+    finally:
+        dummy.cancel()
+
+
+@pytest.mark.asyncio
 async def test_publish_delivers_when_not_freezing():
     """With no broadcaster (nothing to freeze), publish delegates and
     delivers."""


### PR DESCRIPTION
## The problem

Follow-up to #915. That PR made a fleet of OPAL servers *survive* a broadcast-backbone outage (reconnect with backoff, buffer outbound broadcasts, resync clients on recovery). Multi-server validation of it surfaced a consistency gap **during** the outage:

A server-side `publish` fans out two independent ways — **local in-process delivery** to that worker's own clients, and the **broadcaster** to peer workers. Only the outbound path is buffered when the backbone is down; local delivery still fires. So an update that reaches one server mid-outage is applied to *its* clients while every other server's clients hold old data — a fleet split that lasts the whole outage. In a 3-server / 9-client test against a real managed-Postgres backbone stop, a data update published during the outage left the fleet at 3/9 new vs 6/9 old for the entire ~13-minute gap. For an authorization system, that means the same request can be allowed by one PDP and denied by another until the backbone returns.

## The fix

`FreezablePubSubEndpoint` gates client-facing publishes on live backbone connectivity: while the `ReconnectingBroadcaster` is mid-**gap** (an established backbone session was lost and is being re-acquired — see `is_in_backbone_gap()`), `publish` is skipped entirely. Clients stay **connected** but frozen on the last consistent state; the write still lands in its datasource; and the existing reconnect **resync** (from #915) makes every worker's clients refetch on recovery — so the whole fleet moves together instead of diverging. Skipping the whole publish also keeps the replay buffer out of the recovery path for these updates: convergence is purely the resync refetch.

Configurable via `OPAL_BROADCAST_FREEZE_ON_DISCONNECT` (default `true`; set `false` for the previous behavior).

### Scope & semantics (please read if you rely on runtime data updates)

* **Covered:** updates whose data clients re-fetch on reconnect — the configured data sources (`OPAL_DATA_CONFIG_SOURCES` / scope config) and the policy bundle. These are reconciled fleet-wide on recovery.
* **Dropped, not deferred:** one-off updates published *during* a gap that fall outside that set — inline `data` payloads, or fetch URLs not part of the configured sources. Consistency is chosen over freshness for these; if you rely on them, set the flag to `false`.
* **Exempt (keep the old deliver-locally + buffer-for-replay behavior):** internal coordination topics — `__`-prefixed channels (statistics protocol, broadcaster keepalive) and the git-webhook trigger topic. These target server-side subscribers, not clients; freezing them would break statistics state and silently drop repo-pull triggers that no resync re-issues.
* **Guardrail:** the resync is the freeze's only recovery path, so enabling the freeze with `OPAL_BROADCAST_RESYNC_ON_RECONNECT=false` is refused with a warning (freeze disabled) rather than silently losing updates.

### Hardening (second commit)

An adversarial review of the first commit caught real issues, all addressed:

* **Gap-only gating** — freeze keys off `is_in_backbone_gap()` (had a session, lost it, retrying), *not* mere "not subscribed". Freezing while the reader was never started (idle worker — the reader only runs while a listening context is held) or never yet connected (boot) would silently drop publishes on a **healthy** backbone with nothing to ever reconcile them; those states delegate to the pre-freeze behavior. Gap state is scoped to the reader task's own lifetime, mirroring the resync's semantics.
* **`notify = publish` alias re-bound** — the upstream endpoint aliases `notify = publish` at class level, which binds the *base* publish; without re-binding, `endpoint.notify(...)` bypassed the gate entirely.
* **Log hygiene** — one WARNING per freeze episode (subsequent hits at DEBUG) plus a suppressed-count summary on recovery, instead of a WARNING per frozen keepalive for the whole outage.
* **Known limitations** (documented in the class docstring; each degrades to the *pre-freeze* behavior, never worse): an outbound broadcast can fail while the reader subscription is alive (delivered locally + buffered, as before); the gate reopens on re-subscribe before the session proves sustained (a rare connect-flap can slip a publish through); client-originated RPC publishes bypass the endpoint override.

## Validation

* **Unit:** 63 opal-server tests green (35 in the reconnecting-broadcaster suite, 8 of them new), including a fault-injectable in-memory backbone driving the full gap lifecycle, the freeze matrix (never-started / never-connected / gap / reconnected / exempt topics / disabled / no broadcaster / stock broadcaster), suppression + episode-counter behavior, reader-restart state hygiene, and the `notify` alias pin.
* **Multi-server staging (3 servers × 9 clients, shared Postgres backbone, real stop/start and reboot outages):**
  * Without the fix: update during the outage → **3/9** clients diverge for the entire gap.
  * With the fix: same choreography → **0/9** leak (write-target server's own clients included), held across a ~20-minute outage; all 9 clients stayed connected, 0 worker restarts.
  * Source-based end-to-end: a value written to a datasource during the gap, with its update notification provably frozen at the gate (and nothing buffered), converged **9/9** after recovery via the resync refetch alone.
  * The final run also confirmed the exemptions live (internal topics buffered-for-replay during the gap, as before this PR) and the episode logging (single WARNING + recovery summary).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
