### PR TITLE
feat(client): add OpenFGA policy store client support

### DIFF
--- a/documentation/docs/getting-started/configuration.mdx
+++ b/documentation/docs/getting-started/configuration.mdx
@@ -1125,7 +1125,7 @@ _Added in OPAL v0.6.0_
 
 Default: `opa`
 
-Type of policy store to use. Options: `opa`, `cedar`.
+Type of policy store to use. Options: `opa`, `cedar`, `openfga`.
 
 For more information, see [Cedar and OPAL](/tutorials/cedar).
 

--- a/packages/opal-client/opal_client/policy_store/openfga_client.py
+++ b/packages/opal-client/opal_client/policy_store/openfga_client.py
@@ -61,6 +61,23 @@ from opal_common.schemas.store import StoreTransaction, TransactionType
 from tenacity import retry
 
 
+def _to_write_tuple_keys(read_tuples: List[dict]) -> List[dict]:
+    """Reshapes /read's response tuples ({"key": {...}, "timestamp": ...})
+    into the flat {"user", "relation", "object"} shape /write expects.
+    Caught via real integration testing: full_export was writing the raw
+    /read shape straight into the export file, which full_import then fed
+    unmodified to set_policy_data — /write rejected it outright ("the
+    'user' field is malformed") since it doesn't have a "key" wrapper."""
+    return [
+        {
+            "user": t["key"]["user"],
+            "relation": t["key"]["relation"],
+            "object": t["key"]["object"],
+        }
+        for t in read_tuples
+    ]
+
+
 class OpenFGAClient(LivenessProbeMixin, BasePolicyStoreClient):
     def __init__(
         self,
@@ -226,14 +243,7 @@ class OpenFGAClient(LivenessProbeMixin, BasePolicyStoreClient):
         if not tuples:
             return None
 
-        delete_keys = [
-            {
-                "user": t["key"]["user"],
-                "relation": t["key"]["relation"],
-                "object": t["key"]["object"],
-            }
-            for t in tuples
-        ]
+        delete_keys = _to_write_tuple_keys(tuples)
 
         async with aiohttp.ClientSession(trust_env=True) as session:
             try:
@@ -335,7 +345,10 @@ class OpenFGAClient(LivenessProbeMixin, BasePolicyStoreClient):
         return self._engine_reachable
 
     async def full_export(self, writer: AsyncTextIOWrapper) -> None:
-        tuples = await self._read_all_tuples()
+        # Store the flat write-shaped tuples (not /read's raw {"key": ...,
+        # "timestamp": ...} response shape) so full_import can feed them
+        # straight back into set_policy_data without reshaping.
+        tuples = _to_write_tuple_keys(await self._read_all_tuples())
         headers = await self._get_auth_headers()
         model = None
         async with aiohttp.ClientSession(trust_env=True) as session:

--- a/packages/opal-client/opal_client/policy_store/openfga_client.py
+++ b/packages/opal-client/opal_client/policy_store/openfga_client.py
@@ -1,0 +1,365 @@
+"""OpenFGA policy-store client.
+
+Design note (bounty issue permitio/opal#661): OpenFGA's data model does not
+map onto OPA/Cedar's "named policy files" shape. OPA and Cedar let you push
+independent policy modules by id; OpenFGA has exactly one authorization
+model per store, and models are immutable/versioned rather than patched in
+place. So:
+
+- `set_policies(bundle)` compiles every module in the bundle into a single
+  combined authorization model and writes it once, instead of looping a
+  per-module `set_policy()` call the way Cedar does. `set_policy`,
+  `get_policy`, `delete_policy`, and `get_policy_module_ids` are therefore
+  left unimplemented (inheriting `NotImplementedError` from
+  `BasePolicyStoreClient`) — same as Cedar leaves several methods
+  unimplemented, because there is no per-file operation to perform.
+- `set_policy_data` / `delete_policy_data` / `get_data` map onto OpenFGA's
+  relationship tuples (its analogue of "data"/facts) via the real
+  `/write` and `/read` endpoints.
+
+Endpoint paths and request/response shapes below were verified against
+OpenFGA's own OpenAPI spec (github.com/openfga/api,
+docs/openapiv2/apidocs.swagger.json), not guessed.
+
+Known gaps, left for a deliberate follow-up rather than silently guessed at:
+- No REST health-check endpoint exists in OpenFGA's spec, so the liveness
+  probe hits `GET /stores` instead — a real, cheap, store-agnostic endpoint.
+- OAuth is not supported here, matching Cedar's stance — OpenFGA does
+  support OIDC in some deployments, but wiring that up is separate work.
+- `authorization_model_id` pinning (OpenFGA's own recommended practice for
+  Check/Write calls) isn't implemented; writes target the latest model
+  implicitly by omitting `authorization_model_id` from `/write`.
+- Relationship conditions (`TupleKey.condition`) aren't supported; tuples
+  are plain (user, relation, object) triples.
+- `store_id` is read from the `POLICY_STORE_OPENFGA_STORE_ID` environment
+  variable directly at construction time as a pragmatic MVP choice — a real
+  `confi`-declared config option in opal_client/config.py (mirroring how
+  POLICY_STORE_URL etc. are declared) is the correct long-term home for it.
+"""
+import asyncio
+import json
+import os
+from typing import Dict, List, Optional
+
+import aiohttp
+from aiofiles.threadpool.text import AsyncTextIOWrapper
+from opal_client.config import opal_client_config
+from opal_client.logger import logger
+from opal_client.policy_store.base_policy_store_client import (
+    BasePolicyStoreClient,
+    JsonableValue,
+)
+from opal_client.policy_store.liveness_probe import LivenessProbeMixin
+from opal_client.policy_store.opa_client import (
+    RETRY_CONFIG,
+    affects_transaction,
+    fail_silently,
+)
+from opal_client.policy_store.schemas import PolicyStoreAuth
+from opal_common.schemas.policy import PolicyBundle
+from opal_common.schemas.store import StoreTransaction, TransactionType
+from tenacity import retry
+
+
+class OpenFGAClient(LivenessProbeMixin, BasePolicyStoreClient):
+    def __init__(
+        self,
+        openfga_server_url: str = None,
+        openfga_auth_token: Optional[str] = None,
+        auth_type: PolicyStoreAuth = PolicyStoreAuth.NONE,
+        store_id: Optional[str] = None,
+    ):
+        base_url = openfga_server_url or opal_client_config.POLICY_STORE_URL
+        self._openfga_url = base_url.rstrip("/")
+        self._store_id = store_id or os.environ.get("POLICY_STORE_OPENFGA_STORE_ID")
+        self._policy_version: Optional[str] = None
+        self._lock = asyncio.Lock()
+        self._token = openfga_auth_token
+        self._auth_type: PolicyStoreAuth = auth_type
+
+        self._had_successful_data_transaction = False
+        self._had_successful_policy_transaction = False
+        self._most_recent_data_transaction: Optional[StoreTransaction] = None
+        self._most_recent_policy_transaction: Optional[StoreTransaction] = None
+
+        # Defaults to True so /healthy preserves historical behavior;
+        # start_liveness_probe() runs an initial sample synchronously and
+        # overwrites this before the probe loop begins (mirrors Cedar/OPA).
+        self._engine_reachable: bool = True
+        self._init_liveness_probe()
+
+        if auth_type == PolicyStoreAuth.TOKEN:
+            if self._token is None:
+                logger.error("POLICY_STORE_AUTH_TOKEN can not be empty")
+                raise TypeError("required variables for token auth are not set")
+        elif auth_type == PolicyStoreAuth.OAUTH:
+            raise ValueError("OpenFGA client does not support OAuth yet.")
+
+        if not self._store_id:
+            raise TypeError(
+                "OpenFGA policy store requires a store id. Set "
+                "POLICY_STORE_OPENFGA_STORE_ID, or pass store_id= explicitly."
+            )
+
+        logger.info(f"Authentication mode for policy store: {auth_type}")
+
+    def _store_url(self, suffix: str = "") -> str:
+        return f"{self._openfga_url}/stores/{self._store_id}{suffix}"
+
+    async def _get_auth_headers(self) -> Dict[str, str]:
+        headers: Dict[str, str] = {}
+        if self._auth_type == PolicyStoreAuth.TOKEN and self._token is not None:
+            headers["Authorization"] = f"Bearer {self._token}"
+        return headers
+
+    @affects_transaction
+    @retry(**RETRY_CONFIG)
+    async def set_policies(
+        self, bundle: PolicyBundle, transaction_id: Optional[str] = None
+    ):
+        """Compiles every module in the bundle into ONE authorization model
+        and writes it once. Each module's `.rego` text field is expected to
+        already contain JSON-encoded OpenFGA type_definitions — the DSL ->
+        JSON transpile itself is out of scope here; modules are expected to
+        be produced in that JSON form upstream of OPAL (e.g. via the FGA
+        CLI's `model transform` command) before being committed to the
+        policy repo."""
+        type_definitions: List[dict] = []
+        for module in bundle.policy_modules:
+            try:
+                parsed = json.loads(module.rego)
+            except json.JSONDecodeError as e:
+                logger.error(
+                    "OpenFGA policy module {path} is not valid JSON type_definitions: {err}",
+                    path=module.path,
+                    err=repr(e),
+                )
+                raise
+            if isinstance(parsed, list):
+                type_definitions.extend(parsed)
+            elif isinstance(parsed, dict) and "type_definitions" in parsed:
+                type_definitions.extend(parsed["type_definitions"])
+            else:
+                type_definitions.append(parsed)
+
+        if not type_definitions:
+            logger.info("No OpenFGA type_definitions in bundle; skipping model write.")
+            return
+
+        async with aiohttp.ClientSession(trust_env=True) as session:
+            try:
+                headers = await self._get_auth_headers()
+                async with session.post(
+                    self._store_url("/authorization-models"),
+                    json={"type_definitions": type_definitions, "schema_version": "1.1"},
+                    headers=headers,
+                ) as response:
+                    if response.status != 201:
+                        body = await response.text()
+                        raise ValueError(
+                            "OpenFGA Client: unexpected status writing authorization "
+                            f"model: {response.status}, body: {body}"
+                        )
+                    result = await response.json()
+                    self._policy_version = result.get("authorization_model_id")
+            except aiohttp.ClientError as e:
+                logger.warning("OpenFGA connection error: {err}", err=repr(e))
+                raise
+
+    async def get_policy_version(self) -> Optional[str]:
+        return self._policy_version
+
+    @affects_transaction
+    @retry(**RETRY_CONFIG)
+    async def set_policy_data(
+        self,
+        policy_data: JsonableValue,
+        path: str = "",
+        transaction_id: Optional[str] = None,
+    ):
+        """`policy_data` must be a list of {"user", "relation", "object"}
+        dicts — OpenFGA relationship tuples, OPAL's closest analogue to
+        arbitrary "data". There is no sub-path write in OpenFGA's tuple
+        model, so (matching Cedar's identical constraint, for the same
+        reason) a non-empty path is rejected rather than silently ignored."""
+        if path != "":
+            raise ValueError("OpenFGA can only write the entire tuple set at once.")
+        if not isinstance(policy_data, list):
+            logger.warning(
+                "OPAL client was instructed to put something that is not a list of "
+                "tuples on OpenFGA. This will probably not work."
+            )
+            return None
+
+        async with aiohttp.ClientSession(trust_env=True) as session:
+            try:
+                headers = await self._get_auth_headers()
+                async with session.post(
+                    self._store_url("/write"),
+                    json={"writes": {"tuple_keys": policy_data, "on_duplicate": "ignore"}},
+                    headers=headers,
+                ) as response:
+                    if response.status != 200:
+                        body = await response.text()
+                        raise ValueError(
+                            "OpenFGA Client: unexpected status writing tuples: "
+                            f"{response.status}, body: {body}"
+                        )
+                    return await response.json()
+            except aiohttp.ClientError as e:
+                logger.warning("OpenFGA connection error: {err}", err=repr(e))
+                raise
+
+    @affects_transaction
+    @retry(**RETRY_CONFIG)
+    async def delete_policy_data(
+        self, path: str = "", transaction_id: Optional[str] = None
+    ):
+        """OpenFGA has no single "clear everything" call (unlike Cedar's
+        `DELETE /data`) — deleting a tuple requires naming it explicitly. So
+        this reads every current tuple (paginating through /read) and issues
+        one /write call with all of them as `deletes`."""
+        if path != "":
+            raise ValueError("OpenFGA can only clear the entire tuple set at once.")
+
+        tuples = await self._read_all_tuples()
+        if not tuples:
+            return None
+
+        delete_keys = [
+            {
+                "user": t["key"]["user"],
+                "relation": t["key"]["relation"],
+                "object": t["key"]["object"],
+            }
+            for t in tuples
+        ]
+
+        async with aiohttp.ClientSession(trust_env=True) as session:
+            try:
+                headers = await self._get_auth_headers()
+                async with session.post(
+                    self._store_url("/write"),
+                    json={"deletes": {"tuple_keys": delete_keys, "on_missing": "ignore"}},
+                    headers=headers,
+                ) as response:
+                    if response.status != 200:
+                        body = await response.text()
+                        raise ValueError(
+                            "OpenFGA Client: unexpected status deleting tuples: "
+                            f"{response.status}, body: {body}"
+                        )
+                    return await response.json()
+            except aiohttp.ClientError as e:
+                logger.warning("OpenFGA connection error: {err}", err=repr(e))
+                raise
+
+    async def _read_all_tuples(self) -> List[dict]:
+        """Pages through POST /read (no filter = all tuples) until the
+        response's continuation_token comes back empty."""
+        tuples: List[dict] = []
+        continuation_token = ""
+        headers = await self._get_auth_headers()
+        async with aiohttp.ClientSession(trust_env=True) as session:
+            while True:
+                body: Dict[str, object] = {"page_size": 100}
+                if continuation_token:
+                    body["continuation_token"] = continuation_token
+                async with session.post(
+                    self._store_url("/read"), json=body, headers=headers
+                ) as response:
+                    if response.status != 200:
+                        text = await response.text()
+                        raise ValueError(
+                            "OpenFGA Client: unexpected status reading tuples: "
+                            f"{response.status}, body: {text}"
+                        )
+                    result = await response.json()
+                    tuples.extend(result.get("tuples", []))
+                    continuation_token = result.get("continuation_token", "")
+                    if not continuation_token:
+                        break
+        return tuples
+
+    @fail_silently()
+    @retry(**RETRY_CONFIG)
+    async def get_data(self, path: str) -> Dict:
+        """Returns all relationship tuples as {"tuples": [...]} — OpenFGA's
+        closest match to OPA/Cedar's "get everything at this data path"."""
+        if path != "":
+            raise ValueError("OpenFGA can only read the entire tuple set at once.")
+        tuples = await self._read_all_tuples()
+        return {"tuples": tuples}
+
+    async def log_transaction(self, transaction: StoreTransaction):
+        if transaction.transaction_type == TransactionType.policy:
+            self._most_recent_policy_transaction = transaction
+            if transaction.success:
+                self._had_successful_policy_transaction = True
+        elif transaction.transaction_type == TransactionType.data:
+            self._most_recent_data_transaction = transaction
+            if transaction.success:
+                self._had_successful_data_transaction = True
+
+    async def is_ready(self) -> bool:
+        return (
+            self._had_successful_policy_transaction
+            and self._had_successful_data_transaction
+        )
+
+    async def is_healthy(self) -> bool:
+        transactions_healthy: bool = (
+            self._most_recent_policy_transaction is not None
+            and self._most_recent_policy_transaction.success
+        ) and (
+            self._most_recent_data_transaction is not None
+            and self._most_recent_data_transaction.success
+        )
+        return transactions_healthy and self._engine_reachable
+
+    @property
+    def _probe_log_label(self) -> str:
+        return "OpenFGA"
+
+    async def _probe_engine_reachable(self, session: aiohttp.ClientSession) -> bool:
+        """OpenFGA's OpenAPI spec has no dedicated health-check REST path,
+        so this hits `GET /stores` — a real, cheap, store-agnostic endpoint
+        that only requires the server to be up and answering."""
+        async with session.get(f"{self._openfga_url}/stores?page_size=1") as response:
+            return 200 <= response.status < 300
+
+    def _set_engine_reachable(self, value: bool) -> None:
+        self._engine_reachable = value
+
+    def _get_engine_reachable(self) -> bool:
+        return self._engine_reachable
+
+    async def full_export(self, writer: AsyncTextIOWrapper) -> None:
+        tuples = await self._read_all_tuples()
+        headers = await self._get_auth_headers()
+        model = None
+        async with aiohttp.ClientSession(trust_env=True) as session:
+            async with session.get(
+                self._store_url("/authorization-models?page_size=1"), headers=headers
+            ) as response:
+                if response.status == 200:
+                    result = await response.json()
+                    models = result.get("authorization_models", [])
+                    model = models[0] if models else None
+        await writer.write(json.dumps({"model": model, "tuples": tuples}, default=str))
+
+    async def full_import(self, reader: AsyncTextIOWrapper) -> None:
+        import_data = json.loads(await reader.read())
+        model = import_data.get("model")
+        if model:
+            async with aiohttp.ClientSession(trust_env=True) as session:
+                headers = await self._get_auth_headers()
+                await session.post(
+                    self._store_url("/authorization-models"),
+                    json={
+                        "type_definitions": model.get("type_definitions", []),
+                        "schema_version": model.get("schema_version", "1.1"),
+                    },
+                    headers=headers,
+                )
+        await self.set_policy_data(import_data.get("tuples", []))

--- a/packages/opal-client/opal_client/policy_store/policy_store_client_factory.py
+++ b/packages/opal-client/opal_client/policy_store/policy_store_client_factory.py
@@ -152,6 +152,14 @@ class PolicyStoreClientFactory:
                 cedar_auth_token=store_token,
                 auth_type=auth_type,
             )
+        elif PolicyStoreTypes.OPENFGA == store_type:
+            from opal_client.policy_store.openfga_client import OpenFGAClient
+
+            res = OpenFGAClient(
+                url,
+                openfga_auth_token=store_token,
+                auth_type=auth_type,
+            )
         # MOCK
         elif PolicyStoreTypes.MOCK == store_type:
             from opal_client.policy_store.mock_policy_store_client import (

--- a/packages/opal-client/opal_client/policy_store/schemas.py
+++ b/packages/opal-client/opal_client/policy_store/schemas.py
@@ -7,6 +7,7 @@ from pydantic import BaseModel, Field, validator
 class PolicyStoreTypes(Enum):
     OPA = "OPA"
     CEDAR = "CEDAR"
+    OPENFGA = "OPENFGA"
     MOCK = "MOCK"
 
 

--- a/packages/opal-client/opal_client/tests/openfga_client_liveness_test.py
+++ b/packages/opal-client/opal_client/tests/openfga_client_liveness_test.py
@@ -1,0 +1,200 @@
+"""Unit tests for the OpenFGAClient policy-store liveness probe.
+
+OpenFGAClient inherits the same `LivenessProbeMixin` as `OpaClient`/
+`CedarClient`, so most of the lifecycle behavior is exercised in the OPA
+suite. This file covers the OpenFGA-specific surface: that the probe
+reaches OpenFGA's real `GET /stores` endpoint (there is no dedicated
+health-check REST path in OpenFGA's OpenAPI spec) and that the result
+feeds into `is_healthy()`.
+"""
+
+import asyncio
+import contextlib
+import time
+from typing import AsyncIterator, Optional, Tuple
+
+import pytest
+from aiohttp import web
+from opal_client.config import opal_client_config
+from opal_client.policy_store.openfga_client import OpenFGAClient
+from opal_client.policy_store.schemas import PolicyStoreAuth
+from opal_common.schemas.store import StoreTransaction, TransactionType
+
+
+def _make_transaction(
+    success: bool, transaction_type: TransactionType
+) -> StoreTransaction:
+    return StoreTransaction(
+        id="test-id",
+        actions=["set_policy_data"],
+        transaction_type=transaction_type,
+        success=success,
+        error="" if success else "boom",
+    )
+
+
+def _record_successful_transactions(client: OpenFGAClient) -> None:
+    client._most_recent_policy_transaction = _make_transaction(
+        True, TransactionType.policy
+    )
+    client._most_recent_data_transaction = _make_transaction(True, TransactionType.data)
+
+
+class _ToggleOpenFGAServer:
+    """Tiny aiohttp server that exposes `GET /stores` (matching OpenFGA)."""
+
+    HEALTHY = "healthy"
+    UNHEALTHY_5XX = "unhealthy_5xx"
+
+    def __init__(self) -> None:
+        self.mode: str = self.HEALTHY
+        self._runner: Optional[web.AppRunner] = None
+        self._site: Optional[web.TCPSite] = None
+        self.port: int = 0
+
+    async def start(self) -> str:
+        app = web.Application()
+        # OpenFGA serves 200 with a store list on GET /stores; mirror that.
+        app.router.add_get("/stores", self._handle)
+        self._runner = web.AppRunner(app)
+        await self._runner.setup()
+        self._site = web.TCPSite(self._runner, "127.0.0.1", 0)
+        await self._site.start()
+        sockets = self._site._server.sockets  # type: ignore[union-attr]
+        assert sockets, "aiohttp site started without a bound socket"
+        self.port = sockets[0].getsockname()[1]
+        return f"http://127.0.0.1:{self.port}"
+
+    async def stop(self) -> None:
+        if self._site is not None:
+            await self._site.stop()
+        if self._runner is not None:
+            await self._runner.cleanup()
+
+    async def _handle(self, request: web.Request) -> web.Response:
+        if self.mode == self.HEALTHY:
+            return web.json_response({"stores": [], "continuation_token": ""})
+        return web.Response(status=503, text="down")
+
+
+@contextlib.asynccontextmanager
+async def _toggle_server() -> AsyncIterator[Tuple[_ToggleOpenFGAServer, str]]:
+    server = _ToggleOpenFGAServer()
+    base_url = await server.start()
+    try:
+        yield server, base_url
+    finally:
+        await server.stop()
+
+
+@contextlib.asynccontextmanager
+async def _override_config(**overrides):
+    saved = {key: getattr(opal_client_config, key) for key in overrides}
+    try:
+        for key, value in overrides.items():
+            setattr(opal_client_config, key, value)
+        yield
+    finally:
+        for key, value in saved.items():
+            setattr(opal_client_config, key, value)
+
+
+async def _wait_for_engine_reachable(
+    client: OpenFGAClient, expected: bool, timeout: float = 5.0
+) -> None:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if client._engine_reachable is expected:
+            return
+        await asyncio.sleep(0.05)
+    raise AssertionError(
+        f"engine_reachable did not become {expected} within {timeout}s "
+        f"(actual={client._engine_reachable})"
+    )
+
+
+def _make_client(base_url: str) -> OpenFGAClient:
+    return OpenFGAClient(
+        openfga_server_url=base_url,
+        openfga_auth_token=None,
+        auth_type=PolicyStoreAuth.NONE,
+        store_id="01TEST0000000000000000STORE",
+    )
+
+
+def test_missing_store_id_raises():
+    with pytest.raises(TypeError):
+        OpenFGAClient(openfga_server_url="http://127.0.0.1:0", store_id=None)
+
+
+def test_oauth_not_supported():
+    with pytest.raises(ValueError):
+        OpenFGAClient(
+            openfga_server_url="http://127.0.0.1:0",
+            auth_type=PolicyStoreAuth.OAUTH,
+            store_id="01TEST0000000000000000STORE",
+        )
+
+
+@pytest.mark.asyncio
+async def test_healthy_when_transactions_ok_and_openfga_reachable():
+    async with _toggle_server() as (_server, base_url):
+        async with _override_config(
+            POLICY_STORE_LIVENESS_PROBE_ENABLED=True,
+            POLICY_STORE_LIVENESS_PROBE_INTERVAL_SECONDS=1,
+            POLICY_STORE_LIVENESS_PROBE_TIMEOUT_SECONDS=1,
+        ):
+            client = _make_client(base_url)
+            _record_successful_transactions(client)
+            try:
+                await client.start_liveness_probe()
+                # First probe runs synchronously inside start_liveness_probe.
+                assert client._engine_reachable is True
+                assert await client.is_healthy() is True
+            finally:
+                await client.stop_liveness_probe()
+
+
+@pytest.mark.asyncio
+async def test_unhealthy_when_openfga_returns_5xx():
+    async with _toggle_server() as (server, base_url):
+        async with _override_config(
+            POLICY_STORE_LIVENESS_PROBE_ENABLED=True,
+            POLICY_STORE_LIVENESS_PROBE_INTERVAL_SECONDS=1,
+            POLICY_STORE_LIVENESS_PROBE_TIMEOUT_SECONDS=1,
+        ):
+            client = _make_client(base_url)
+            _record_successful_transactions(client)
+            server.mode = _ToggleOpenFGAServer.UNHEALTHY_5XX
+            try:
+                await client.start_liveness_probe()
+                await _wait_for_engine_reachable(client, False, timeout=5.0)
+                assert await client.is_healthy() is False
+            finally:
+                await client.stop_liveness_probe()
+
+
+@pytest.mark.asyncio
+async def test_recovery_after_openfga_returns():
+    async with _toggle_server() as (server, base_url):
+        async with _override_config(
+            POLICY_STORE_LIVENESS_PROBE_ENABLED=True,
+            POLICY_STORE_LIVENESS_PROBE_INTERVAL_SECONDS=1,
+            POLICY_STORE_LIVENESS_PROBE_TIMEOUT_SECONDS=1,
+        ):
+            client = _make_client(base_url)
+            _record_successful_transactions(client)
+            try:
+                await client.start_liveness_probe()
+                await _wait_for_engine_reachable(client, True)
+                assert await client.is_healthy() is True
+
+                server.mode = _ToggleOpenFGAServer.UNHEALTHY_5XX
+                await _wait_for_engine_reachable(client, False, timeout=10.0)
+                assert await client.is_healthy() is False
+
+                server.mode = _ToggleOpenFGAServer.HEALTHY
+                await _wait_for_engine_reachable(client, True, timeout=10.0)
+                assert await client.is_healthy() is True
+            finally:
+                await client.stop_liveness_probe()


### PR DESCRIPTION
Adds OpenFGA support per #661.

## Design

OpenFGA's data model doesn't map onto OPA/Cedar's "named policy files" shape — OpenFGA has one immutable, versioned authorization model per store rather than independently-addressable policy files. So `set_policies(bundle)` compiles every module in the bundle into a single authorization model and writes it once, instead of looping a per-module `set_policy()` call. `set_policy`/`get_policy`/`delete_policy`/`get_policy_module_ids` are left unimplemented (inheriting `NotImplementedError`), same as Cedar leaves several methods unimplemented — there's no per-file operation to perform. `set_policy_data`/`delete_policy_data`/`get_data` map onto OpenFGA relationship tuples via the real `/write` and `/read` endpoints.

Endpoint paths and payload shapes were verified against OpenFGA's own OpenAPI spec (`github.com/openfga/api`), not guessed.

## Testing

- Unit/liveness tests: `openfga_client_liveness_test.py`, mirroring the existing Cedar suite. Full `opal-client` suite passes (37/37; two unrelated pre-existing test files don't collect on Windows due to a POSIX-only `fcntl` import in `opal_common`, confirmed via `git stash` to predate this change).
- Verified against a real, containerized OpenFGA instance (`docker run openfga/openfga run`) — not mocked: `set_policies` (real model write), `set_policy_data`/`get_data` (real tuple write/read round-trip), `delete_policy_data`, the liveness probe against `GET /stores`, the transaction-context path (`is_ready`/`is_healthy` via real `log_transaction` calls), and `full_export`/`full_import` round-trip. This caught and fixed a real bug: `full_export` was writing `/read`'s raw response shape into the export instead of the flat shape `/write` expects.

## Known scope limits (flagged, not hidden)

- OAuth isn't supported (matches Cedar's stance); OpenFGA does support OIDC in some deployments but that's separate work.
- `store_id` is read from `POLICY_STORE_OPENFGA_STORE_ID` directly rather than wired into `config.py`'s `confi` system — a pragmatic MVP choice, real config wiring is a natural follow-up.
- No OpenFGA DSL → JSON transpile; policy modules are expected to already contain JSON-encoded `type_definitions`.
- `authorization_model_id` pinning on writes isn't implemented; writes target the latest model implicitly.
- The "inline runner" (OPAL spawning the engine itself, like it does for OPA/Cedar) isn't included — OpenFGA normally runs as its own service with its own datastore, so that felt like separately-scoped work rather than a mechanical port.