### PR TITLE
fix(scopes): return 404 instead of 500 for a missing scope policy

### DIFF
--- a/packages/opal-server/opal_server/scopes/api.py
+++ b/packages/opal-server/opal_server/scopes/api.py
@@ -316,7 +316,9 @@ def init_scope_router(
             pygit2.GitError,
             ValueError,
         ):
-            raise ScopeNotFoundError(scope_id)
+            raise HTTPException(
+                status.HTTP_404_NOT_FOUND, detail=f"No such scope: {scope_id}"
+            )
 
     @router.get(
         "/{scope_id}/data",

--- a/packages/opal-server/opal_server/tests/scope_policy_fallback_test.py
+++ b/packages/opal-server/opal_server/tests/scope_policy_fallback_test.py
@@ -114,3 +114,14 @@ def test_missing_scope_still_falls_back_to_default_bundle(tmp_path, monkeypatch)
 
     assert resp.status_code == 200
     assert resp.json()["hash"] == "default-head"
+
+
+def test_missing_scope_without_default_returns_404(tmp_path):
+    """An absent scope with no 'default' scope to fall back on must return 404,
+    matching get_scope/refresh_scope, not a 500 from an uncaught
+    ScopeNotFoundError re-raised out of the default-bundle path (#919)."""
+    repo = FakeScopeRepository([])
+
+    resp = _client(repo, tmp_path).get("/scopes/ghost/policy")
+
+    assert resp.status_code == 404


### PR DESCRIPTION
## Fixes Issue

Closes #919

## Changes proposed

`GET /scopes/{scope_id}/policy` falls back to the default scope bundle when the requested scope isn't found. If no `default` scope exists either, `_generate_default_scope_bundle` re-raised `ScopeNotFoundError`, which was never caught, so the route returned a `500` ("Uncaught server exception") for an unknown or not-yet-synced scope. The OPAL client hits this on connect (it fetches `/scopes/{scope_id}/policy` before the scope has synced), so it sees repeated 500s until the sync completes. 

- `_generate_default_scope_bundle` now raises `HTTPException(404)` instead of `ScopeNotFoundError` when neither the requested scope nor a `default` scope can be served, matching the existing `get_scope` /  `refresh_scope` routes and the client's existing 404 handling.
- Added a regression test in `scope_policy_fallback_test.py` for the "absent scope, no default configured"
  case (existing tests cover the fallback-succeeds case).

## Check List (Check all the applicable boxes)

- [x] I sign off on contributing this submission to open-source
- [x] My code follows the code style of this project.
- [ ] My change requires changes to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] This PR does not contain plagiarized content.
- [x] The title of my pull request is a short description of the requested changes.

## Note to reviewers

The 404 path only triggers when the default fallback can't be served (no `default` scope, or its repo is unavailable) — the happy-path fallback to the default bundle is unchanged. `black`/`isort` clean; all three tests in `scope_policy_fallback_test.py` pass, and the new one fails on `master` with the pre-fix 500 and passes with the fix.
