### PR TITLE
[PARKED] fix(opal-client): honour Retry-After, stop retrying 409, and defer re-fetch after exhausted retries

### DIFF
--- a/documentation/docs/getting-started/configuration.mdx
+++ b/documentation/docs/getting-started/configuration.mdx
@@ -1318,28 +1318,30 @@ Retry options when connecting to the policy source (e.g., the policy bundle serv
 
 Default: `60.0`
 
-Upper bound, in seconds, on how long the client will wait because a policy source asked
-it to. When the OPAL Server answers a bundle request with `503` (for example while it is
+Upper bound, in seconds, on how long the client will wait *because a policy source asked
+it to*. When the OPAL Server answers a bundle request with `503` (for example while it is
 still cloning the scope's policy repository) or `429`, it may include a `Retry-After`
-header. The client waits for whichever is longer — the server's hint or its own
-`OPAL_POLICY_UPDATER_CONN_RETRY` backoff — but never longer than this value, so a hostile
-or buggy header cannot stall policy updates. `Retry-After` is accepted in both forms
-allowed by RFC 9110 (delta-seconds and an HTTP-date); a header the client cannot parse is ignored.
+header. `Retry-After` is accepted in both forms allowed by RFC 9110 (delta-seconds and an
+HTTP-date); a header the client cannot parse is ignored.
 
 This key does three things:
 
-1. It caps each individual `Retry-After` the client honours. The bound applies only to
-   the server-supplied hint — it does not clamp the backoff you configured in
-   `OPAL_POLICY_UPDATER_CONN_RETRY`.
-2. It caps the **total** wall-clock time of a single bundle fetch. Policy updates run off
-   a serial queue, so a proxy answering `Retry-After: 300` would otherwise block every
-   other update for `attempts x 300` seconds. Once a fetch has spent this budget it gives
-   up, and the deferred re-fetch below takes over the long horizon.
-3. It ceilings the deferred re-fetch backoff described under
+1. **Caps each honoured `Retry-After`.** Per attempt the client waits for whichever is
+   longer, the server's hint or its own `OPAL_POLICY_UPDATER_CONN_RETRY` backoff, but it
+   never honours a hint beyond this value — so a hostile or buggy header cannot stall
+   policy updates.
+2. **Bounds the extra wall-clock time one fetch may spend beyond the operator's own
+   backoff.** Policy updates run off a serial queue, so a proxy answering
+   `Retry-After: 300` would otherwise block every other update for `attempts x 300`
+   seconds. The actual bound is `max(this key, the worst case of
+   OPAL_POLICY_UPDATER_CONN_RETRY)`, so a retry policy you configured deliberately is
+   never shortened; only server-driven waiting is capped.
+3. **Ceilings the deferred re-fetch backoff and the flat cadence** described under
    `OPAL_POLICY_UPDATER_RESCHEDULE_ON_RETRYABLE`.
 
-Setting it to `0` disables in-fetch waiting entirely (one attempt per fetch); the deferred
-re-fetch still applies, floored at 5 seconds.
+Setting it to `0` means "honour no server hint at all". It does **not** disable retries:
+your `OPAL_POLICY_UPDATER_CONN_RETRY` attempts still run in full, and the deferred
+re-fetch continues at its 5-second floor.
 
 #### OPAL_POLICY_UPDATER_RESCHEDULE_ON_RETRYABLE
 
@@ -1347,10 +1349,11 @@ Default: `True`
 
 If `True`, when a bundle fetch exhausts `OPAL_POLICY_UPDATER_CONN_RETRY` against a
 retryable error (`503` while the server clones the policy repository, or `429`), the
-client schedules one deferred re-fetch instead of waiting for the next Pub/Sub message or
+client schedules a deferred re-fetch instead of waiting for the next Pub/Sub message or
 WebSocket reconnect. Non-retryable answers (`409` — the branch could not be resolved, and
 `404` — the requested path is not in the repository) are never rescheduled. Set to `False`
-to restore the previous fire-and-forget behaviour.
+to restore the previous fire-and-forget behaviour; this switch disables *all* deferral,
+including the flat cadence below.
 
 At most one deferred re-fetch is pending at a time. The delay for round _n_ is the longer
 of the server's `Retry-After` and an exponential backoff of `5, 10, 20, 40, 60, 60, …`
@@ -1363,17 +1366,23 @@ cancelled by a successful fetch, by an incoming policy update, and by client shu
 
 Default: `20`
 
-Maximum number of consecutive deferred bundle re-fetches before the client gives up and
-waits for the next Pub/Sub message or reconnect. Only relevant when
-`OPAL_POLICY_UPDATER_RESCHEDULE_ON_RETRYABLE` is enabled.
+Number of **escalation** rounds before the deferred re-fetch settles into a flat cadence.
+Only relevant when `OPAL_POLICY_UPDATER_RESCHEDULE_ON_RETRYABLE` is enabled.
 
-The counter is reset by a successful fetch and by an incoming policy update. It is
-deliberately **not** reset by a WebSocket reconnect: reconnects are frequent during
-exactly the outages this budget is meant to bound, so resetting there would make the
-limit unreachable. With the defaults, one outage therefore costs a client at most
-20 deferred rounds: the deferred waits alone sum to `5 + 10 + 20 + 40 + 16x60 = 1035 s`
-before jitter, so between about 8.5 and 17 minutes of re-fetching, after which the client
-falls silent and waits for a real policy update or a reconnect.
+For the first `MAX_DEFERRED_ROUNDS` rounds the delay grows as described above. After that
+the client does not give up — a client whose WebSocket never reconnects and whose scope
+never receives a commit would otherwise stay stale forever after a long clone — it keeps
+re-fetching at a flat `OPAL_POLICY_UPDATER_MAX_RETRY_AFTER` cadence, jittered into
+`[cap/2, cap]`. At the defaults that is one bundle request every 30–60 seconds per client
+(mean ~45 s, so roughly 1.3 requests per minute) until a fetch succeeds. Entering the flat
+phase logs a single warning, not one per round.
+
+The round counter, and the flat phase, are cleared by a successful fetch and by an
+incoming policy update. They are deliberately **not** cleared by a WebSocket reconnect:
+reconnects are frequent during exactly the outages this budget is meant to bound, so
+resetting there would make the escalation limit unreachable. With the defaults the
+escalating phase lasts `5 + 10 + 20 + 40 + 16x60 = 1035 s` before jitter — roughly 8.5 to
+17 minutes — after which the flat cadence takes over.
 
 ### Data Updates Configuration
 

--- a/documentation/docs/getting-started/configuration.mdx
+++ b/documentation/docs/getting-started/configuration.mdx
@@ -1314,6 +1314,38 @@ Default:
 
 Retry options when connecting to the policy source (e.g., the policy bundle server).
 
+#### OPAL_POLICY_UPDATER_MAX_RETRY_AFTER
+
+Default: `60.0`
+
+Upper bound, in seconds, on a `Retry-After` header sent by the policy source. When the
+OPAL Server answers a bundle request with `503` (for example while it is still cloning
+the scope's policy repository) it may include `Retry-After`. The client waits for
+whichever is longer — the server's hint or its own `OPAL_POLICY_UPDATER_CONN_RETRY`
+backoff — but never longer than this value, so a hostile or buggy header cannot stall
+policy updates. This bound applies only to the server-supplied hint; it does not clamp
+the backoff you configured in `OPAL_POLICY_UPDATER_CONN_RETRY`.
+
+#### OPAL_POLICY_UPDATER_RESCHEDULE_ON_RETRYABLE
+
+Default: `True`
+
+If `True`, when a bundle fetch exhausts `OPAL_POLICY_UPDATER_CONN_RETRY` against a
+retryable error (such as `503` while the server clones the policy repository), the client
+schedules one deferred re-fetch instead of waiting for the next Pub/Sub message or
+WebSocket reconnect. Non-retryable answers (`409` — the branch could not be resolved, and
+`404` — the requested path is not in the repository) are never rescheduled. Set to `False`
+to restore the previous fire-and-forget behaviour.
+
+#### OPAL_POLICY_UPDATER_MAX_DEFERRED_ROUNDS
+
+Default: `20`
+
+Maximum number of consecutive deferred bundle re-fetches before the client gives up and
+waits for the next Pub/Sub message or reconnect. A successful fetch, or an incoming policy
+update, resets the counter. Only relevant when
+`OPAL_POLICY_UPDATER_RESCHEDULE_ON_RETRYABLE` is enabled.
+
 ### Data Updates Configuration
 
 #### OPAL_DATA_UPDATER_ENABLED

--- a/documentation/docs/getting-started/configuration.mdx
+++ b/documentation/docs/getting-started/configuration.mdx
@@ -1318,33 +1318,62 @@ Retry options when connecting to the policy source (e.g., the policy bundle serv
 
 Default: `60.0`
 
-Upper bound, in seconds, on a `Retry-After` header sent by the policy source. When the
-OPAL Server answers a bundle request with `503` (for example while it is still cloning
-the scope's policy repository) it may include `Retry-After`. The client waits for
-whichever is longer — the server's hint or its own `OPAL_POLICY_UPDATER_CONN_RETRY`
-backoff — but never longer than this value, so a hostile or buggy header cannot stall
-policy updates. This bound applies only to the server-supplied hint; it does not clamp
-the backoff you configured in `OPAL_POLICY_UPDATER_CONN_RETRY`.
+Upper bound, in seconds, on how long the client will wait because a policy source asked
+it to. When the OPAL Server answers a bundle request with `503` (for example while it is
+still cloning the scope's policy repository) or `429`, it may include a `Retry-After`
+header. The client waits for whichever is longer — the server's hint or its own
+`OPAL_POLICY_UPDATER_CONN_RETRY` backoff — but never longer than this value, so a hostile
+or buggy header cannot stall policy updates. `Retry-After` is accepted in both forms
+allowed by RFC 9110 (delta-seconds and an HTTP-date); a header the client cannot parse is ignored.
+
+This key does three things:
+
+1. It caps each individual `Retry-After` the client honours. The bound applies only to
+   the server-supplied hint — it does not clamp the backoff you configured in
+   `OPAL_POLICY_UPDATER_CONN_RETRY`.
+2. It caps the **total** wall-clock time of a single bundle fetch. Policy updates run off
+   a serial queue, so a proxy answering `Retry-After: 300` would otherwise block every
+   other update for `attempts x 300` seconds. Once a fetch has spent this budget it gives
+   up, and the deferred re-fetch below takes over the long horizon.
+3. It ceilings the deferred re-fetch backoff described under
+   `OPAL_POLICY_UPDATER_RESCHEDULE_ON_RETRYABLE`.
+
+Setting it to `0` disables in-fetch waiting entirely (one attempt per fetch); the deferred
+re-fetch still applies, floored at 5 seconds.
 
 #### OPAL_POLICY_UPDATER_RESCHEDULE_ON_RETRYABLE
 
 Default: `True`
 
 If `True`, when a bundle fetch exhausts `OPAL_POLICY_UPDATER_CONN_RETRY` against a
-retryable error (such as `503` while the server clones the policy repository), the client
-schedules one deferred re-fetch instead of waiting for the next Pub/Sub message or
+retryable error (`503` while the server clones the policy repository, or `429`), the
+client schedules one deferred re-fetch instead of waiting for the next Pub/Sub message or
 WebSocket reconnect. Non-retryable answers (`409` — the branch could not be resolved, and
 `404` — the requested path is not in the repository) are never rescheduled. Set to `False`
 to restore the previous fire-and-forget behaviour.
+
+At most one deferred re-fetch is pending at a time. The delay for round _n_ is the longer
+of the server's `Retry-After` and an exponential backoff of `5, 10, 20, 40, 60, 60, …`
+seconds, clamped to `OPAL_POLICY_UPDATER_MAX_RETRY_AFTER` above and to 5 seconds below,
+and then **jittered** into `[delay/2, delay]` so that a fleet of clients recovering from
+the same outage does not return to the server in lockstep. The pending re-fetch is
+cancelled by a successful fetch, by an incoming policy update, and by client shutdown.
 
 #### OPAL_POLICY_UPDATER_MAX_DEFERRED_ROUNDS
 
 Default: `20`
 
 Maximum number of consecutive deferred bundle re-fetches before the client gives up and
-waits for the next Pub/Sub message or reconnect. A successful fetch, or an incoming policy
-update, resets the counter. Only relevant when
+waits for the next Pub/Sub message or reconnect. Only relevant when
 `OPAL_POLICY_UPDATER_RESCHEDULE_ON_RETRYABLE` is enabled.
+
+The counter is reset by a successful fetch and by an incoming policy update. It is
+deliberately **not** reset by a WebSocket reconnect: reconnects are frequent during
+exactly the outages this budget is meant to bound, so resetting there would make the
+limit unreachable. With the defaults, one outage therefore costs a client at most
+20 deferred rounds: the deferred waits alone sum to `5 + 10 + 20 + 40 + 16x60 = 1035 s`
+before jitter, so between about 8.5 and 17 minutes of re-fetching, after which the client
+falls silent and waits for a real policy update or a reconnect.
 
 ### Data Updates Configuration
 

--- a/packages/opal-client/opal_client/config.py
+++ b/packages/opal-client/opal_client/config.py
@@ -103,11 +103,14 @@ class OpalClientConfig(Confi):
     POLICY_UPDATER_MAX_RETRY_AFTER = confi.float(
         "POLICY_UPDATER_MAX_RETRY_AFTER",
         60.0,
-        description="Upper bound (in seconds) on a `Retry-After` header sent by the "
-        "policy source. The client honours the server's hint when it is longer than "
-        "the configured backoff, but never waits longer than this, so a hostile or "
-        "buggy header cannot stall policy updates. Does not clamp "
-        "POLICY_UPDATER_CONN_RETRY's own backoff.",
+        description="Upper bound (in seconds) on how long the client waits because a "
+        "policy source asked it to. It (1) caps each `Retry-After` header the client "
+        "honours, so a hostile or buggy header cannot stall policy updates; (2) bounds "
+        "the extra wall-clock time one bundle fetch may spend beyond the operator's own "
+        "backoff -- the effective limit is max(this key, the worst case of "
+        "POLICY_UPDATER_CONN_RETRY), so a deliberately configured retry policy is never "
+        "shortened; and (3) ceilings the deferred re-fetch backoff and its flat cadence. "
+        "Setting it to 0 means 'honour no server hint'; it does not disable retries.",
     )
 
     POLICY_UPDATER_RESCHEDULE_ON_RETRYABLE = confi.bool(
@@ -115,17 +118,22 @@ class OpalClientConfig(Confi):
         True,
         description="If True, when a bundle fetch exhausts POLICY_UPDATER_CONN_RETRY "
         "against a retryable error (e.g. HTTP 503 while the server clones the policy "
-        "repo), the client schedules one deferred re-fetch instead of waiting for the "
+        "repo), the client schedules a deferred re-fetch instead of waiting for the "
         "next pub/sub message or WebSocket reconnect. Set to False to restore the "
-        "previous fire-and-forget behaviour.",
+        "previous fire-and-forget behaviour; this disables all deferral, including the "
+        "flat cadence described under POLICY_UPDATER_MAX_DEFERRED_ROUNDS.",
     )
 
     POLICY_UPDATER_MAX_DEFERRED_ROUNDS = confi.int(
         "POLICY_UPDATER_MAX_DEFERRED_ROUNDS",
         20,
-        description="Maximum number of consecutive deferred bundle re-fetches before "
-        "the client gives up and waits for the next pub/sub message or reconnect. "
-        "A successful fetch or an incoming policy update resets the counter.",
+        description="Number of escalation rounds before the deferred bundle re-fetch "
+        "settles into a flat cadence. For the first N rounds the delay grows (5, 10, 20, "
+        "40, ... seconds, jittered); after that the client keeps re-fetching at a flat "
+        "POLICY_UPDATER_MAX_RETRY_AFTER cadence rather than giving up, so a client whose "
+        "WebSocket never reconnects and whose scope never receives a commit still "
+        "recovers. A successful fetch or an incoming policy update resets the counter; a "
+        "reconnect deliberately does not.",
     )
 
     DATA_STORE_CONN_RETRY: ConnRetryOptions = confi.model(

--- a/packages/opal-client/opal_client/config.py
+++ b/packages/opal-client/opal_client/config.py
@@ -100,6 +100,34 @@ class OpalClientConfig(Confi):
         description="Retry options when connecting to the policy source (e.g. the policy bundle server)",
     )
 
+    POLICY_UPDATER_MAX_RETRY_AFTER = confi.float(
+        "POLICY_UPDATER_MAX_RETRY_AFTER",
+        60.0,
+        description="Upper bound (in seconds) on a `Retry-After` header sent by the "
+        "policy source. The client honours the server's hint when it is longer than "
+        "the configured backoff, but never waits longer than this, so a hostile or "
+        "buggy header cannot stall policy updates. Does not clamp "
+        "POLICY_UPDATER_CONN_RETRY's own backoff.",
+    )
+
+    POLICY_UPDATER_RESCHEDULE_ON_RETRYABLE = confi.bool(
+        "POLICY_UPDATER_RESCHEDULE_ON_RETRYABLE",
+        True,
+        description="If True, when a bundle fetch exhausts POLICY_UPDATER_CONN_RETRY "
+        "against a retryable error (e.g. HTTP 503 while the server clones the policy "
+        "repo), the client schedules one deferred re-fetch instead of waiting for the "
+        "next pub/sub message or WebSocket reconnect. Set to False to restore the "
+        "previous fire-and-forget behaviour.",
+    )
+
+    POLICY_UPDATER_MAX_DEFERRED_ROUNDS = confi.int(
+        "POLICY_UPDATER_MAX_DEFERRED_ROUNDS",
+        20,
+        description="Maximum number of consecutive deferred bundle re-fetches before "
+        "the client gives up and waits for the next pub/sub message or reconnect. "
+        "A successful fetch or an incoming policy update resets the counter.",
+    )
+
     DATA_STORE_CONN_RETRY: ConnRetryOptions = confi.model(
         "DATA_STORE_CONN_RETRY",
         ConnRetryOptions,

--- a/packages/opal-client/opal_client/policy/fetcher.py
+++ b/packages/opal-client/opal_client/policy/fetcher.py
@@ -18,7 +18,12 @@ from pydantic import ValidationError
 from tenacity import retry, retry_if_not_exception_type, stop, stop_after_delay, wait
 from tenacity.wait import wait_base
 
-# Statuses the OPAL server uses to say "this will work later, come back":
+# The classification below follows the contract introduced by opal-server
+# PR #924 (scopes API). On older servers only the 503 path is exercised -- they
+# do not emit 409 for an unresolved branch -- so this is safe to run against a
+# mixed fleet.
+#
+# Statuses that mean "this will work later, come back":
 #   503 - the scope's repo clone is in progress, or its clone vanished/is corrupt
 #   429 - the server (or something in front of it) is shedding load
 # Both may carry a `Retry-After` header telling us how long to wait.
@@ -235,8 +240,16 @@ class PolicyFetcher:
         # loop would block every other policy update for attempts x cap. Past
         # this budget we give up and let the deferred re-fetch (which does not
         # hold the queue) own the long horizon.
+        #
+        # The bound is the LARGER of the cap and the operator's own
+        # POLICY_UPDATER_CONN_RETRY budget: this exists to stop a *server-
+        # supplied* hint from monopolising the queue, not to quietly shorten a
+        # retry policy someone configured on purpose.
         self._retry_config["stop"] = self._retry_config["stop"] | stop_after_delay(
-            opal_client_config.POLICY_UPDATER_MAX_RETRY_AFTER
+            max(
+                opal_client_config.POLICY_UPDATER_MAX_RETRY_AFTER,
+                opal_client_config.POLICY_UPDATER_CONN_RETRY.worstCaseTotalWait(),
+            )
         )
 
         scope_id = opal_client_config.SCOPE_ID
@@ -370,5 +383,7 @@ class PolicyFetcher:
 
                     return bundle
             except aiohttp.ClientError as e:
-                logger.warning("server connection error: {err}", err=repr(e))
+                # debug, not warning: `fetch_policy_bundle` emits exactly one
+                # summary WARNING once the attempts are exhausted.
+                logger.debug("server connection error: {err}", err=repr(e))
                 raise

--- a/packages/opal-client/opal_client/policy/fetcher.py
+++ b/packages/opal-client/opal_client/policy/fetcher.py
@@ -15,7 +15,7 @@ from opal_common.utils import (
     tuple_to_dict,
 )
 from pydantic import ValidationError
-from tenacity import retry, retry_if_not_exception_type, stop, wait
+from tenacity import retry, retry_if_not_exception_type, stop, stop_after_delay, wait
 from tenacity.wait import wait_base
 
 # Statuses the OPAL server uses to say "this will work later, come back":
@@ -230,6 +230,14 @@ class PolicyFetcher:
             self._retry_config["wait"],
             max_retry_after=opal_client_config.POLICY_UPDATER_MAX_RETRY_AFTER,
         )
+        # Bound the wall-clock cost of ONE fetch. `update_policy` runs off a
+        # serial queue, so honouring a large `Retry-After` inside the tenacity
+        # loop would block every other policy update for attempts x cap. Past
+        # this budget we give up and let the deferred re-fetch (which does not
+        # hold the queue) own the long horizon.
+        self._retry_config["stop"] = self._retry_config["stop"] | stop_after_delay(
+            opal_client_config.POLICY_UPDATER_MAX_RETRY_AFTER
+        )
 
         scope_id = opal_client_config.SCOPE_ID
 
@@ -256,6 +264,24 @@ class PolicyFetcher:
         attempter = retry(**self._retry_config)(self._fetch_policy_bundle)
         try:
             return await attempter(directories=directories, base_hash=base_hash)
+        except NonRetryableBundleError as err:
+            # Exactly one WARNING per fetch that gave up: the per-attempt
+            # classification lines are debug, so a fleet-wide outage does not
+            # multiply the log volume by the attempt count.
+            logger.warning(
+                "Bundle fetch non-retryable ({status}): {detail}",
+                status=err.status_code,
+                detail=err.detail,
+            )
+            raise
+        except RetryableBundleError as err:
+            logger.warning(
+                "Bundle fetch retryable ({status}); server asked to retry after "
+                "{retry_after}s, giving up this round after exhausting retries",
+                status=err.status_code,
+                retry_after=err.retry_after,
+            )
+            raise
         except Exception as err:
             logger.warning(
                 "Failed all attempts to fetch bundle, got error: {err}",
@@ -273,7 +299,7 @@ class PolicyFetcher:
         if response.status in RETRYABLE_BUNDLE_STATUSES:
             retry_after = parse_retry_after(response.headers.get("Retry-After"))
             detail = await _response_detail(response)
-            logger.warning(
+            logger.debug(
                 "Bundle fetch retryable ({status}); server asked to retry after {retry_after}s",
                 status=response.status,
                 retry_after=retry_after,
@@ -284,7 +310,7 @@ class PolicyFetcher:
 
         if response.status in NON_RETRYABLE_BUNDLE_STATUSES:
             detail = await _response_detail(response)
-            logger.warning(
+            logger.debug(
                 "Bundle fetch non-retryable ({status}): {detail}",
                 status=response.status,
                 detail=detail,
@@ -321,7 +347,7 @@ class PolicyFetcher:
                     **self._ssl_context_kwargs,
                 ) as response:
                     if response.status == status.HTTP_404_NOT_FOUND:
-                        logger.warning(
+                        logger.debug(
                             "requested paths not found: {paths}",
                             paths=directories,
                         )

--- a/packages/opal-client/opal_client/policy/fetcher.py
+++ b/packages/opal-client/opal_client/policy/fetcher.py
@@ -1,3 +1,6 @@
+import math
+from datetime import datetime, timezone
+from email.utils import parsedate_to_datetime
 from typing import List, Optional
 
 import aiohttp
@@ -12,7 +15,163 @@ from opal_common.utils import (
     tuple_to_dict,
 )
 from pydantic import ValidationError
-from tenacity import retry, stop, wait
+from tenacity import retry, retry_if_not_exception_type, stop, wait
+from tenacity.wait import wait_base
+
+# Statuses the OPAL server uses to say "this will work later, come back":
+#   503 - the scope's repo clone is in progress, or its clone vanished/is corrupt
+#   429 - the server (or something in front of it) is shedding load
+# Both may carry a `Retry-After` header telling us how long to wait.
+RETRYABLE_BUNDLE_STATUSES = frozenset(
+    {status.HTTP_503_SERVICE_UNAVAILABLE, status.HTTP_429_TOO_MANY_REQUESTS}
+)
+
+# Statuses that will NOT fix themselves by asking again:
+#   409 - the scope's branch could not be resolved in the policy repo
+# (404 is handled separately, so that it keeps raising an HTTPException.)
+NON_RETRYABLE_BUNDLE_STATUSES = frozenset({status.HTTP_409_CONFLICT})
+
+
+class BundleFetchError(Exception):
+    """A bundle request that the server answered with a status we classified.
+
+    Carries the status code and the server's `detail` so callers (and
+    logs) can tell a "come back later" apart from a "this will never
+    work".
+    """
+
+    def __init__(self, status_code: int, detail: str = ""):
+        self.status_code = status_code
+        self.detail = detail
+        # Deliberately NOT `super().__init__(...)`: BundlePathNotFoundError also
+        # inherits fastapi's HTTPException, and a cooperative super() would hand
+        # this message string to HTTPException.__init__ as its `status_code`.
+        Exception.__init__(
+            self, f"bundle fetch failed with status {status_code}: {detail}"
+        )
+
+    def __repr__(self) -> str:
+        return (
+            f"{self.__class__.__name__}(status_code={self.status_code!r}, "
+            f"detail={self.detail!r})"
+        )
+
+
+class RetryableBundleError(BundleFetchError):
+    """The server said the bundle is temporarily unavailable.
+
+    `retry_after` is the server's `Retry-After` hint in seconds, or None
+    if the header was absent or could not be parsed.
+    """
+
+    def __init__(
+        self, status_code: int, retry_after: Optional[float] = None, detail: str = ""
+    ):
+        self.retry_after = retry_after
+        super().__init__(status_code, detail)
+
+    def __repr__(self) -> str:
+        return (
+            f"{self.__class__.__name__}(status_code={self.status_code!r}, "
+            f"retry_after={self.retry_after!r}, detail={self.detail!r})"
+        )
+
+
+class NonRetryableBundleError(BundleFetchError):
+    """The server said this request cannot succeed; retrying only adds load."""
+
+
+class BundlePathNotFoundError(NonRetryableBundleError, HTTPException):
+    """404 - the requested path is not in the policy repo.
+
+    Inherits `HTTPException` as well so that callers written against the
+    pre-existing behaviour (this used to be a bare `fastapi.HTTPException`)
+    keep working unchanged, while the retry predicate can still recognise
+    it as non-retryable through the single `NonRetryableBundleError` type.
+    """
+
+    def __init__(self, detail: str = ""):
+        HTTPException.__init__(
+            self, status_code=status.HTTP_404_NOT_FOUND, detail=detail
+        )
+        NonRetryableBundleError.__init__(
+            self, status_code=status.HTTP_404_NOT_FOUND, detail=detail
+        )
+
+
+def parse_retry_after(value: Optional[str]) -> Optional[float]:
+    """Parses an HTTP `Retry-After` header into seconds from now.
+
+    Accepts both forms allowed by RFC 9110: delta-seconds (we also
+    tolerate a float) and an HTTP-date. Returns None when the header is
+    missing or cannot be parsed -- a malformed header must never be
+    able to stall the client. Negative or past values are clamped to 0.
+    """
+    if value is None:
+        return None
+    value = value.strip()
+    if not value:
+        return None
+
+    # delta-seconds
+    try:
+        seconds = float(value)
+    except (TypeError, ValueError):
+        pass
+    else:
+        # "nan"/"inf" parse as floats but are not usable sleep durations
+        if not math.isfinite(seconds):
+            return None
+        return max(seconds, 0.0)
+
+    # HTTP-date
+    try:
+        when = parsedate_to_datetime(value)
+    except (TypeError, ValueError):
+        return None
+    if when is None:  # older pythons return None instead of raising
+        return None
+    if when.tzinfo is None:
+        # An HTTP-date without a timezone is GMT by definition.
+        when = when.replace(tzinfo=timezone.utc)
+    return max((when - datetime.now(timezone.utc)).total_seconds(), 0.0)
+
+
+def _retry_after_of(retry_state) -> Optional[float]:
+    """The `Retry-After` the last attempt's exception carried, if any."""
+    outcome = getattr(retry_state, "outcome", None)
+    if outcome is None or not outcome.failed:
+        return None
+    error = outcome.exception()
+    if isinstance(error, RetryableBundleError):
+        return error.retry_after
+    return None
+
+
+class wait_retry_after_or_backoff(wait_base):
+    """Waits for whichever is longer: the server's `Retry-After` or our
+    backoff.
+
+    The server knows how long its clone will take; our backoff exists to
+    protect the server from a stampede. Honouring the larger of the two
+    respects both.
+
+    `max_retry_after` bounds only the *server-supplied* value, so a
+    hostile or buggy header cannot stall the client for hours. It
+    deliberately does NOT clamp `base_wait`, which is the operator's own
+    POLICY_UPDATER_CONN_RETRY configuration and must keep its meaning.
+    """
+
+    def __init__(self, base_wait: wait_base, max_retry_after: float):
+        self._base_wait = base_wait
+        self._max_retry_after = max_retry_after
+
+    def __call__(self, retry_state) -> float:
+        base = self._base_wait(retry_state)
+        retry_after = _retry_after_of(retry_state)
+        if retry_after is None:
+            return base
+        return max(min(retry_after, self._max_retry_after), base)
 
 
 def force_valid_bundle(bundle) -> PolicyBundle:
@@ -23,6 +182,26 @@ def force_valid_bundle(bundle) -> PolicyBundle:
             "server returned invalid bundle: {err}", bundle=bundle, err=repr(e)
         )
         raise
+
+
+async def _response_detail(response) -> str:
+    """Best-effort extraction of the server's error `detail`.
+
+    Must never raise: it runs on the error path, and a server that
+    answered with a non-JSON body (a proxy's HTML 503 page, say) would
+    otherwise turn a clean classification into an unclassified
+    ValueError.
+    """
+    try:
+        body = await response.json()
+    except Exception:
+        try:
+            return (await response.text())[:512]
+        except Exception:
+            return ""
+    if isinstance(body, dict):
+        return str(body.get("detail", body))[:512]
+    return str(body)[:512]
 
 
 class PolicyFetcher:
@@ -42,6 +221,15 @@ class PolicyFetcher:
             opal_client_config.POLICY_UPDATER_CONN_RETRY.toTenacityConfig()
         )
         self._retry_config["reraise"] = True  # This is currently not configurable
+        # Never spend attempts on a status the server told us is permanent.
+        self._retry_config["retry"] = retry_if_not_exception_type(
+            NonRetryableBundleError
+        )
+        # Honour the server's `Retry-After` on top of the configured backoff.
+        self._retry_config["wait"] = wait_retry_after_or_backoff(
+            self._retry_config["wait"],
+            max_retry_after=opal_client_config.POLICY_UPDATER_MAX_RETRY_AFTER,
+        )
 
         scope_id = opal_client_config.SCOPE_ID
 
@@ -75,12 +263,42 @@ class PolicyFetcher:
             )
             raise
 
+    async def _classify_response(self, response) -> None:
+        """Raises a classified error if the response is one we know about.
+
+        Returns normally for anything else, leaving
+        `throw_if_bad_status_code` to apply the pre-existing (retryable)
+        behaviour.
+        """
+        if response.status in RETRYABLE_BUNDLE_STATUSES:
+            retry_after = parse_retry_after(response.headers.get("Retry-After"))
+            detail = await _response_detail(response)
+            logger.warning(
+                "Bundle fetch retryable ({status}); server asked to retry after {retry_after}s",
+                status=response.status,
+                retry_after=retry_after,
+            )
+            raise RetryableBundleError(
+                response.status, retry_after=retry_after, detail=detail
+            )
+
+        if response.status in NON_RETRYABLE_BUNDLE_STATUSES:
+            detail = await _response_detail(response)
+            logger.warning(
+                "Bundle fetch non-retryable ({status}): {detail}",
+                status=response.status,
+                detail=detail,
+            )
+            raise NonRetryableBundleError(response.status, detail=detail)
+
     async def _fetch_policy_bundle(
         self, directories: List[str] = ["."], base_hash: Optional[str] = None
     ) -> Optional[PolicyBundle]:
         """Fetches the bundle.
 
-        May throw, in which case we retry again.
+        May throw, in which case we retry again -- unless the error is a
+        NonRetryableBundleError, which the retry predicate lets through
+        immediately.
         """
         params = {"path": directories}
         if base_hash is not None:
@@ -107,10 +325,12 @@ class PolicyFetcher:
                             "requested paths not found: {paths}",
                             paths=directories,
                         )
-                        raise HTTPException(
-                            status_code=status.HTTP_404_NOT_FOUND,
+                        raise BundlePathNotFoundError(
                             detail=f"requested path {self._policy_endpoint_url} was not found in the policy repo!",
                         )
+
+                    # may throw RetryableBundleError / NonRetryableBundleError
+                    await self._classify_response(response)
 
                     # may throw ValueError
                     await throw_if_bad_status_code(

--- a/packages/opal-client/opal_client/policy/options.py
+++ b/packages/opal-client/opal_client/policy/options.py
@@ -35,6 +35,24 @@ class ConnRetryOptions(BaseModel):
         description="max time to wait in total (for exponential strategies only)",
     )
 
+    def worstCaseTotalWait(self) -> float:
+        """Upper bound (seconds) on the time this policy can spend *waiting*.
+
+        Callers use it to size a wall-clock stop condition without truncating a
+        retry budget the operator asked for. Note that the exponential
+        strategies default `max_wait` to tenacity's MAX_WAIT, so an operator who
+        configures an unbounded backoff gets an unbounded bound -- which is the
+        point: their configuration wins.
+        """
+        if self.wait_strategy in (
+            WaitStrategy.exponential,
+            WaitStrategy.random_exponential,
+        ):
+            per_wait = self.max_wait
+        else:
+            per_wait = self.wait_time
+        return max(self.attempts, 0) * per_wait
+
     def toTenacityConfig(self):
         if self.wait_strategy == WaitStrategy.exponential:
             wait = wait_exponential(multiplier=self.wait_time, max=self.max_wait)

--- a/packages/opal-client/opal_client/policy/options.py
+++ b/packages/opal-client/opal_client/policy/options.py
@@ -39,19 +39,36 @@ class ConnRetryOptions(BaseModel):
         """Upper bound (seconds) on the time this policy can spend *waiting*.
 
         Callers use it to size a wall-clock stop condition without truncating a
-        retry budget the operator asked for. Note that the exponential
-        strategies default `max_wait` to tenacity's MAX_WAIT, so an operator who
-        configures an unbounded backoff gets an unbounded bound -- which is the
-        point: their configuration wins.
+        retry budget the operator asked for.
+
+        This is the exact sum of the individual waits, not `attempts x max_wait`:
+        `max_wait` defaults to tenacity's MAX_WAIT (~4.6e18), so the coarse
+        estimate would be astronomically large for anyone who selects an
+        exponential strategy without pinning `max_wait`, and a bound derived
+        from it would be no bound at all.
+
+        `attempts` attempts are separated by `attempts - 1` waits. Once the
+        doubling reaches `max_wait` every remaining wait is `max_wait`, so we
+        add them in one step and stop doubling -- both because it is cheaper and
+        because `wait_time * 2 ** i` raises OverflowError past i == 1023, which
+        a large `attempts` would otherwise hit at client startup.
         """
-        if self.wait_strategy in (
+        n_waits = max(self.attempts - 1, 0)
+        if self.wait_strategy not in (
             WaitStrategy.exponential,
             WaitStrategy.random_exponential,
         ):
-            per_wait = self.max_wait
-        else:
-            per_wait = self.wait_time
-        return max(self.attempts, 0) * per_wait
+            return float(n_waits * self.wait_time)
+
+        total = 0.0
+        wait = float(self.wait_time)
+        for i in range(n_waits):
+            if wait >= self.max_wait:
+                total += (n_waits - i) * self.max_wait
+                break
+            total += wait
+            wait *= 2.0
+        return total
 
     def toTenacityConfig(self):
         if self.wait_strategy == WaitStrategy.exponential:

--- a/packages/opal-client/opal_client/policy/updater.py
+++ b/packages/opal-client/opal_client/policy/updater.py
@@ -10,7 +10,7 @@ from opal_client.callbacks.reporter import CallbacksReporter
 from opal_client.config import opal_client_config
 from opal_client.data.fetcher import DataFetcher
 from opal_client.logger import logger
-from opal_client.policy.fetcher import PolicyFetcher
+from opal_client.policy.fetcher import PolicyFetcher, RetryableBundleError
 from opal_client.policy.topics import default_subscribed_policy_directories
 from opal_client.policy_store.base_policy_store_client import BasePolicyStoreClient
 from opal_client.policy_store.policy_store_client_factory import (
@@ -24,6 +24,11 @@ from opal_common.schemas.store import TransactionType
 from opal_common.security.sslcontext import get_custom_ssl_context
 from opal_common.topics.utils import pubsub_topics_from_directories
 from opal_common.utils import get_authorization_header
+
+# Floor for a deferred re-fetch, and the base of its per-round exponential
+# backoff. Used when the server did not send a `Retry-After` (or sent a smaller
+# one than the round's backoff).
+DEFERRED_REFETCH_BASE_SECONDS = 5.0
 
 
 class PolicyUpdater:
@@ -106,6 +111,11 @@ class PolicyUpdater:
             else {}
         )
         self._policy_update_queue = asyncio.Queue()
+        # At most ONE pending deferred bundle re-fetch, armed when a fetch
+        # exhausts its retries against a retryable error (e.g. the server is
+        # still cloning the scope's repo). See _maybe_schedule_deferred_refetch.
+        self._deferred_refetch_task: Optional[asyncio.Task] = None
+        self._deferred_refetch_rounds: int = 0
         self._tasks = TasksPool()
         self._on_connect_callbacks = on_connect or []
         self._on_disconnect_callbacks = on_disconnect or []
@@ -154,6 +164,97 @@ class PolicyUpdater:
     async def trigger_update_policy(
         self, directories: List[str] = None, force_full_update: bool = False
     ):
+        # A freshly-triggered update supersedes any pending deferred re-fetch:
+        # we are about to do the work that the timer was waiting to do.
+        self._cancel_deferred_refetch()
+        self._deferred_refetch_rounds = 0
+        await self._policy_update_queue.put((directories, force_full_update))
+
+    def _cancel_deferred_refetch(self):
+        """Cancels the pending deferred re-fetch, if any."""
+        task = self._deferred_refetch_task
+        if task is not None:
+            self._deferred_refetch_task = None
+            task.cancel()
+
+    def _deferred_refetch_delay(
+        self, retry_after: Optional[float], round_index: int
+    ) -> float:
+        """How long to wait before the next deferred bundle re-fetch.
+
+        Whichever is longer: the server's `Retry-After` hint, or our own
+        per-round exponential backoff. Both are bounded by
+        POLICY_UPDATER_MAX_RETRY_AFTER so that neither a hostile header
+        nor a long-running outage pushes the next attempt hours out.
+        """
+        ceiling = float(opal_client_config.POLICY_UPDATER_MAX_RETRY_AFTER)
+        backoff = min(
+            DEFERRED_REFETCH_BASE_SECONDS * (2 ** max(round_index - 1, 0)), ceiling
+        )
+        if retry_after is None:
+            return backoff
+        return min(max(retry_after, backoff), ceiling)
+
+    def _maybe_schedule_deferred_refetch(
+        self,
+        error: RetryableBundleError,
+        directories: List[str],
+        force_full_update: bool,
+    ):
+        """Arms a single deferred bundle re-fetch after a retryable failure.
+
+        Without this, a client whose bundle request exhausted its
+        retries sits on a stale policy store until the next pub/sub
+        message or WebSocket reconnect -- which for a low-churn scope
+        can be hours.
+        """
+        if not opal_client_config.POLICY_UPDATER_RESCHEDULE_ON_RETRYABLE:
+            return
+
+        if self._stopping:
+            return
+
+        # Coalesce: one pending timer at a time, never a stack of them.
+        if self._deferred_refetch_task is not None:
+            return
+
+        max_rounds = opal_client_config.POLICY_UPDATER_MAX_DEFERRED_ROUNDS
+        if self._deferred_refetch_rounds >= max_rounds:
+            logger.warning(
+                "Giving up on deferred bundle re-fetch after {rounds} rounds; "
+                "waiting for the next policy update or reconnect",
+                rounds=self._deferred_refetch_rounds,
+            )
+            return
+
+        self._deferred_refetch_rounds += 1
+        delay = self._deferred_refetch_delay(
+            error.retry_after, self._deferred_refetch_rounds
+        )
+        logger.warning(
+            "Deferring bundle re-fetch by {delay}s (round {round}/{max_rounds})",
+            delay=delay,
+            round=self._deferred_refetch_rounds,
+            max_rounds=max_rounds,
+        )
+        self._deferred_refetch_task = asyncio.create_task(
+            self._deferred_refetch(delay, directories, force_full_update)
+        )
+
+    async def _deferred_refetch(
+        self, delay: float, directories: List[str], force_full_update: bool
+    ):
+        """Sleeps, then re-queues the update that failed.
+
+        Goes through the update queue rather than calling
+        update_policy() directly so that the re-fetch stays serialized
+        with every other policy update -- two concurrent policy-store
+        transactions would race.
+        """
+        await asyncio.sleep(delay)
+        # Clear our own handle before queueing: from here on there is nothing
+        # left to cancel, and the next failure is free to arm a new timer.
+        self._deferred_refetch_task = None
         await self._policy_update_queue.put((directories, force_full_update))
 
     async def _on_connect(self, client: PubSubClient, channel: RpcChannel):
@@ -187,6 +288,7 @@ class PolicyUpdater:
         """Resets internal state so the updater can be started again after
         being stopped."""
         self._stopping = False
+        self._deferred_refetch_rounds = 0
         self._tasks.restart()
 
     async def start(self):
@@ -203,6 +305,9 @@ class PolicyUpdater:
         """Stops the policy updater."""
         self._stopping = True
         logger.info("Stopping policy updater")
+
+        # drop any pending deferred bundle re-fetch
+        self._cancel_deferred_refetch()
 
         # disconnect from Pub/Sub
         if self._client is not None:
@@ -300,6 +405,7 @@ class PolicyUpdater:
         bundle_error = None
         bundle = None
         bundle_succeeded = True
+        retryable_error: Optional[RetryableBundleError] = None
         try:
             bundle: Optional[
                 PolicyBundle
@@ -331,6 +437,17 @@ class PolicyUpdater:
         except Exception as err:
             bundle_error = repr(err)
             bundle_succeeded = False
+            if isinstance(err, RetryableBundleError):
+                retryable_error = err
+
+        if bundle_succeeded:
+            # We are in sync again: drop any timer armed by an earlier failure.
+            self._cancel_deferred_refetch()
+            self._deferred_refetch_rounds = 0
+        elif retryable_error is not None:
+            self._maybe_schedule_deferred_refetch(
+                retryable_error, directories, force_full_update
+            )
 
         bundle_hash = None if bundle is None else bundle.hash
 

--- a/packages/opal-client/opal_client/policy/updater.py
+++ b/packages/opal-client/opal_client/policy/updater.py
@@ -128,6 +128,10 @@ class PolicyUpdater:
         # still cloning the scope's repo). See _maybe_schedule_deferred_refetch.
         self._deferred_refetch_task: Optional[asyncio.Task] = None
         self._deferred_refetch_rounds: int = 0
+        # True once the escalation budget is spent and we have fallen back to a
+        # flat re-fetch cadence. Tracked so the notice is logged once per
+        # episode rather than once per round.
+        self._deferred_flat_phase: bool = False
         self._tasks = TasksPool()
         self._on_connect_callbacks = on_connect or []
         self._on_disconnect_callbacks = on_disconnect or []
@@ -176,6 +180,7 @@ class PolicyUpdater:
         # only *incoming* signal that resets it -- notably not a reconnect, which
         # would otherwise make MAX_DEFERRED_ROUNDS unreachable.
         self._deferred_refetch_rounds = 0
+        self._deferred_flat_phase = False
         await self.trigger_update_policy(directories)
 
     async def trigger_update_policy(
@@ -223,6 +228,18 @@ class PolicyUpdater:
         bounded = max(min(raw, ceiling), DEFERRED_REFETCH_BASE_SECONDS)
         return _jittered(bounded)
 
+    def _flat_refetch_delay(self) -> float:
+        """Steady-state cadence once the escalation budget is spent.
+
+        Flat rather than growing: the client must keep asking, because a
+        WebSocket that never reconnects and a scope that never receives a
+        commit would otherwise leave it permanently stale after a long
+        clone. Jittered and floored for the same reasons the escalating
+        delay is.
+        """
+        ceiling = float(opal_client_config.POLICY_UPDATER_MAX_RETRY_AFTER)
+        return _jittered(max(ceiling, DEFERRED_REFETCH_BASE_SECONDS))
+
     def _maybe_schedule_deferred_refetch(
         self,
         error: RetryableBundleError,
@@ -248,23 +265,28 @@ class PolicyUpdater:
 
         max_rounds = opal_client_config.POLICY_UPDATER_MAX_DEFERRED_ROUNDS
         if self._deferred_refetch_rounds >= max_rounds:
-            logger.warning(
-                "Giving up on deferred bundle re-fetch after {rounds} rounds; "
-                "waiting for the next policy update or reconnect",
-                rounds=self._deferred_refetch_rounds,
+            # The budget bounds ESCALATION, not the deferral itself: stopping
+            # here would strand a client whose WebSocket never reconnects and
+            # whose scope never receives a commit. Keep asking, at a flat rate.
+            if not self._deferred_flat_phase:
+                self._deferred_flat_phase = True
+                logger.warning(
+                    "Bundle re-fetch budget exhausted; continuing at a flat "
+                    "{cap}s cadence",
+                    cap=float(opal_client_config.POLICY_UPDATER_MAX_RETRY_AFTER),
+                )
+            delay = self._flat_refetch_delay()
+        else:
+            self._deferred_refetch_rounds += 1
+            delay = self._deferred_refetch_delay(
+                error.retry_after, self._deferred_refetch_rounds
             )
-            return
-
-        self._deferred_refetch_rounds += 1
-        delay = self._deferred_refetch_delay(
-            error.retry_after, self._deferred_refetch_rounds
-        )
-        logger.warning(
-            "Deferring bundle re-fetch by {delay}s (round {round}/{max_rounds})",
-            delay=delay,
-            round=self._deferred_refetch_rounds,
-            max_rounds=max_rounds,
-        )
+            logger.warning(
+                "Deferring bundle re-fetch by {delay}s (round {round}/{max_rounds})",
+                delay=delay,
+                round=self._deferred_refetch_rounds,
+                max_rounds=max_rounds,
+            )
         self._deferred_refetch_task = asyncio.create_task(
             self._deferred_refetch(delay, directories, force_full_update)
         )
@@ -317,6 +339,7 @@ class PolicyUpdater:
         being stopped."""
         self._stopping = False
         self._deferred_refetch_rounds = 0
+        self._deferred_flat_phase = False
         self._tasks.restart()
 
     async def start(self):
@@ -487,6 +510,7 @@ class PolicyUpdater:
             # We are in sync again: drop any timer armed by an earlier failure.
             self._cancel_deferred_refetch()
             self._deferred_refetch_rounds = 0
+            self._deferred_flat_phase = False
         elif retryable_error is not None:
             self._maybe_schedule_deferred_refetch(
                 retryable_error, directories, force_full_update

--- a/packages/opal-client/opal_client/policy/updater.py
+++ b/packages/opal-client/opal_client/policy/updater.py
@@ -1,4 +1,5 @@
 import asyncio
+import random
 from typing import List, Optional
 
 import pydantic
@@ -29,6 +30,17 @@ from opal_common.utils import get_authorization_header
 # backoff. Used when the server did not send a `Retry-After` (or sent a smaller
 # one than the round's backoff).
 DEFERRED_REFETCH_BASE_SECONDS = 5.0
+
+
+def _jittered(delay: float) -> float:
+    """Spreads a deferred re-fetch uniformly over [delay/2, delay].
+
+    Without this every client that hit the same outage re-fetches on the
+    same tick, so the fleet arrives at the server in lockstep and re-
+    creates the stampede the backoff exists to prevent. Module-level so
+    tests can replace it with the identity function.
+    """
+    return random.uniform(delay / 2.0, delay)
 
 
 class PolicyUpdater:
@@ -159,6 +171,11 @@ class PolicyUpdater:
                 set(self._subscription_directories)
             )
         )
+        # A real policy update means the source moved on: the previous failure
+        # episode is over, so the deferred round budget starts fresh. This is the
+        # only *incoming* signal that resets it -- notably not a reconnect, which
+        # would otherwise make MAX_DEFERRED_ROUNDS unreachable.
+        self._deferred_refetch_rounds = 0
         await self.trigger_update_policy(directories)
 
     async def trigger_update_policy(
@@ -166,16 +183,25 @@ class PolicyUpdater:
     ):
         # A freshly-triggered update supersedes any pending deferred re-fetch:
         # we are about to do the work that the timer was waiting to do.
+        # NOTE: deliberately does NOT reset `_deferred_refetch_rounds`. This runs
+        # on every WebSocket reconnect (via _on_connect), and reconnects are
+        # frequent during exactly the outages the round budget is meant to bound
+        # -- resetting here would make MAX_DEFERRED_ROUNDS unreachable. Only a
+        # genuine incoming policy update, or a successful fetch, resets it.
         self._cancel_deferred_refetch()
-        self._deferred_refetch_rounds = 0
         await self._policy_update_queue.put((directories, force_full_update))
 
-    def _cancel_deferred_refetch(self):
-        """Cancels the pending deferred re-fetch, if any."""
+    def _cancel_deferred_refetch(self) -> Optional[asyncio.Task]:
+        """Cancels the pending deferred re-fetch, if any, and returns it.
+
+        The caller may await the returned task to make sure it has
+        actually finished unwinding (see stop()).
+        """
         task = self._deferred_refetch_task
         if task is not None:
             self._deferred_refetch_task = None
             task.cancel()
+        return task
 
     def _deferred_refetch_delay(
         self, retry_after: Optional[float], round_index: int
@@ -183,17 +209,19 @@ class PolicyUpdater:
         """How long to wait before the next deferred bundle re-fetch.
 
         Whichever is longer: the server's `Retry-After` hint, or our own
-        per-round exponential backoff. Both are bounded by
-        POLICY_UPDATER_MAX_RETRY_AFTER so that neither a hostile header
-        nor a long-running outage pushes the next attempt hours out.
+        per-round exponential backoff (5, 10, 20, 40, ... seconds). The
+        result is then bounded above by POLICY_UPDATER_MAX_RETRY_AFTER --
+        so neither a hostile header nor a long outage pushes the next
+        attempt hours out -- and below by DEFERRED_REFETCH_BASE_SECONDS,
+        so a mis-set (or zero) ceiling cannot collapse the deferral into
+        a back-to-back loop. Finally it is jittered into [delay/2, delay]
+        so a whole fleet does not come back on the same tick.
         """
         ceiling = float(opal_client_config.POLICY_UPDATER_MAX_RETRY_AFTER)
-        backoff = min(
-            DEFERRED_REFETCH_BASE_SECONDS * (2 ** max(round_index - 1, 0)), ceiling
-        )
-        if retry_after is None:
-            return backoff
-        return min(max(retry_after, backoff), ceiling)
+        backoff = DEFERRED_REFETCH_BASE_SECONDS * (2 ** max(round_index - 1, 0))
+        raw = backoff if retry_after is None else max(retry_after, backoff)
+        bounded = max(min(raw, ceiling), DEFERRED_REFETCH_BASE_SECONDS)
+        return _jittered(bounded)
 
     def _maybe_schedule_deferred_refetch(
         self,
@@ -306,8 +334,11 @@ class PolicyUpdater:
         self._stopping = True
         logger.info("Stopping policy updater")
 
-        # drop any pending deferred bundle re-fetch
-        self._cancel_deferred_refetch()
+        # drop any pending deferred bundle re-fetch, and wait for it to unwind
+        # so we do not leave a half-cancelled task behind at shutdown
+        deferred_refetch = self._cancel_deferred_refetch()
+        if deferred_refetch is not None:
+            await asyncio.gather(deferred_refetch, return_exceptions=True)
 
         # disconnect from Pub/Sub
         if self._client is not None:
@@ -393,7 +424,19 @@ class PolicyUpdater:
             logger.info("full update was forced (ignoring stored hash if exists)")
             base_hash = None
         else:
-            base_hash = await self._policy_store.get_policy_version()
+            try:
+                base_hash = await self._policy_store.get_policy_version()
+            except Exception as err:
+                # The policy store can be restarting alongside the server. If we
+                # let this escape, update_policy() never reaches the fetch, so no
+                # deferred re-fetch is armed and the client waits for an external
+                # event to recover. Degrade to a full bundle instead.
+                logger.warning(
+                    "Could not read the current policy version from the policy "
+                    "store ({err}); falling back to a full bundle fetch",
+                    err=repr(err),
+                )
+                base_hash = None
 
         if base_hash is None:
             logger.info("Refetching policy code (full bundle)")

--- a/packages/opal-client/opal_client/tests/policy_fetcher_retry_test.py
+++ b/packages/opal-client/opal_client/tests/policy_fetcher_retry_test.py
@@ -1,0 +1,494 @@
+"""Tests for the bundle-fetch retry policy of `opal_client.policy.fetcher`.
+
+The OPAL server (scopes mode) answers `GET /scopes/{id}/policy` with:
+
+  * ``503`` + ``Retry-After: 30``  -- the scope's clone is still in progress
+  * ``503`` + ``Retry-After: 5``   -- the clone vanished / is corrupt
+  * ``409``                        -- the branch could not be resolved (never
+                                      fixes itself by retrying)
+  * ``404``                        -- the requested path is not in the repo
+
+Before this module existed the client retried *every* exception with a blind
+random-exponential backoff, never read ``Retry-After``, and hammered a 409 four
+extra times. These tests pin the classification, the wait computation and the
+"do not retry what cannot succeed" rule.
+
+Every test names the single-line mutation it is designed to catch, so that a
+future refactor that silently drops a guard fails here.
+"""
+
+import asyncio
+import os
+import sys
+from datetime import datetime, timedelta, timezone
+from email.utils import format_datetime
+
+import aiohttp
+import pytest
+from fastapi import HTTPException
+from tenacity import RetryCallState, wait_fixed
+
+# Add parent path to use local src as package for tests
+root_dir = os.path.abspath(
+    os.path.join(os.path.dirname(__file__), os.path.pardir, os.path.pardir)
+)
+sys.path.append(root_dir)
+
+from opal_client.config import opal_client_config
+from opal_client.policy.fetcher import (
+    BundlePathNotFoundError,
+    NonRetryableBundleError,
+    PolicyFetcher,
+    RetryableBundleError,
+    parse_retry_after,
+    wait_retry_after_or_backoff,
+)
+
+# ---------------------------------------------------------------------------
+# aiohttp test doubles
+# ---------------------------------------------------------------------------
+
+
+class FakeResponse:
+    """Minimal stand-in for `aiohttp.ClientResponse`."""
+
+    def __init__(self, status: int, headers: dict = None, body=None):
+        self.status = status
+        self.headers = headers or {}
+        self._body = body
+
+    async def json(self):
+        if self._body is None:
+            raise ValueError("no json body")
+        return self._body
+
+    async def text(self):
+        return str(self._body)
+
+
+class _FakeGetContext:
+    def __init__(self, response_or_exc):
+        self._response_or_exc = response_or_exc
+
+    async def __aenter__(self):
+        if isinstance(self._response_or_exc, Exception):
+            raise self._response_or_exc
+        return self._response_or_exc
+
+    async def __aexit__(self, *args):
+        return False
+
+
+class FakeSession:
+    """Replaces `aiohttp.ClientSession`; replays a scripted list of responses.
+
+    `_fetch_policy_bundle` opens a fresh session per attempt, so the script
+    cursor is class-level: attempt N gets script[N-1]. The last entry repeats if
+    more requests arrive than were scripted, so a test can script one response
+    and let tenacity retry against it N times.
+    """
+
+    instances = []
+    script = []
+    calls = 0  # class-level: total requests across all attempts
+
+    def __init__(self, *args, **kwargs):
+        self.request_kwargs = []
+        FakeSession.instances.append(self)
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *args):
+        return False
+
+    def get(self, url, **kwargs):
+        FakeSession.calls += 1
+        self.request_kwargs.append(kwargs)
+        entry = FakeSession.script[
+            min(FakeSession.calls - 1, len(FakeSession.script) - 1)
+        ]
+        return _FakeGetContext(entry)
+
+
+@pytest.fixture
+def scripted_session(monkeypatch):
+    """Patch aiohttp.ClientSession with FakeSession for the duration of a test.
+
+    Returns a setter that installs the response script and hands back the list
+    of sessions that were created (one per `_fetch_policy_bundle` attempt).
+    """
+    FakeSession.instances = []
+    FakeSession.script = []
+    FakeSession.calls = 0
+    monkeypatch.setattr(aiohttp, "ClientSession", FakeSession)
+
+    def _install(*responses):
+        FakeSession.script = list(responses)
+        return FakeSession.instances
+
+    yield _install
+
+    FakeSession.instances = []
+    FakeSession.script = []
+    FakeSession.calls = 0
+
+
+def total_requests() -> int:
+    """How many HTTP GETs were issued across all attempts."""
+    return FakeSession.calls
+
+
+@pytest.fixture
+def no_sleep():
+    """Records the waits tenacity *would* have slept, without sleeping."""
+    recorded = []
+
+    async def _sleep(seconds):
+        recorded.append(seconds)
+
+    _sleep.recorded = recorded
+    return _sleep
+
+
+def make_fetcher(no_sleep=None, attempts: int = None, **config_overrides):
+    """Builds a PolicyFetcher, optionally overriding retry knobs."""
+    fetcher = PolicyFetcher(backend_url="http://opal-server:7002", token="t")
+    if attempts is not None:
+        from tenacity import stop_after_attempt
+
+        fetcher._retry_config["stop"] = stop_after_attempt(attempts)
+    if no_sleep is not None:
+        # `fetch_policy_bundle` builds the tenacity attempter per call from
+        # `_retry_config`, so injecting `sleep` here keeps the test instant.
+        fetcher._retry_config["sleep"] = no_sleep
+    for key, value in config_overrides.items():
+        setattr(fetcher, key, value)
+    return fetcher
+
+
+# ---------------------------------------------------------------------------
+# parse_retry_after
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "header,expected",
+    [("30", 30.0), ("5", 5.0), ("0", 0.0), ("0.5", 0.5), ("  12  ", 12.0)],
+)
+def test_parse_retry_after_delta_seconds(header, expected):
+    # MUTATION: returning `None` instead of the parsed float (i.e. deleting the
+    # delta-seconds branch) makes every case here fail.
+    assert parse_retry_after(header) == pytest.approx(expected)
+
+
+def test_parse_retry_after_http_date():
+    when = datetime.now(timezone.utc) + timedelta(seconds=45)
+    parsed = parse_retry_after(format_datetime(when, usegmt=True))
+    assert parsed is not None
+    # HTTP-date has 1s resolution, and a little wall-clock passes in between.
+    # MUTATION: dropping the `parsedate_to_datetime` branch returns None here.
+    assert 42.0 <= parsed <= 46.0
+
+
+def test_parse_retry_after_http_date_in_the_past_is_clamped_to_zero():
+    when = datetime.now(timezone.utc) - timedelta(seconds=120)
+    # MUTATION: replacing `max(delta, 0.0)` with `delta` yields ~-120 and fails.
+    assert parse_retry_after(format_datetime(when, usegmt=True)) == 0.0
+
+
+def test_parse_retry_after_naive_http_date_is_treated_as_utc():
+    # Some servers emit an RFC-850/asctime date with no timezone. `parsedate_to_datetime`
+    # returns a naive datetime for those; we must not crash comparing it to an aware now().
+    when = datetime.now(timezone.utc) + timedelta(seconds=30)
+    naive = when.strftime("%a %b %d %H:%M:%S %Y")  # asctime, no tz
+    parsed = parse_retry_after(naive)
+    assert parsed is not None
+    assert 27.0 <= parsed <= 32.0
+
+
+@pytest.mark.parametrize(
+    "header",
+    [None, "", "   ", "soon", "later please", "nan", "inf", "-inf", "1,5", "30s"],
+)
+def test_parse_retry_after_malformed_is_none(header):
+    # MUTATION: removing the `math.isfinite` guard lets "nan"/"inf" through and
+    # would produce a NaN/infinite sleep; removing the try/except would raise.
+    assert parse_retry_after(header) is None
+
+
+def test_parse_retry_after_negative_delta_is_clamped_to_zero():
+    # MUTATION: `float(value)` without the `max(..., 0.0)` clamp returns -10.0,
+    # which tenacity would happily "sleep" for, corrupting the wait computation.
+    assert parse_retry_after("-10") == 0.0
+
+
+# ---------------------------------------------------------------------------
+# wait_retry_after_or_backoff
+# ---------------------------------------------------------------------------
+
+
+def _retry_state(exc: Exception = None, attempt_number: int = 2) -> RetryCallState:
+    state = RetryCallState(retry_object=None, fn=None, args=(), kwargs={})
+    state.attempt_number = attempt_number
+    if exc is not None:
+        state.set_exception((type(exc), exc, exc.__traceback__))
+    else:
+        state.set_result(None)
+    return state
+
+
+def test_wait_prefers_retry_after_when_larger_than_backoff():
+    waiter = wait_retry_after_or_backoff(wait_fixed(1), max_retry_after=60)
+    state = _retry_state(RetryableBundleError(503, retry_after=30.0))
+    # MUTATION: returning `base` unconditionally (dropping the max()) gives 1.0.
+    assert waiter(state) == pytest.approx(30.0)
+
+
+def test_wait_prefers_backoff_when_larger_than_retry_after():
+    waiter = wait_retry_after_or_backoff(wait_fixed(12), max_retry_after=60)
+    state = _retry_state(RetryableBundleError(503, retry_after=3.0))
+    # MUTATION: returning `retry_after` unconditionally gives 3.0 and would let
+    # a server shrink the operator's configured backoff.
+    assert waiter(state) == pytest.approx(12.0)
+
+
+def test_wait_caps_a_hostile_retry_after():
+    waiter = wait_retry_after_or_backoff(wait_fixed(1), max_retry_after=60)
+    state = _retry_state(RetryableBundleError(503, retry_after=3600.0))
+    # MUTATION: dropping the `min(retry_after, max_retry_after)` cap stalls the
+    # client for an hour on a single hostile header.
+    assert waiter(state) == pytest.approx(60.0)
+
+
+def test_wait_falls_back_to_backoff_without_a_retry_after():
+    waiter = wait_retry_after_or_backoff(wait_fixed(7), max_retry_after=60)
+    assert waiter(_retry_state(RetryableBundleError(503, retry_after=None))) == 7.0
+    assert waiter(_retry_state(ValueError("boom"))) == 7.0
+    assert waiter(_retry_state(None)) == 7.0
+
+
+def test_wait_handles_a_state_with_no_outcome_yet():
+    waiter = wait_retry_after_or_backoff(wait_fixed(3), max_retry_after=60)
+    state = RetryCallState(retry_object=None, fn=None, args=(), kwargs={})
+    # MUTATION: reading `retry_state.outcome.failed` without the None guard
+    # raises AttributeError on the very first wait computation.
+    assert waiter(state) == 3.0
+
+
+def test_wait_does_not_shrink_a_backoff_larger_than_the_cap():
+    """The cap bounds the *server-supplied* header, not the operator's backoff.
+
+    POLICY_UPDATER_CONN_RETRY semantics must be unchanged.
+    """
+    waiter = wait_retry_after_or_backoff(wait_fixed(120), max_retry_after=60)
+    state = _retry_state(RetryableBundleError(503, retry_after=5.0))
+    # MUTATION: applying the cap to the whole max() would clamp this to 60.
+    assert waiter(state) == pytest.approx(120.0)
+
+
+# ---------------------------------------------------------------------------
+# response classification
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_503_raises_retryable_error_carrying_retry_after(
+    scripted_session, no_sleep
+):
+    scripted_session(
+        FakeResponse(
+            503, headers={"Retry-After": "30"}, body={"detail": "clone in progress"}
+        )
+    )
+    fetcher = make_fetcher(no_sleep, attempts=1)
+
+    with pytest.raises(RetryableBundleError) as excinfo:
+        await fetcher.fetch_policy_bundle()
+
+    # MUTATION: classifying 503 as non-retryable (or not classifying it at all)
+    # breaks the type assertion and the retry_after payload.
+    assert excinfo.value.status_code == 503
+    assert excinfo.value.retry_after == pytest.approx(30.0)
+
+
+@pytest.mark.asyncio
+async def test_429_is_retryable(scripted_session, no_sleep):
+    scripted_session(FakeResponse(429, headers={"Retry-After": "5"}, body={}))
+    fetcher = make_fetcher(no_sleep, attempts=1)
+
+    with pytest.raises(RetryableBundleError) as excinfo:
+        await fetcher.fetch_policy_bundle()
+
+    # MUTATION: dropping 429 from the retryable status set makes this a plain
+    # ValueError from throw_if_bad_status_code with no Retry-After.
+    assert excinfo.value.status_code == 429
+    assert excinfo.value.retry_after == pytest.approx(5.0)
+
+
+@pytest.mark.asyncio
+async def test_503_without_retry_after_header_is_still_retryable(
+    scripted_session, no_sleep
+):
+    scripted_session(FakeResponse(503, headers={}, body={"detail": "nope"}))
+    fetcher = make_fetcher(no_sleep, attempts=1)
+
+    with pytest.raises(RetryableBundleError) as excinfo:
+        await fetcher.fetch_policy_bundle()
+
+    assert excinfo.value.retry_after is None
+
+
+@pytest.mark.asyncio
+async def test_409_is_attempted_exactly_once(scripted_session, no_sleep):
+    scripted_session(FakeResponse(409, body={"detail": "branch not found"}))
+    fetcher = make_fetcher(no_sleep, attempts=5)
+
+    with pytest.raises(NonRetryableBundleError) as excinfo:
+        await fetcher.fetch_policy_bundle()
+
+    assert excinfo.value.status_code == 409
+    assert "branch not found" in excinfo.value.detail
+    # MUTATION: removing `retry=retry_if_not_exception_type(NonRetryableBundleError)`
+    # makes this 5 requests -- the exact bug this PR fixes (a 409 hammered for ~40s).
+    assert total_requests() == 1
+    assert no_sleep.recorded == []
+
+
+@pytest.mark.asyncio
+async def test_404_is_attempted_exactly_once_and_stays_an_http_exception(
+    scripted_session, no_sleep
+):
+    scripted_session(FakeResponse(404, body={"detail": "no such path"}))
+    fetcher = make_fetcher(no_sleep, attempts=5)
+
+    with pytest.raises(BundlePathNotFoundError) as excinfo:
+        await fetcher.fetch_policy_bundle()
+
+    # Backwards compatibility: callers that catch fastapi's HTTPException (the
+    # pre-PR behaviour for 404) keep working.
+    assert isinstance(excinfo.value, HTTPException)
+    assert isinstance(excinfo.value, NonRetryableBundleError)
+    assert excinfo.value.status_code == 404
+    # MUTATION: making BundlePathNotFoundError inherit only HTTPException (i.e.
+    # dropping it from the retry predicate's type) turns this into 5 requests.
+    assert total_requests() == 1
+
+
+@pytest.mark.asyncio
+async def test_503_is_retried_and_each_wait_honours_retry_after(
+    scripted_session, no_sleep
+):
+    scripted_session(FakeResponse(503, headers={"Retry-After": "30"}, body={}))
+    fetcher = make_fetcher(no_sleep, attempts=3)
+
+    with pytest.raises(RetryableBundleError):
+        await fetcher.fetch_policy_bundle()
+
+    assert total_requests() == 3
+    # 3 attempts => 2 waits between them.
+    assert len(no_sleep.recorded) == 2
+    # MUTATION: leaving `wait` as the bare random-exponential (max=10) makes every
+    # recorded wait <= 10 and fails here -- the "Retry-After is never read" bug.
+    assert all(wait >= 30.0 for wait in no_sleep.recorded)
+
+
+@pytest.mark.asyncio
+async def test_retry_after_is_capped_end_to_end(
+    scripted_session, no_sleep, monkeypatch
+):
+    monkeypatch.setattr(opal_client_config, "POLICY_UPDATER_MAX_RETRY_AFTER", 12.0)
+    scripted_session(FakeResponse(503, headers={"Retry-After": "9999"}, body={}))
+    fetcher = make_fetcher(no_sleep, attempts=2)
+
+    with pytest.raises(RetryableBundleError):
+        await fetcher.fetch_policy_bundle()
+
+    # MUTATION: ignoring POLICY_UPDATER_MAX_RETRY_AFTER sleeps for 9999s.
+    assert no_sleep.recorded == [pytest.approx(12.0)]
+
+
+@pytest.mark.asyncio
+async def test_unclassified_bad_status_is_still_retried(scripted_session, no_sleep):
+    """500 has no special handling -- it keeps the pre-PR retry behaviour."""
+    scripted_session(FakeResponse(500, body={"detail": "boom"}))
+    fetcher = make_fetcher(no_sleep, attempts=4)
+
+    with pytest.raises(ValueError):
+        await fetcher.fetch_policy_bundle()
+
+    # MUTATION: excluding *all* errors from retry (e.g. inverting the predicate)
+    # would make this 1 request and silently weaken transient-fault handling.
+    assert total_requests() == 4
+
+
+@pytest.mark.asyncio
+async def test_connection_errors_are_still_retried(scripted_session, no_sleep):
+    scripted_session(aiohttp.ClientConnectionError("refused"))
+    fetcher = make_fetcher(no_sleep, attempts=3)
+
+    with pytest.raises(aiohttp.ClientError):
+        await fetcher.fetch_policy_bundle()
+
+    assert total_requests() == 3
+
+
+@pytest.mark.asyncio
+async def test_successful_fetch_returns_a_bundle(scripted_session, no_sleep):
+    scripted_session(
+        FakeResponse(
+            200,
+            body={
+                "manifest": [],
+                "hash": "abc123",
+                "old_hash": None,
+                "data_modules": [],
+                "policy_modules": [],
+            },
+        )
+    )
+    fetcher = make_fetcher(no_sleep, attempts=5)
+
+    bundle = await fetcher.fetch_policy_bundle()
+
+    assert bundle is not None
+    assert bundle.hash == "abc123"
+    assert total_requests() == 1
+
+
+@pytest.mark.asyncio
+async def test_a_503_followed_by_a_200_succeeds(scripted_session, no_sleep):
+    scripted_session(
+        FakeResponse(503, headers={"Retry-After": "2"}, body={}),
+        FakeResponse(
+            200,
+            body={
+                "manifest": [],
+                "hash": "def456",
+                "old_hash": None,
+                "data_modules": [],
+                "policy_modules": [],
+            },
+        ),
+    )
+    fetcher = make_fetcher(no_sleep, attempts=5)
+
+    bundle = await fetcher.fetch_policy_bundle()
+
+    assert bundle.hash == "def456"
+    assert total_requests() == 2
+    assert no_sleep.recorded == [pytest.approx(2.0)]
+
+
+@pytest.mark.asyncio
+async def test_detail_extraction_survives_a_non_json_body(scripted_session, no_sleep):
+    """The 409 path must not blow up when the server did not answer JSON."""
+    scripted_session(FakeResponse(409, body=None))
+    fetcher = make_fetcher(no_sleep, attempts=2)
+
+    with pytest.raises(NonRetryableBundleError) as excinfo:
+        await fetcher.fetch_policy_bundle()
+
+    # MUTATION: calling `await response.json()` unguarded raises ValueError here,
+    # which would be *retried* (wrong class) instead of failing fast.
+    assert excinfo.value.status_code == 409

--- a/packages/opal-client/opal_client/tests/policy_fetcher_retry_test.py
+++ b/packages/opal-client/opal_client/tests/policy_fetcher_retry_test.py
@@ -636,9 +636,12 @@ async def test_a_404_logs_exactly_one_warning(
 @pytest.mark.parametrize(
     "strategy,wait_time,max_wait,attempts,expected",
     [
-        ("fixed", 0.2, 10, 5, 1.0),  # fixed -> attempts x wait_time
-        ("exponential", 1, 10, 5, 50.0),  # exponential -> attempts x max_wait
-        ("random_exponential", 1, 10, 5, 50.0),
+        # n attempts are separated by n-1 waits
+        ("fixed", 0.2, 10, 5, 0.8),  # 4 x 0.2
+        ("exponential", 1, 10, 5, 15.0),  # 1 + 2 + 4 + 8
+        ("random_exponential", 1, 10, 5, 15.0),
+        ("exponential", 1, 3, 5, 9.0),  # 1 + 2 + 3 + 3, max_wait bites
+        ("fixed", 2, 10, 1, 0.0),  # a single attempt never waits
         ("fixed", 2, 10, 0, 0.0),
     ],
 )
@@ -651,10 +654,36 @@ def test_conn_retry_options_report_their_worst_case_total_wait(
         max_wait=max_wait,
         attempts=attempts,
     )
-    # MUTATION: using wait_time for the exponential strategies (or max_wait for
-    # fixed) under-reports the budget, and the whole-fetch bound then truncates
-    # a retry policy the operator explicitly configured.
+    # MUTATION: using `attempts` instead of `attempts - 1` waits, or a flat
+    # `per_wait` instead of the per-step exponential sum, mis-sizes the budget
+    # and the whole-fetch bound then truncates (or fails to bound) a retry
+    # policy the operator explicitly configured.
     assert options.worstCaseTotalWait() == pytest.approx(expected)
+
+
+def test_worst_case_total_wait_is_finite_without_an_explicit_max_wait():
+    """`max_wait` defaults to tenacity's MAX_WAIT (~4.6e18)."""
+    options = ConnRetryOptions(wait_strategy="exponential", wait_time=1, attempts=5)
+
+    # MUTATION: `attempts x max_wait` gives ~2.3e19 here, so the whole-fetch
+    # bound becomes effectively infinite and the HIGH-2 queue protection is
+    # silently gone for anyone who configures an exponential backoff without
+    # pinning max_wait.
+    assert options.worstCaseTotalWait() == pytest.approx(15.0)
+
+
+def test_worst_case_total_wait_does_not_overflow_on_many_attempts():
+    """`wait_time * 2**i` with an int exponent raises OverflowError past
+    ~1024."""
+    options = ConnRetryOptions(
+        wait_strategy="exponential", wait_time=1, max_wait=10, attempts=3000
+    )
+
+    # 2999 waits: 1 + 2 + 4 + 8, then 2995 more clamped to max_wait.
+    # MUTATION: doubling all the way with `wait_time * 2 ** i` raises
+    # OverflowError here at PolicyFetcher construction, i.e. the client fails to
+    # start for anyone with a large `attempts`.
+    assert options.worstCaseTotalWait() == pytest.approx(1 + 2 + 4 + 8 + 2995 * 10)
 
 
 def test_the_delay_bound_is_the_larger_of_the_cap_and_the_operator_budget(monkeypatch):
@@ -673,7 +702,7 @@ def test_the_delay_bound_is_the_larger_of_the_cap_and_the_operator_budget(monkey
     ][0]
     # MUTATION: `stop_after_delay(cap)` alone gives 0.3 here and cuts the
     # operator's 5 attempts down to 2.
-    assert delay_stop.max_delay == pytest.approx(1.0)
+    assert delay_stop.max_delay == pytest.approx(0.8)  # 4 waits x 0.2s
 
 
 @pytest.mark.asyncio

--- a/packages/opal-client/opal_client/tests/policy_fetcher_retry_test.py
+++ b/packages/opal-client/opal_client/tests/policy_fetcher_retry_test.py
@@ -504,7 +504,13 @@ async def test_detail_extraction_survives_a_non_json_body(scripted_session, no_s
 
 
 def test_the_stop_condition_is_bounded_by_both_attempts_and_total_delay(monkeypatch):
+    # operator budget (fixed 1s x 5 == 5s) is smaller than the cap, so the cap wins
     monkeypatch.setattr(opal_client_config, "POLICY_UPDATER_MAX_RETRY_AFTER", 42.0)
+    monkeypatch.setattr(
+        opal_client_config,
+        "POLICY_UPDATER_CONN_RETRY",
+        ConnRetryOptions(wait_strategy="fixed", wait_time=1, attempts=5),
+    )
     fetcher = PolicyFetcher(backend_url="http://opal-server:7002", token="t")
 
     stop = fetcher._retry_config["stop"]
@@ -619,3 +625,120 @@ async def test_a_404_logs_exactly_one_warning(
     warnings = _warnings(captured_logs)
     assert len(warnings) == 1, [w["message"] for w in warnings]
     assert "404" in warnings[0]["message"]
+
+
+# ---------------------------------------------------------------------------
+# NEW-2/NEW-5: the whole-fetch bound must never truncate the operator's own
+# POLICY_UPDATER_CONN_RETRY budget
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "strategy,wait_time,max_wait,attempts,expected",
+    [
+        ("fixed", 0.2, 10, 5, 1.0),  # fixed -> attempts x wait_time
+        ("exponential", 1, 10, 5, 50.0),  # exponential -> attempts x max_wait
+        ("random_exponential", 1, 10, 5, 50.0),
+        ("fixed", 2, 10, 0, 0.0),
+    ],
+)
+def test_conn_retry_options_report_their_worst_case_total_wait(
+    strategy, wait_time, max_wait, attempts, expected
+):
+    options = ConnRetryOptions(
+        wait_strategy=strategy,
+        wait_time=wait_time,
+        max_wait=max_wait,
+        attempts=attempts,
+    )
+    # MUTATION: using wait_time for the exponential strategies (or max_wait for
+    # fixed) under-reports the budget, and the whole-fetch bound then truncates
+    # a retry policy the operator explicitly configured.
+    assert options.worstCaseTotalWait() == pytest.approx(expected)
+
+
+def test_the_delay_bound_is_the_larger_of_the_cap_and_the_operator_budget(monkeypatch):
+    monkeypatch.setattr(opal_client_config, "POLICY_UPDATER_MAX_RETRY_AFTER", 0.3)
+    monkeypatch.setattr(
+        opal_client_config,
+        "POLICY_UPDATER_CONN_RETRY",
+        ConnRetryOptions(wait_strategy="fixed", wait_time=0.2, attempts=5),
+    )
+    fetcher = PolicyFetcher(backend_url="http://opal-server:7002", token="t")
+
+    delay_stop = [
+        s
+        for s in fetcher._retry_config["stop"].stops
+        if isinstance(s, stop_after_delay)
+    ][0]
+    # MUTATION: `stop_after_delay(cap)` alone gives 0.3 here and cuts the
+    # operator's 5 attempts down to 2.
+    assert delay_stop.max_delay == pytest.approx(1.0)
+
+
+@pytest.mark.asyncio
+async def test_the_operators_attempts_survive_a_smaller_cap(
+    scripted_session, monkeypatch
+):
+    """`wait_fixed(0.2) x 5` with cap 0.3 must still make all 5 attempts."""
+    monkeypatch.setattr(opal_client_config, "POLICY_UPDATER_MAX_RETRY_AFTER", 0.3)
+    monkeypatch.setattr(
+        opal_client_config,
+        "POLICY_UPDATER_CONN_RETRY",
+        ConnRetryOptions(wait_strategy="fixed", wait_time=0.2, attempts=5),
+    )
+    scripted_session(FakeResponse(503, headers={}, body={}))
+    fetcher = PolicyFetcher(backend_url="http://opal-server:7002", token="t")
+
+    with pytest.raises(RetryableBundleError):
+        await fetcher.fetch_policy_bundle()
+
+    assert total_requests() == 5
+
+
+@pytest.mark.asyncio
+async def test_a_zero_cap_does_not_disable_the_operators_retries(
+    scripted_session, monkeypatch
+):
+    """NEW-5: `MAX_RETRY_AFTER=0` means "honour no server hint", not "no retries"."""
+    monkeypatch.setattr(opal_client_config, "POLICY_UPDATER_MAX_RETRY_AFTER", 0.0)
+    monkeypatch.setattr(
+        opal_client_config,
+        "POLICY_UPDATER_CONN_RETRY",
+        ConnRetryOptions(wait_strategy="fixed", wait_time=0.05, attempts=3),
+    )
+    scripted_session(FakeResponse(503, headers={"Retry-After": "900"}, body={}))
+    fetcher = PolicyFetcher(backend_url="http://opal-server:7002", token="t")
+
+    with pytest.raises(RetryableBundleError):
+        await fetcher.fetch_policy_bundle()
+
+    # MUTATION: `stop_after_delay(0)` (no max() with the operator budget) stops
+    # after a single attempt, silently disabling retries for anyone who set the
+    # cap to 0 to mean "ignore Retry-After".
+    assert total_requests() == 3
+
+
+# ---------------------------------------------------------------------------
+# NEW-4: a connection error must also cost exactly one WARNING
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_a_connection_error_logs_exactly_one_warning(
+    scripted_session, no_sleep, captured_logs
+):
+    scripted_session(aiohttp.ClientConnectionError("connection refused"))
+    fetcher = make_fetcher(no_sleep, attempts=4)
+
+    with pytest.raises(aiohttp.ClientError):
+        await fetcher.fetch_policy_bundle()
+
+    assert total_requests() == 4
+    # MUTATION: leaving the per-attempt "server connection error" line at WARNING
+    # makes this 5 (4 per-attempt + 1 summary) -- a server outage then costs the
+    # log budget one line per attempt per client.
+    warnings = _warnings(captured_logs)
+    assert len(warnings) == 1, [w["message"] for w in warnings]
+    assert "connection refused" in warnings[0]["message"]
+    assert len([m for m in _messages(captured_logs, "DEBUG") if "refused" in m]) == 4

--- a/packages/opal-client/opal_client/tests/policy_fetcher_retry_test.py
+++ b/packages/opal-client/opal_client/tests/policy_fetcher_retry_test.py
@@ -20,6 +20,7 @@ future refactor that silently drops a guard fails here.
 import asyncio
 import os
 import sys
+import time
 from datetime import datetime, timedelta, timezone
 from email.utils import format_datetime
 
@@ -27,6 +28,7 @@ import aiohttp
 import pytest
 from fastapi import HTTPException
 from tenacity import RetryCallState, wait_fixed
+from tenacity.stop import stop_after_attempt, stop_after_delay, stop_any
 
 # Add parent path to use local src as package for tests
 root_dir = os.path.abspath(
@@ -35,6 +37,7 @@ root_dir = os.path.abspath(
 sys.path.append(root_dir)
 
 from opal_client.config import opal_client_config
+from opal_client.logger import logger
 from opal_client.policy.fetcher import (
     BundlePathNotFoundError,
     NonRetryableBundleError,
@@ -43,6 +46,7 @@ from opal_client.policy.fetcher import (
     parse_retry_after,
     wait_retry_after_or_backoff,
 )
+from opal_client.policy.options import ConnRetryOptions
 
 # ---------------------------------------------------------------------------
 # aiohttp test doubles
@@ -492,3 +496,126 @@ async def test_detail_extraction_survives_a_non_json_body(scripted_session, no_s
     # MUTATION: calling `await response.json()` unguarded raises ValueError here,
     # which would be *retried* (wrong class) instead of failing fast.
     assert excinfo.value.status_code == 409
+
+
+# ---------------------------------------------------------------------------
+# HIGH-2: one fetch must not block the serial update queue for attempts x cap
+# ---------------------------------------------------------------------------
+
+
+def test_the_stop_condition_is_bounded_by_both_attempts_and_total_delay(monkeypatch):
+    monkeypatch.setattr(opal_client_config, "POLICY_UPDATER_MAX_RETRY_AFTER", 42.0)
+    fetcher = PolicyFetcher(backend_url="http://opal-server:7002", token="t")
+
+    stop = fetcher._retry_config["stop"]
+    # MUTATION: leaving `stop` as the bare stop_after_attempt lets a proxy's
+    # `Retry-After: 300` hold the policy-update queue for attempts x cap.
+    assert isinstance(stop, stop_any)
+    assert any(isinstance(s, stop_after_attempt) for s in stop.stops)
+    delay_stops = [s for s in stop.stops if isinstance(s, stop_after_delay)]
+    assert len(delay_stops) == 1
+    assert delay_stops[0].max_delay == pytest.approx(42.0)
+
+
+@pytest.mark.asyncio
+async def test_a_huge_retry_after_cannot_hold_the_fetch_past_the_cap(
+    scripted_session, monkeypatch
+):
+    """`Retry-After: 300` from a proxy must not stall one fetch for minutes.
+
+    Uses the real clock and real (tiny) sleeps on purpose: `stop_after_delay`
+    is wall-clock based, so a faked sleep would never let it fire.
+    """
+    monkeypatch.setattr(opal_client_config, "POLICY_UPDATER_MAX_RETRY_AFTER", 0.2)
+    monkeypatch.setattr(
+        opal_client_config,
+        "POLICY_UPDATER_CONN_RETRY",
+        ConnRetryOptions(wait_strategy="fixed", wait_time=0.01, attempts=10),
+    )
+    scripted_session(FakeResponse(503, headers={"Retry-After": "300"}, body={}))
+    fetcher = PolicyFetcher(backend_url="http://opal-server:7002", token="t")
+
+    started = time.monotonic()
+    with pytest.raises(RetryableBundleError):
+        await fetcher.fetch_policy_bundle()
+    elapsed = time.monotonic() - started
+
+    # Without the delay bound this is 10 attempts x 0.2s == ~2s; with it, the
+    # fetch gives up as soon as it has spent `cap` seconds waiting.
+    assert elapsed < 0.8, f"one fetch blocked the queue for {elapsed:.2f}s"
+    assert total_requests() <= 3
+
+
+# ---------------------------------------------------------------------------
+# LOW-1: exactly one WARNING per exhausted fetch; per-attempt logs are DEBUG
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def captured_logs():
+    records = []
+    sink_id = logger.add(lambda m: records.append(m.record), level="DEBUG")
+    yield records
+    logger.remove(sink_id)
+
+
+def _warnings(records):
+    return [r for r in records if r["level"].name == "WARNING"]
+
+
+def _messages(records, level):
+    return [r["message"] for r in records if r["level"].name == level]
+
+
+@pytest.mark.asyncio
+async def test_a_retried_503_logs_one_warning_not_one_per_attempt(
+    scripted_session, no_sleep, captured_logs
+):
+    scripted_session(FakeResponse(503, headers={"Retry-After": "30"}, body={}))
+    fetcher = make_fetcher(no_sleep, attempts=4)
+
+    with pytest.raises(RetryableBundleError):
+        await fetcher.fetch_policy_bundle()
+
+    assert total_requests() == 4
+    # MUTATION: leaving the per-attempt classification at WARNING emits one line
+    # per attempt, so a fleet-wide outage floods the log budget 4x over.
+    warnings = _warnings(captured_logs)
+    assert len(warnings) == 1, [w["message"] for w in warnings]
+    assert "retryable" in warnings[0]["message"]
+    assert "503" in warnings[0]["message"]
+    # the per-attempt detail is still available, at debug
+    assert len([m for m in _messages(captured_logs, "DEBUG") if "503" in m]) == 4
+
+
+@pytest.mark.asyncio
+async def test_a_409_logs_exactly_one_warning(
+    scripted_session, no_sleep, captured_logs
+):
+    scripted_session(FakeResponse(409, body={"detail": "branch not found"}))
+    fetcher = make_fetcher(no_sleep, attempts=5)
+
+    with pytest.raises(NonRetryableBundleError):
+        await fetcher.fetch_policy_bundle()
+
+    warnings = _warnings(captured_logs)
+    assert len(warnings) == 1, [w["message"] for w in warnings]
+    assert "non-retryable" in warnings[0]["message"]
+    assert "branch not found" in warnings[0]["message"]
+
+
+@pytest.mark.asyncio
+async def test_a_404_logs_exactly_one_warning(
+    scripted_session, no_sleep, captured_logs
+):
+    scripted_session(FakeResponse(404, body={"detail": "no such path"}))
+    fetcher = make_fetcher(no_sleep, attempts=5)
+
+    with pytest.raises(BundlePathNotFoundError):
+        await fetcher.fetch_policy_bundle()
+
+    # MUTATION: leaving the "requested paths not found" line at WARNING makes
+    # this 2 and breaks the one-warning-per-exhausted-fetch contract.
+    warnings = _warnings(captured_logs)
+    assert len(warnings) == 1, [w["message"] for w in warnings]
+    assert "404" in warnings[0]["message"]

--- a/packages/opal-client/opal_client/tests/policy_updater_deferred_refetch_test.py
+++ b/packages/opal-client/opal_client/tests/policy_updater_deferred_refetch_test.py
@@ -1,0 +1,379 @@
+"""Tests for `PolicyUpdater`'s deferred bundle re-fetch.
+
+Before this change, once `fetch_policy_bundle` exhausted its tenacity attempts
+(~40s with the shipped defaults) `update_policy` recorded the error and *nothing
+re-scheduled the fetch*. A PDP that asked for its bundle while the server was
+still cloning the scope's repo (`503 + Retry-After: 30`) would sit on a stale or
+empty policy store until the next pub/sub message or WebSocket reconnect -- which,
+for a low-churn scope, can be hours.
+
+These tests pin the deferred re-fetch: exactly one pending timer, cancelled by
+success / a new update / `stop()`, bounded in rounds, and never armed for an
+error the server told us will not fix itself.
+"""
+
+import asyncio
+import os
+import sys
+
+import pytest
+
+# Add parent path to use local src as package for tests
+root_dir = os.path.abspath(
+    os.path.join(os.path.dirname(__file__), os.path.pardir, os.path.pardir)
+)
+sys.path.append(root_dir)
+
+from opal_client.config import opal_client_config
+from opal_client.policy import updater as updater_module
+from opal_client.policy.fetcher import (
+    BundlePathNotFoundError,
+    NonRetryableBundleError,
+    RetryableBundleError,
+)
+from opal_client.policy.updater import PolicyUpdater
+from opal_common.schemas.policy import PolicyBundle
+
+# ---------------------------------------------------------------------------
+# test doubles
+# ---------------------------------------------------------------------------
+
+
+def make_bundle(commit_hash: str = "abc123") -> PolicyBundle:
+    return PolicyBundle(
+        manifest=[], hash=commit_hash, data_modules=[], policy_modules=[]
+    )
+
+
+class FakeTransaction:
+    def __init__(self, store):
+        self._store = store
+
+    def _update_remote_status(self, url, status, error):
+        self._store.remote_statuses.append((url, status, error))
+
+    async def set_policies(self, bundle):
+        self._store.set_policies_calls.append(bundle)
+
+
+class FakeTransactionContext:
+    def __init__(self, store):
+        self._store = store
+
+    async def __aenter__(self):
+        return FakeTransaction(self._store)
+
+    async def __aexit__(self, *args):
+        return False
+
+
+class FakePolicyStore:
+    def __init__(self):
+        self.version = None
+        self.remote_statuses = []
+        self.set_policies_calls = []
+
+    async def get_policy_version(self):
+        return self.version
+
+    def transaction_context(self, bundle_hash, transaction_type=None):
+        return FakeTransactionContext(self)
+
+
+class FakeLifecycleComponent:
+    """Stands in for DataFetcher / CallbacksReporter (start+stop only)."""
+
+    def __init__(self):
+        self.started = False
+        self.stopped = False
+
+    async def start(self):
+        self.started = True
+
+    async def stop(self):
+        self.stopped = True
+
+
+class FakePolicyFetcher:
+    """Replaces PolicyFetcher; replays a scripted list of outcomes."""
+
+    policy_endpoint_url = "http://opal-server:7002/scopes/s1/policy"
+
+    def __init__(self, *outcomes):
+        self.outcomes = list(outcomes)
+        self.calls = []
+
+    async def fetch_policy_bundle(self, directories=["."], base_hash=None):
+        self.calls.append((tuple(directories), base_hash))
+        outcome = self.outcomes[min(len(self.calls) - 1, len(self.outcomes) - 1)]
+        if isinstance(outcome, Exception):
+            raise outcome
+        return outcome
+
+
+def make_updater(*outcomes) -> PolicyUpdater:
+    updater = PolicyUpdater(
+        token="t",
+        pubsub_url="ws://opal-server:7002/ws",
+        subscription_directories=["."],
+        policy_store=FakePolicyStore(),
+        data_fetcher=FakeLifecycleComponent(),
+    )
+    updater._policy_fetcher = FakePolicyFetcher(*outcomes)
+    updater._callbacks_reporter = FakeLifecycleComponent()
+    return updater
+
+
+async def drain():
+    """Let scheduled tasks reach their first suspension point."""
+    await asyncio.sleep(0)
+    await asyncio.sleep(0)
+
+
+# ---------------------------------------------------------------------------
+# delay computation
+# ---------------------------------------------------------------------------
+
+
+def test_deferred_delay_honours_retry_after():
+    updater = make_updater()
+    # MUTATION: ignoring `retry_after` and always returning the base backoff
+    # gives 5.0 and fails -- the server's "come back in 30s" would be discarded.
+    assert updater._deferred_refetch_delay(30.0, round_index=1) == pytest.approx(30.0)
+
+
+def test_deferred_delay_falls_back_to_the_base_when_no_retry_after():
+    updater = make_updater()
+    # MUTATION: returning 0 when retry_after is None turns the deferral into a
+    # busy-loop against a server that is already refusing us.
+    assert updater._deferred_refetch_delay(None, round_index=1) == pytest.approx(
+        updater_module.DEFERRED_REFETCH_BASE_SECONDS
+    )
+
+
+def test_deferred_delay_backs_off_across_rounds():
+    updater = make_updater()
+    first = updater._deferred_refetch_delay(None, round_index=1)
+    second = updater._deferred_refetch_delay(None, round_index=2)
+    third = updater._deferred_refetch_delay(None, round_index=3)
+    # MUTATION: dropping the `2 ** (round_index - 1)` factor makes all three equal.
+    assert second > first
+    assert third > second
+
+
+def test_deferred_delay_is_capped(monkeypatch):
+    monkeypatch.setattr(opal_client_config, "POLICY_UPDATER_MAX_RETRY_AFTER", 60.0)
+    updater = make_updater()
+    # MUTATION: dropping the cap lets round 20 compute 5 * 2**19 == ~2.9 days.
+    assert updater._deferred_refetch_delay(None, round_index=20) == pytest.approx(60.0)
+    assert updater._deferred_refetch_delay(99999.0, round_index=1) == pytest.approx(
+        60.0
+    )
+
+
+# ---------------------------------------------------------------------------
+# scheduling
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_exhausted_retryable_schedules_exactly_one_deferred_refetch():
+    updater = make_updater(RetryableBundleError(503, retry_after=30.0))
+
+    await updater.update_policy(["."], force_full_update=False)
+
+    # MUTATION: not scheduling at all (the pre-PR behaviour) leaves this None --
+    # the client would then sit stale until the next pub/sub message.
+    assert updater._deferred_refetch_task is not None
+    assert not updater._deferred_refetch_task.done()
+    assert updater._deferred_refetch_rounds == 1
+
+    await updater.stop()
+
+
+@pytest.mark.asyncio
+async def test_a_second_failure_while_one_is_pending_does_not_stack_timers():
+    updater = make_updater(RetryableBundleError(503, retry_after=30.0))
+
+    await updater.update_policy(["."], force_full_update=False)
+    first_task = updater._deferred_refetch_task
+    await updater.update_policy(["."], force_full_update=False)
+
+    # MUTATION: dropping the "already pending" guard creates a second task, and
+    # every failed round would multiply the number of in-flight timers.
+    assert updater._deferred_refetch_task is first_task
+    assert updater._deferred_refetch_rounds == 1
+    assert not first_task.cancelled()
+
+    await updater.stop()
+
+
+@pytest.mark.asyncio
+async def test_a_successful_fetch_cancels_the_pending_deferred_refetch():
+    updater = make_updater(RetryableBundleError(503, retry_after=30.0))
+
+    await updater.update_policy(["."], force_full_update=False)
+    pending = updater._deferred_refetch_task
+    assert pending is not None
+
+    updater._policy_fetcher.outcomes = [make_bundle()]
+    await updater.update_policy(["."], force_full_update=False)
+    await drain()
+
+    # MUTATION: not cancelling on success leaves a stale timer that re-fetches
+    # the bundle for no reason (and keeps the round counter climbing).
+    assert updater._deferred_refetch_task is None
+    assert pending.cancelled()
+    assert updater._deferred_refetch_rounds == 0
+
+    await updater.stop()
+
+
+@pytest.mark.asyncio
+async def test_a_new_incoming_policy_update_replaces_the_pending_deferred_refetch():
+    updater = make_updater(RetryableBundleError(503, retry_after=30.0))
+
+    await updater.update_policy(["."], force_full_update=False)
+    pending = updater._deferred_refetch_task
+    assert pending is not None
+
+    await updater.trigger_update_policy(["."], force_full_update=True)
+    await drain()
+
+    # MUTATION: leaving the timer armed means the fresh update we just queued
+    # gets followed by a redundant deferred re-fetch of the same bundle.
+    assert updater._deferred_refetch_task is None
+    assert pending.cancelled()
+    assert updater._policy_update_queue.qsize() == 1
+
+    await updater.stop()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "error",
+    [
+        NonRetryableBundleError(409, detail="branch could not be resolved"),
+        BundlePathNotFoundError(detail="requested path not found"),
+    ],
+)
+async def test_non_retryable_errors_are_never_rescheduled(error):
+    updater = make_updater(error)
+
+    await updater.update_policy(["."], force_full_update=False)
+
+    # MUTATION: scheduling on *any* fetch error (rather than only on
+    # RetryableBundleError) re-fetches a 409 forever, which is exactly the
+    # "hammer a permanent failure" behaviour the server contract rules out.
+    assert updater._deferred_refetch_task is None
+    assert updater._deferred_refetch_rounds == 0
+
+    await updater.stop()
+
+
+@pytest.mark.asyncio
+async def test_unclassified_errors_are_not_rescheduled():
+    """Connection errors / 5xx keep their pre-PR behaviour (no deferral)."""
+    updater = make_updater(ValueError("unexpected response code 500"))
+
+    await updater.update_policy(["."], force_full_update=False)
+
+    assert updater._deferred_refetch_task is None
+
+    await updater.stop()
+
+
+@pytest.mark.asyncio
+async def test_stop_cancels_the_pending_deferred_refetch():
+    updater = make_updater(RetryableBundleError(503, retry_after=30.0))
+
+    await updater.update_policy(["."], force_full_update=False)
+    pending = updater._deferred_refetch_task
+    assert pending is not None
+
+    await updater.stop()
+    await drain()
+
+    # MUTATION: forgetting to cancel in stop() leaks the timer past shutdown and
+    # produces "Task was destroyed but it is pending!" on client teardown.
+    assert pending.cancelled()
+    assert updater._deferred_refetch_task is None
+
+
+@pytest.mark.asyncio
+async def test_deferred_rounds_are_bounded(monkeypatch):
+    monkeypatch.setattr(opal_client_config, "POLICY_UPDATER_MAX_DEFERRED_ROUNDS", 3)
+    updater = make_updater(RetryableBundleError(503, retry_after=30.0))
+
+    for _ in range(3):
+        # each round: fail, arm a timer, then pretend the timer fired
+        await updater.update_policy(["."], force_full_update=False)
+        assert updater._deferred_refetch_task is not None
+        updater._deferred_refetch_task.cancel()
+        updater._deferred_refetch_task = None
+
+    assert updater._deferred_refetch_rounds == 3
+
+    await updater.update_policy(["."], force_full_update=False)
+
+    # MUTATION: dropping the `rounds >= max` guard lets a permanently-503 scope
+    # re-fetch forever, which is a slow-motion self-inflicted DoS on the server.
+    assert updater._deferred_refetch_task is None
+    assert updater._deferred_refetch_rounds == 3
+
+    await updater.stop()
+
+
+@pytest.mark.asyncio
+async def test_rescheduling_can_be_disabled_by_config(monkeypatch):
+    monkeypatch.setattr(
+        opal_client_config, "POLICY_UPDATER_RESCHEDULE_ON_RETRYABLE", False
+    )
+    updater = make_updater(RetryableBundleError(503, retry_after=30.0))
+
+    await updater.update_policy(["."], force_full_update=False)
+
+    # MUTATION: ignoring POLICY_UPDATER_RESCHEDULE_ON_RETRYABLE removes the
+    # operator's escape hatch back to the pre-PR behaviour.
+    assert updater._deferred_refetch_task is None
+    assert updater._deferred_refetch_rounds == 0
+
+    await updater.stop()
+
+
+@pytest.mark.asyncio
+async def test_the_deferred_timer_enqueues_the_original_update_arguments(monkeypatch):
+    updater = make_updater(RetryableBundleError(503, retry_after=30.0))
+    monkeypatch.setattr(
+        updater, "_deferred_refetch_delay", lambda retry_after, round_index: 0.01
+    )
+
+    await updater.update_policy(["sub/dir"], force_full_update=True)
+    assert updater._policy_update_queue.qsize() == 0
+
+    await asyncio.sleep(0.05)
+
+    # MUTATION: enqueueing `(None, False)` instead of the captured arguments
+    # would silently widen the subscription and drop force_full_update.
+    assert updater._policy_update_queue.qsize() == 1
+    assert updater._policy_update_queue.get_nowait() == (["sub/dir"], True)
+    # the timer clears its own handle once it has fired
+    assert updater._deferred_refetch_task is None
+
+    await updater.stop()
+
+
+@pytest.mark.asyncio
+async def test_the_failed_fetch_is_still_recorded_on_the_store_transaction():
+    """Scheduling a retry must not swallow the error report to the policy
+    store."""
+    updater = make_updater(RetryableBundleError(503, retry_after=30.0))
+
+    await updater.update_policy(["."], force_full_update=False)
+
+    assert len(updater._policy_store.remote_statuses) == 1
+    url, ok, error = updater._policy_store.remote_statuses[0]
+    assert ok is False
+    assert "503" in error
+
+    await updater.stop()

--- a/packages/opal-client/opal_client/tests/policy_updater_deferred_refetch_test.py
+++ b/packages/opal-client/opal_client/tests/policy_updater_deferred_refetch_test.py
@@ -32,6 +32,7 @@ from opal_client.policy.fetcher import (
     RetryableBundleError,
 )
 from opal_client.policy.updater import PolicyUpdater
+from opal_common.config import opal_common_config
 from opal_common.schemas.policy import PolicyBundle
 
 # ---------------------------------------------------------------------------
@@ -307,7 +308,12 @@ async def test_stop_cancels_the_pending_deferred_refetch():
 
 
 @pytest.mark.asyncio
-async def test_deferred_rounds_are_bounded(monkeypatch):
+async def test_the_escalation_stops_at_the_round_budget(monkeypatch):
+    """The budget bounds how far the backoff *escalates*, not the deferral.
+
+    Past it the client keeps re-fetching, but at the flat cadence (see
+    test_the_deferral_continues_past_the_escalation_budget).
+    """
     monkeypatch.setattr(opal_client_config, "POLICY_UPDATER_MAX_DEFERRED_ROUNDS", 3)
     updater = make_updater(RetryableBundleError(503, retry_after=30.0))
 
@@ -319,13 +325,15 @@ async def test_deferred_rounds_are_bounded(monkeypatch):
         updater._deferred_refetch_task = None
 
     assert updater._deferred_refetch_rounds == 3
+    assert updater._deferred_flat_phase is False
 
     await updater.update_policy(["."], force_full_update=False)
 
-    # MUTATION: dropping the `rounds >= max` guard lets a permanently-503 scope
-    # re-fetch forever, which is a slow-motion self-inflicted DoS on the server.
-    assert updater._deferred_refetch_task is None
+    # MUTATION: dropping the `rounds >= max` guard lets the backoff keep
+    # doubling (and the round counter keep climbing) instead of settling into
+    # the bounded flat cadence.
     assert updater._deferred_refetch_rounds == 3
+    assert updater._deferred_flat_phase is True
 
     await updater.stop()
 
@@ -452,7 +460,10 @@ def test_a_tiny_ceiling_is_still_floored(monkeypatch, no_jitter):
 
 
 @pytest.mark.asyncio
-async def test_a_websocket_reconnect_does_not_reset_the_round_counter():
+async def test_a_websocket_reconnect_does_not_reset_the_round_counter(monkeypatch):
+    # _on_connect publishes statistics when this is on, which would need a live
+    # pubsub client; pin it off so the test exercises only the reconnect path.
+    monkeypatch.setattr(opal_common_config, "STATISTICS_ENABLED", False)
     updater = make_updater(RetryableBundleError(503, retry_after=30.0))
 
     await updater.update_policy(["."], force_full_update=False)
@@ -587,3 +598,153 @@ async def test_stop_awaits_the_timer_it_cancelled():
     # moment stop() returns, which surfaces as "Task was destroyed but it is
     # pending!" when the client shuts down.
     assert pending.done()
+
+
+# ---------------------------------------------------------------------------
+# NEW-1: the round budget bounds ESCALATION, not the deferral itself
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def captured_logs():
+    from opal_client.logger import logger
+
+    records = []
+    sink_id = logger.add(lambda m: records.append(m.record), level="DEBUG")
+    yield records
+    logger.remove(sink_id)
+
+
+def _warnings(records):
+    return [r for r in records if r["level"].name == "WARNING"]
+
+
+async def _burn_rounds(updater, rounds: int):
+    """Fails `rounds` times, pretending each armed timer then fired."""
+    for _ in range(rounds):
+        await updater.update_policy(["."], force_full_update=False)
+        if updater._deferred_refetch_task is not None:
+            updater._deferred_refetch_task.cancel()
+            updater._deferred_refetch_task = None
+
+
+def test_the_flat_cadence_is_the_ceiling(monkeypatch, no_jitter):
+    monkeypatch.setattr(opal_client_config, "POLICY_UPDATER_MAX_RETRY_AFTER", 60.0)
+    updater = make_updater()
+    assert updater._flat_refetch_delay() == pytest.approx(60.0)
+
+
+def test_the_flat_cadence_is_also_floored(monkeypatch, no_jitter):
+    monkeypatch.setattr(opal_client_config, "POLICY_UPDATER_MAX_RETRY_AFTER", 0.0)
+    updater = make_updater()
+    # MUTATION: `_jittered(ceiling)` without the floor makes the steady state a
+    # zero-delay busy loop against a server that is already refusing us.
+    assert updater._flat_refetch_delay() == pytest.approx(5.0)
+
+
+def test_the_flat_cadence_is_jittered():
+    samples = {make_updater()._flat_refetch_delay() for _ in range(200)}
+    assert len(samples) > 100
+
+
+@pytest.mark.asyncio
+async def test_the_deferral_continues_past_the_escalation_budget(monkeypatch):
+    monkeypatch.setattr(opal_client_config, "POLICY_UPDATER_MAX_DEFERRED_ROUNDS", 3)
+    updater = make_updater(RetryableBundleError(503, retry_after=30.0))
+
+    await _burn_rounds(updater, 3)
+    assert updater._deferred_refetch_rounds == 3
+
+    # past the budget: the client must NOT go permanently silent, because a WS
+    # that never reconnects and a scope that never gets a commit would otherwise
+    # leave it stale forever
+    for _ in range(3):
+        await updater.update_policy(["."], force_full_update=False)
+        # MUTATION: `return` at the budget (the round-2 behaviour) leaves this
+        # None and strands the client.
+        assert updater._deferred_refetch_task is not None
+        assert updater._deferred_flat_phase is True
+        assert updater._deferred_refetch_rounds == 3
+        updater._deferred_refetch_task.cancel()
+        updater._deferred_refetch_task = None
+
+    await updater.stop()
+
+
+@pytest.mark.asyncio
+async def test_the_flat_phase_warning_fires_exactly_once(monkeypatch, captured_logs):
+    monkeypatch.setattr(opal_client_config, "POLICY_UPDATER_MAX_DEFERRED_ROUNDS", 2)
+    updater = make_updater(RetryableBundleError(503, retry_after=30.0))
+
+    await _burn_rounds(updater, 2)
+    captured_logs.clear()
+    await _burn_rounds(updater, 5)
+
+    flat = [w for w in _warnings(captured_logs) if "budget exhausted" in w["message"]]
+    # MUTATION: logging the flat-phase notice per round turns a stuck scope into
+    # a permanent warning stream (one line per client per minute, forever).
+    assert len(flat) == 1, [w["message"] for w in _warnings(captured_logs)]
+    # and no per-round "Deferring ... (round n/max)" lines once flat
+    assert not [w for w in _warnings(captured_logs) if "round" in w["message"]]
+
+    await updater.stop()
+
+
+@pytest.mark.asyncio
+async def test_a_success_clears_the_flat_phase(monkeypatch):
+    monkeypatch.setattr(opal_client_config, "POLICY_UPDATER_MAX_DEFERRED_ROUNDS", 2)
+    updater = make_updater(RetryableBundleError(503, retry_after=30.0))
+
+    await _burn_rounds(updater, 3)
+    assert updater._deferred_flat_phase is True
+
+    updater._policy_fetcher.outcomes = [make_bundle()]
+    await updater.update_policy(["."], force_full_update=False)
+
+    # MUTATION: not clearing the flag means the next unrelated outage skips the
+    # escalation ramp and starts hammering at the flat cadence immediately.
+    assert updater._deferred_flat_phase is False
+    assert updater._deferred_refetch_rounds == 0
+
+    await updater.stop()
+
+
+@pytest.mark.asyncio
+async def test_an_incoming_update_clears_the_flat_phase(monkeypatch):
+    monkeypatch.setattr(opal_client_config, "POLICY_UPDATER_MAX_DEFERRED_ROUNDS", 2)
+    updater = make_updater(RetryableBundleError(503, retry_after=30.0))
+
+    await _burn_rounds(updater, 3)
+    assert updater._deferred_flat_phase is True
+
+    await updater._update_policy_callback(
+        data={
+            "old_policy_hash": "aaa",
+            "new_policy_hash": "bbb",
+            "changed_directories": ["."],
+        },
+        topic="policy:.",
+    )
+
+    assert updater._deferred_flat_phase is False
+    assert updater._deferred_refetch_rounds == 0
+
+    await updater.stop()
+
+
+@pytest.mark.asyncio
+async def test_disabling_rescheduling_also_disables_the_flat_phase(monkeypatch):
+    monkeypatch.setattr(opal_client_config, "POLICY_UPDATER_MAX_DEFERRED_ROUNDS", 1)
+    monkeypatch.setattr(
+        opal_client_config, "POLICY_UPDATER_RESCHEDULE_ON_RETRYABLE", False
+    )
+    updater = make_updater(RetryableBundleError(503, retry_after=30.0))
+
+    await _burn_rounds(updater, 4)
+
+    # MUTATION: checking the config gate only on the escalation path would make
+    # the kill switch stop working once the budget is spent.
+    assert updater._deferred_refetch_task is None
+    assert updater._deferred_flat_phase is False
+
+    await updater.stop()

--- a/packages/opal-client/opal_client/tests/policy_updater_deferred_refetch_test.py
+++ b/packages/opal-client/opal_client/tests/policy_updater_deferred_refetch_test.py
@@ -130,19 +130,25 @@ async def drain():
     await asyncio.sleep(0)
 
 
+@pytest.fixture
+def no_jitter(monkeypatch):
+    """Makes the deferred delay deterministic (jitter is tested separately)."""
+    monkeypatch.setattr(updater_module, "_jittered", lambda delay: delay)
+
+
 # ---------------------------------------------------------------------------
 # delay computation
 # ---------------------------------------------------------------------------
 
 
-def test_deferred_delay_honours_retry_after():
+def test_deferred_delay_honours_retry_after(no_jitter):
     updater = make_updater()
     # MUTATION: ignoring `retry_after` and always returning the base backoff
     # gives 5.0 and fails -- the server's "come back in 30s" would be discarded.
     assert updater._deferred_refetch_delay(30.0, round_index=1) == pytest.approx(30.0)
 
 
-def test_deferred_delay_falls_back_to_the_base_when_no_retry_after():
+def test_deferred_delay_falls_back_to_the_base_when_no_retry_after(no_jitter):
     updater = make_updater()
     # MUTATION: returning 0 when retry_after is None turns the deferral into a
     # busy-loop against a server that is already refusing us.
@@ -151,7 +157,7 @@ def test_deferred_delay_falls_back_to_the_base_when_no_retry_after():
     )
 
 
-def test_deferred_delay_backs_off_across_rounds():
+def test_deferred_delay_backs_off_across_rounds(no_jitter):
     updater = make_updater()
     first = updater._deferred_refetch_delay(None, round_index=1)
     second = updater._deferred_refetch_delay(None, round_index=2)
@@ -161,7 +167,7 @@ def test_deferred_delay_backs_off_across_rounds():
     assert third > second
 
 
-def test_deferred_delay_is_capped(monkeypatch):
+def test_deferred_delay_is_capped(monkeypatch, no_jitter):
     monkeypatch.setattr(opal_client_config, "POLICY_UPDATER_MAX_RETRY_AFTER", 60.0)
     updater = make_updater()
     # MUTATION: dropping the cap lets round 20 compute 5 * 2**19 == ~2.9 days.
@@ -377,3 +383,207 @@ async def test_the_failed_fetch_is_still_recorded_on_the_store_transaction():
     assert "503" in error
 
     await updater.stop()
+
+
+# ---------------------------------------------------------------------------
+# HIGH-1: jitter, so a fleet does not re-fetch in lockstep
+# ---------------------------------------------------------------------------
+
+
+def test_jittered_stays_inside_the_lower_half_of_its_window():
+    for _ in range(500):
+        assert 5.0 <= updater_module._jittered(10.0) <= 10.0
+
+
+def test_jittered_actually_spreads_the_delay():
+    samples = {updater_module._jittered(20.0) for _ in range(200)}
+    # MUTATION: `return delay` (no jitter) collapses this to a single value, and
+    # every client in the fleet re-fetches on the same tick.
+    assert len(samples) > 100
+
+
+def test_the_deferred_delay_routes_through_the_jitter(monkeypatch):
+    seen = []
+
+    def fake_jitter(delay):
+        seen.append(delay)
+        return 1.23
+
+    monkeypatch.setattr(updater_module, "_jittered", fake_jitter)
+    updater = make_updater()
+
+    assert updater._deferred_refetch_delay(30.0, round_index=1) == pytest.approx(1.23)
+    # MUTATION: computing the delay without calling _jittered leaves `seen` empty.
+    assert seen == [pytest.approx(30.0)]
+
+
+def test_two_clients_in_the_same_round_get_different_delays():
+    a = make_updater()
+    b = make_updater()
+    draws_a = [a._deferred_refetch_delay(30.0, round_index=2) for _ in range(50)]
+    draws_b = [b._deferred_refetch_delay(30.0, round_index=2) for _ in range(50)]
+    assert draws_a != draws_b
+
+
+# ---------------------------------------------------------------------------
+# MEDIUM-1: a zero ceiling must not collapse the deferred backoff
+# ---------------------------------------------------------------------------
+
+
+def test_a_zero_ceiling_does_not_collapse_the_deferred_delay(monkeypatch, no_jitter):
+    monkeypatch.setattr(opal_client_config, "POLICY_UPDATER_MAX_RETRY_AFTER", 0.0)
+    updater = make_updater()
+
+    # MUTATION: without the base-seconds floor both of these are 0.0, and the
+    # client burns all 20 deferred rounds back-to-back with no wait at all.
+    assert updater._deferred_refetch_delay(None, round_index=1) == pytest.approx(5.0)
+    assert updater._deferred_refetch_delay(30.0, round_index=3) == pytest.approx(5.0)
+
+
+def test_a_tiny_ceiling_is_still_floored(monkeypatch, no_jitter):
+    monkeypatch.setattr(opal_client_config, "POLICY_UPDATER_MAX_RETRY_AFTER", 0.5)
+    updater = make_updater()
+    assert updater._deferred_refetch_delay(0.1, round_index=1) == pytest.approx(5.0)
+
+
+# ---------------------------------------------------------------------------
+# MEDIUM-2: only a genuine policy update resets the round counter
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_a_websocket_reconnect_does_not_reset_the_round_counter():
+    updater = make_updater(RetryableBundleError(503, retry_after=30.0))
+
+    await updater.update_policy(["."], force_full_update=False)
+    assert updater._deferred_refetch_rounds == 1
+    updater._deferred_refetch_task.cancel()
+    updater._deferred_refetch_task = None
+
+    # _on_connect fires on every reconnect, and reconnects are frequent
+    await updater._on_connect(client=None, channel=None)
+
+    # MUTATION: resetting the counter in trigger_update_policy (as the first
+    # version did) means a client that reconnects every few minutes never
+    # reaches MAX_DEFERRED_ROUNDS and re-fetches forever.
+    assert updater._deferred_refetch_rounds == 1
+
+    await updater.stop()
+
+
+@pytest.mark.asyncio
+async def test_a_genuine_incoming_policy_update_resets_the_round_counter():
+    updater = make_updater(RetryableBundleError(503, retry_after=30.0))
+
+    await updater.update_policy(["."], force_full_update=False)
+    assert updater._deferred_refetch_rounds == 1
+
+    await updater._update_policy_callback(
+        data={
+            "old_policy_hash": "aaa",
+            "new_policy_hash": "bbb",
+            "changed_directories": ["."],
+        },
+        topic="policy:.",
+    )
+
+    # MUTATION: never resetting means a scope that recovers after 20 rounds
+    # stays permanently un-deferrable.
+    assert updater._deferred_refetch_rounds == 0
+
+    await updater.stop()
+
+
+@pytest.mark.asyncio
+async def test_a_malformed_policy_update_message_does_not_reset_the_counter():
+    updater = make_updater(RetryableBundleError(503, retry_after=30.0))
+    await updater.update_policy(["."], force_full_update=False)
+
+    await updater._update_policy_callback(data=None, topic="policy:.")
+    await updater._update_policy_callback(data={"garbage": True}, topic="policy:.")
+
+    assert updater._deferred_refetch_rounds == 1
+
+    await updater.stop()
+
+
+# ---------------------------------------------------------------------------
+# MEDIUM-3: a policy-store read failure must not swallow the deferral
+# ---------------------------------------------------------------------------
+
+
+class ExplodingVersionStore(FakePolicyStore):
+    async def get_policy_version(self):
+        raise RuntimeError("OPA is restarting")
+
+
+@pytest.mark.asyncio
+async def test_a_policy_store_read_failure_still_fetches_and_still_defers():
+    updater = make_updater(RetryableBundleError(503, retry_after=30.0))
+    updater._policy_store = ExplodingVersionStore()
+
+    await updater.update_policy(["."], force_full_update=False)
+
+    # falls back to a full bundle rather than aborting
+    assert updater._policy_fetcher.calls == [((".",), None)]
+    # MUTATION: leaving get_policy_version outside the try lets the RuntimeError
+    # escape update_policy, so the deferral never arms and a client whose OPA
+    # restarted alongside the server never recovers on its own.
+    assert updater._deferred_refetch_task is not None
+
+    await updater.stop()
+
+
+# ---------------------------------------------------------------------------
+# MEDIUM-4: the deferral round-trips through the real update loop
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_the_deferral_round_trips_through_handle_policy_updates(monkeypatch):
+    """Fail(503) -> timer -> queue -> handler -> update_policy -> success."""
+    updater = make_updater(
+        RetryableBundleError(503, retry_after=30.0), make_bundle("recovered")
+    )
+    monkeypatch.setattr(
+        updater, "_deferred_refetch_delay", lambda retry_after, round_index: 0.0
+    )
+    updater._policy_update_task = asyncio.create_task(updater.handle_policy_updates())
+
+    await updater.trigger_update_policy(["."], force_full_update=False)
+
+    loop = asyncio.get_event_loop()
+    deadline = loop.time() + 3.0
+    while not updater._policy_store.set_policies_calls:
+        if loop.time() > deadline:
+            pytest.fail("the deferred re-fetch never round-tripped through the loop")
+        await asyncio.sleep(0.01)
+
+    # MUTATION: if the timer never re-queues (or the handler never picks it up)
+    # this test times out -- it is the only end-to-end proof the loop closes.
+    assert len(updater._policy_fetcher.calls) == 2
+    assert updater._policy_store.set_policies_calls[0].hash == "recovered"
+    assert updater._deferred_refetch_rounds == 0
+    assert updater._deferred_refetch_task is None
+
+    await updater.stop()
+
+
+# ---------------------------------------------------------------------------
+# LOW-2: stop() must await the timer it cancelled
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_stop_awaits_the_timer_it_cancelled():
+    updater = make_updater(RetryableBundleError(503, retry_after=30.0))
+    await updater.update_policy(["."], force_full_update=False)
+    pending = updater._deferred_refetch_task
+    assert pending is not None
+
+    await updater.stop()
+
+    # MUTATION: cancelling without awaiting leaves the task un-finalised at the
+    # moment stop() returns, which surfaces as "Task was destroyed but it is
+    # pending!" when the client shuts down.
+    assert pending.done()


### PR DESCRIPTION
## Motivation

This is the client companion of server PR #924, which gave `GET /scopes/{id}/policy` a classified contract: `503 + Retry-After: 30` (clone in progress), `503 + Retry-After: 5` (clone vanished/corrupt), `409` (branch unresolved, no `Retry-After`), `404` (path not in repo).

The client understands none of it. `PolicyFetcher` drives tenacity with only `wait` + `stop` and **no `retry=` predicate**, so:

- a `409` burns the same 5 attempts as a transient `503`;
- `Retry-After` is never read — the client backs off on its own schedule (`wait_random_exponential(multiplier=1, max=10)`), ignoring the server's estimate;
- after ~40 s the fetch gives up **permanently**. `PolicyUpdater.update_policy` records the error into the store transaction and nothing re-schedules.

A PDP that asks for its bundle while the server is still cloning therefore sits on a stale or empty policy store until the next pub/sub message or WebSocket reconnect — for a low-churn scope, hours.

Against a **master** server the `409` path is inert (the server does not emit it yet); the `503`/`Retry-After` handling pays off immediately, and the `409` handling lands ahead of #924.

## Behaviour

| Server answer | Before | After |
|---|---|---|
| `503` + `Retry-After: 30` | 5 attempts, waits ≤10 s each, then permanent give-up | waits ≥30 s between attempts (whole fetch time-bounded); on exhaustion, a deferred re-fetch |
| `503` + `Retry-After: 5` | same as above | waits ≥5 s; deferred re-fetch on exhaustion |
| `503`, no `Retry-After` | same as above | unchanged backoff; deferred re-fetch on exhaustion |
| `429` | 5 attempts, header ignored | retryable, `Retry-After` honoured |
| `409` branch unresolved | **5 attempts over ~40 s** | **1 attempt**, `NonRetryableBundleError`, no re-schedule |
| `404` path missing | 5 attempts, `HTTPException` | **1 attempt**, still an `HTTPException` |
| other non-200 / connection error | 5 attempts, then give up | unchanged (still retried) |
| hostile `Retry-After: 99999` | ignored | capped at `POLICY_UPDATER_MAX_RETRY_AFTER` (60 s), per wait and per fetch |
| policy store unreadable during fetch | exception escaped, no deferral armed | degrades to a full bundle; deferral still arms |

## Configuration

Three new keys, all backwards-compatible defaults (`OPAL_` prefix):

| Key | Type | Default | Meaning |
|---|---|---|---|
| `POLICY_UPDATER_MAX_RETRY_AFTER` | float | `60.0` | Bounds server-driven waiting: caps each honoured `Retry-After`, bounds the extra wall-clock time one fetch may spend beyond the operator's own backoff, and ceilings the deferred backoff and flat cadence. `0` = honour no server hint (does **not** disable retries). |
| `POLICY_UPDATER_RESCHEDULE_ON_RETRYABLE` | bool | `True` | Master switch for all deferral. `False` restores the previous fire-and-forget behaviour. |
| `POLICY_UPDATER_MAX_DEFERRED_ROUNDS` | int | `20` | Escalation rounds before the flat cadence. |

The whole-fetch time bound is `max(POLICY_UPDATER_MAX_RETRY_AFTER, exact worst-case wait of POLICY_UPDATER_CONN_RETRY)` — it exists to stop a server-supplied hint from monopolising the serial update queue, never to shorten a retry policy you configured on purpose.

## Deferred re-fetch

At most one pending timer at a time. Escalating phase: delay = `max(Retry-After, 5·2^(n−1))`, clamped to `[5 s, MAX_RETRY_AFTER]`, then jittered into `[delay/2, delay]` so a recovering fleet does not return in lockstep. That phase lasts `5 + 10 + 20 + 40 + 16×60 = 1035 s` before jitter (~8.5–17 min).

After the budget the client does **not** give up — a client whose WebSocket never reconnects and whose scope never receives a commit would otherwise stay stale forever — it settles into a flat jittered cadence of one request every 30–60 s (mean ~45 s, ~1.3/min per client) until a fetch succeeds. Entering the flat phase logs one warning, not one per round.

Cancelled by a successful fetch, by an incoming policy update, and by `stop()`. The round counter and flat phase are reset by a successful fetch and by a genuine policy update — deliberately **not** by a reconnect, since reconnects are frequent during exactly these outages and would make the escalation limit unreachable. The timer re-queues through the existing update queue rather than calling `update_policy` directly, so it stays serialized with other updates instead of racing a second policy-store transaction.

## Logging

Exactly one WARNING per exhausted fetch (classified: retryable / non-retryable / connection error), one per deferral round, and one on entering the flat phase. Per-attempt classification, the 404 "requested paths not found" line, and the "server connection error" line are all `debug`, so a fleet-wide outage does not multiply log volume by the attempt count.

## Tests

90 new tests (36 → 126 in the opal-client suite; full repo 326). No real sleeping except two deliberate real-clock tests for the whole-fetch bound (`stop_after_delay` is wall-clock based, so a faked sleep would disarm them). Coverage: `Retry-After` delta / HTTP-date / naive-date / malformed / negative / `nan` / `inf`; both caps and the operator-budget floor (exact sum of waits, saturating, no overflow at absurd attempt counts); `409` and `404` single-attempt; `500` and connection errors still retried; `503`→`200` recovery; non-JSON error bodies; log-level and warning-count contract; jitter envelope and spread; the 5 s floor; reconnect-vs-update round semantics; policy-store read failure; flat-phase engagement, once-only warning and clearing; and an end-to-end pass through the real `handle_policy_updates` loop.

Each guard names in a comment the single-line mutation it catches. A script applies **34** such mutations and verifies every one fails the suite.

## Compatibility

No default behaviour change beyond "stop hammering 409/404", "honour `Retry-After`", and the new whole-fetch time bound. `BundlePathNotFoundError` is still a `fastapi.HTTPException` with `status_code=404`, so existing 404 handlers keep working.

One visible change: the 404 exception's `repr()` is now `BundlePathNotFoundError(status_code=404, detail=...)` rather than fastapi's `HTTPException(...)`, and that string is what lands in the OPA transaction log's `error` field — anything grepping for `HTTPException` there needs updating.

**Permit's PDP pins opal-client 0.9.6, so shipping this needs a PDP bump**; the three keys can then be set per-PDP via `pdp_opal_client_config_overrides`.

## Follow-up (out of scope)

A `404` returned for an unknown `base_hash` (the server no longer has the delta base) is currently non-retryable and waits for the next update; it could instead be recovered immediately with a forced full re-fetch. Worth a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
