### PR TITLE
feat(confi): load .env from CONFI_PATH or current directory

### DIFF
--- a/packages/opal-common/opal_common/confi/confi.py
+++ b/packages/opal-common/opal_common/confi/confi.py
@@ -7,12 +7,13 @@ Adding typing support and parsing with Pydantic and Enum.
 import inspect
 import json
 import logging
+import os
 import string
 from collections import OrderedDict
 from functools import partial, wraps
 from typing import Any, Callable, Dict, List, Optional, Tuple, TypeVar, Union
 
-from decouple import Csv, UndefinedValueError, config, text_type, undefined
+from decouple import AutoConfig, Csv, UndefinedValueError, text_type, undefined
 from opal_common.authentication.casting import cast_private_key, cast_public_key
 from opal_common.authentication.types import EncryptionKeyFormat, PrivateKey, PublicKey
 from opal_common.confi.cli import get_cli_object_for_config_objects
@@ -20,6 +21,13 @@ from opal_common.confi.types import ConfiDelay, ConfiEntry, no_cast
 from opal_common.logging_utils.decorators import log_exception
 from pydantic import BaseModel, ValidationError
 from typer import Typer
+
+
+def build_config() -> AutoConfig:
+    return AutoConfig(os.environ.get("CONFI_PATH") or os.getcwd())
+
+
+config = build_config()
 
 
 class Placeholder(object):

--- a/packages/opal-common/opal_common/tests/test_confi_config_path.py
+++ b/packages/opal-common/opal_common/tests/test_confi_config_path.py
@@ -1,0 +1,39 @@
+from opal_common.confi.confi import build_config
+
+# Unique key that is not present in the real environment, so decouple resolves
+# it from the .env file we write rather than from os.environ.
+_TEST_KEY = "OPAL_TEST_CONFI_ENV_FOLDER_KEY"
+
+
+def _write_env_file(directory, value):
+    (directory / ".env").write_text(f"{_TEST_KEY}={value}\n")
+
+
+def test_reads_env_file_from_confi_path(tmp_path, monkeypatch):
+    _write_env_file(tmp_path, "from_confi_path")
+    monkeypatch.setenv("CONFI_PATH", str(tmp_path))
+
+    assert build_config()(_TEST_KEY) == "from_confi_path"
+
+
+def test_falls_back_to_current_working_directory(tmp_path, monkeypatch):
+    _write_env_file(tmp_path, "from_cwd")
+    monkeypatch.delenv("CONFI_PATH", raising=False)
+    monkeypatch.chdir(tmp_path)
+
+    assert build_config()(_TEST_KEY) == "from_cwd"
+
+
+def test_confi_path_takes_precedence_over_cwd(tmp_path, monkeypatch):
+    confi_path_dir = tmp_path / "config_dir"
+    confi_path_dir.mkdir()
+    _write_env_file(confi_path_dir, "from_confi_path")
+
+    cwd_dir = tmp_path / "cwd_dir"
+    cwd_dir.mkdir()
+    _write_env_file(cwd_dir, "from_cwd")
+
+    monkeypatch.setenv("CONFI_PATH", str(confi_path_dir))
+    monkeypatch.chdir(cwd_dir)
+
+    assert build_config()(_TEST_KEY) == "from_confi_path"


### PR DESCRIPTION
## Fixes Issue

Closes #201

## Changes proposed

`Confi` used decouple's global `config`, which only looks for `.env` / `settings.ini` next to the
importing module — so there was no way to keep the config file in another folder.

It now builds its own `AutoConfig` that reads from `CONFI_PATH` when set, and otherwise the current
working directory:

```python
config = AutoConfig(os.environ.get("CONFI_PATH") or os.getcwd())
```

(wrapped in a small `build_config()` helper so the behavior can be unit-tested).

This is the same approach as #715, which was closed only for missing tests. Added tests for the three
cases: reading from `CONFI_PATH`, falling back to the cwd, and `CONFI_PATH` taking precedence over the cwd.

## Check List (Check all the applicable boxes)

- [x] I sign off on contributing this submission to open-source
- [x] My code follows the code style of this project.
- [ ] My change requires changes to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] This PR does not contain plagiarized content.
- [x] The title of my pull request is a short description of the requested changes.

## Note to reviewers

Picks up where #715 left off, the tests that were missing.
They live in `packages/opal-common/opal_common/tests/test_confi_config_path.py`. Happy to add a note
about `CONFI_PATH` to the docs if you'd like it mentioned there.
