### PR TITLE
fix(opal-server): PR3 follow-ups from the staging campaign (rc.3)

### DIFF
--- a/documentation/docs/getting-started/configuration.mdx
+++ b/documentation/docs/getting-started/configuration.mdx
@@ -789,7 +789,7 @@ Default: `True`
 
 Enable repository watching for policy changes.
 
-In scopes mode (`OPAL_SCOPES=true`) this same flag enables the **scopes sync task** on the leader worker: the periodic `sync_scopes` pass (every `OPAL_POLICY_REFRESH_INTERVAL` seconds), the boot-time sync of all scopes, and the fleet-wide purge of deleted or repointed scopes. With it set to `false` in scopes mode, scopes can be registered and served but are never synced or purged — the server logs a warning at startup when it detects this combination.
+In scopes mode (`OPAL_SCOPES=true`) this same flag enables the **scopes sync task** on the leader worker: the boot-time sync of all scopes, the periodic `sync_scopes` pass when `OPAL_POLICY_REFRESH_INTERVAL` is greater than 0 (it defaults to 0, which skips the periodic pass), and the fleet-wide purge handler for deleted or repointed scopes. With it set to `false` in scopes mode, scopes can be registered and served but are never synced or purged — the server logs a warning at startup when it detects this combination.
 
 #### OPAL_POLICY_REFRESH_INTERVAL
 

--- a/documentation/docs/getting-started/configuration.mdx
+++ b/documentation/docs/getting-started/configuration.mdx
@@ -583,6 +583,14 @@ Default: `None`
 
 URI for the broadcast backend (Redis, PostgreSQL, etc.).
 
+**Postgres TCP keepalive (opal-server ≥ 0.9.9-rc.3 / `permit-broadcaster` ≥ 0.2.7):** the Postgres backend enables TCP keepalive on every backbone connection by default (idle 30 s, interval 10 s, 3 lost probes → a silently vanished server — e.g. an RDS Multi-AZ failover — is detected within ~60 s instead of never). It can be tuned or disabled with libpq-style parameters in the URI: `postgres://…/db?keepalives=1&keepalives_idle=30&keepalives_interval=10&keepalives_count=3` (`keepalives=0` disables).
+
+:::danger version constraint
+Only set `keepalives*` parameters when **every** opal-server that shares this URI runs ≥ 0.9.9-rc.3. Earlier versions (`permit-broadcaster` ≤ 0.2.6) forward these parameters to Postgres as session settings, and Postgres rejects the connection with `FATAL: unrecognized configuration parameter` — a pod rolled back (or a canary slice still on the old image) would have **zero backbone connectivity while its health checks stay green**. The defaults require no URI change at all; only add the parameters once the fleet is uniformly upgraded.
+:::
+
+**Connection budget (Postgres backend):** each worker process that holds a backbone reader opens a connection *pool*: 10 connections at boot (asyncpg's default `min_size`, not configurable downward via `BROADCASTER_PG_MAX_POOL_SIZE`, which only raises the ceiling), decaying to ~1 idle connection after ~300 s. Size the broadcast database's `max_connections` for **10 × workers × pods during a rolling restart**, not for the steady state.
+
 For more information, see [running OPAL with Kafka](/tutorials/run_opal_with_kafka) and [running OPAL with Apache Pulsar](/tutorials/run_opal_with_pulsar).
 
 #### OPAL_BROADCAST_CHANNEL_NAME
@@ -789,7 +797,7 @@ Default: `True`
 
 Enable repository watching for policy changes.
 
-In scopes mode (`OPAL_SCOPES=true`) this same flag enables the **scopes sync task** on the leader worker: the boot-time sync of all scopes, the periodic `sync_scopes` pass when `OPAL_POLICY_REFRESH_INTERVAL` is greater than 0 (it defaults to 0, which skips the periodic pass), and the fleet-wide purge handler for deleted or repointed scopes. With it set to `false` in scopes mode, scopes can be registered and served but are never synced or purged — the server logs a warning at startup when it detects this combination.
+In scopes mode (`OPAL_SCOPES=true`) this same flag enables the **scopes sync task** on the leader worker: the boot-time sync of all scopes, the periodic `sync_scopes` pass when `OPAL_POLICY_REFRESH_INTERVAL` is greater than 0 (it defaults to 0, which skips the periodic pass), and the fleet-wide purge handler for deleted or repointed scopes. With it set to `false` in scopes mode, scopes are registered, preloaded and served but never re-synced or purged afterwards — the server logs a warning at startup when it detects this combination. Note that this flag does **not** gate the gunicorn master's pre-fork preload: every registered scope is still cloned/fetched once at every boot, so boot-time git traffic and clone-tree disk usage are expected even with the flag off.
 
 #### OPAL_POLICY_REFRESH_INTERVAL
 

--- a/documentation/docs/getting-started/configuration.mdx
+++ b/documentation/docs/getting-started/configuration.mdx
@@ -789,6 +789,8 @@ Default: `True`
 
 Enable repository watching for policy changes.
 
+In scopes mode (`OPAL_SCOPES=true`) this same flag enables the **scopes sync task** on the leader worker: the periodic `sync_scopes` pass (every `OPAL_POLICY_REFRESH_INTERVAL` seconds), the boot-time sync of all scopes, and the fleet-wide purge of deleted or repointed scopes. With it set to `false` in scopes mode, scopes can be registered and served but are never synced or purged — the server logs a warning at startup when it detects this combination.
+
 #### OPAL_POLICY_REFRESH_INTERVAL
 
 Default: `0`

--- a/packages/opal-server/opal_server/config.py
+++ b/packages/opal-server/opal_server/config.py
@@ -424,7 +424,12 @@ class OpalServerConfig(Confi):
     )
 
     REPO_WATCHER_ENABLED = confi.bool(
-        "REPO_WATCHER_ENABLED", True, description="Enable the repository watcher"
+        "REPO_WATCHER_ENABLED",
+        True,
+        description="Enable the repository watcher. In scopes mode (SCOPES=true) this "
+        "same flag enables the scopes sync task on the leader worker: the periodic "
+        "sync_scopes pass, the boot-time sync of all scopes and the fleet purger. "
+        "With it off, scopes can be registered but are never synced or purged.",
     )
 
     # publisher

--- a/packages/opal-server/opal_server/config.py
+++ b/packages/opal-server/opal_server/config.py
@@ -428,8 +428,10 @@ class OpalServerConfig(Confi):
         True,
         description="Enable the repository watcher. In scopes mode (SCOPES=true) this "
         "same flag enables the scopes sync task on the leader worker: the periodic "
-        "sync_scopes pass, the boot-time sync of all scopes and the fleet purger. "
-        "With it off, scopes can be registered but are never synced or purged.",
+        "sync_scopes pass, the post-leadership sync of all scopes and the fleet "
+        "purger. It does NOT gate the pre-fork preload, which still clones/fetches "
+        "every registered scope at boot. With the flag off, scopes are registered, "
+        "preloaded at boot and served, but never re-synced or purged afterwards.",
     )
 
     # publisher

--- a/packages/opal-server/opal_server/metrics_setup.py
+++ b/packages/opal-server/opal_server/metrics_setup.py
@@ -1,0 +1,32 @@
+"""One place that decides how opal-server's DogStatsD client is configured.
+
+Both the worker app (``OpalServer._configure_monitoring``) and the gunicorn
+MASTER (the pre-fork scope preload in ``scopes/task.py``, run from
+``scripts/gunicorn_conf.py:when_ready`` before any worker exists) must call
+this: the master emits git metrics during preload, and until 0.9.9-rc.3 it
+never configured the client, so those metrics reached Datadog WITHOUT the
+``permit.opal`` namespace (``opal_server.scopes.git_ops_in_flight`` next to the
+workers' ``permit.opal.opal_server.scopes.git_ops_in_flight``) — invisible to
+every dashboard and monitor written against the namespaced names.
+"""
+import os
+
+from opal_common.config import opal_common_config
+from opal_common.monitoring import metrics
+
+STATSD_PORT = 8125
+METRICS_NAMESPACE = "opal"
+
+
+def configure_server_metrics() -> None:
+    """Configure (or re-configure) the process-wide DogStatsD client the way
+    opal-server expects it: fail-silent when metrics are disabled, namespace
+    ``permit.opal`` and the agent host from ``DD_AGENT_HOST`` when enabled.
+    Safe to call more than once (a forked worker configures again at app
+    startup)."""
+    metrics.configure_metrics(
+        enable_metrics=opal_common_config.ENABLE_METRICS,
+        statsd_host=os.environ.get("DD_AGENT_HOST", "localhost"),
+        statsd_port=STATSD_PORT,
+        namespace=METRICS_NAMESPACE,
+    )

--- a/packages/opal-server/opal_server/scopes/purge.py
+++ b/packages/opal-server/opal_server/scopes/purge.py
@@ -40,13 +40,13 @@ kept so a dropped broadcast does not regress against the merge base.
 What that leaves on disk, stated plainly because nothing else will reclaim it:
 
 - a DELETE's dir on every pod EXCEPT the serving one, when the broadcast is
-  lost — and the broadcast is droppable at shipped defaults, since a DELETE
-  usually lands on a non-leader worker (SERVER_WORKER_COUNT defaults to the
-  core count) and must traverse the broadcaster, while a leader keeps a reader
-  alive only if it has a connected client or STATISTICS_ENABLED (default False).
-  The LEADER always has a reader — its watcher enters a listening context
-  unconditionally (policy/watcher/task.py) — so it is non-leader workers that
-  can be deaf, not the leader; a backbone outage still loses it for everyone;
+  lost. Since 0.9.9-rc.3 every worker keeps a backbone reader for the whole
+  process when SCOPES is on and the broadcaster is the reconnecting one
+  (server.py holds the global listening context; the default), so a
+  client-less non-leader is no longer deaf to the purge; the residual is
+  BROADCAST_RECONNECT_ENABLED=false (legacy broadcaster, reader only while a
+  client is connected) and a backbone outage, which still loses the message
+  for everyone;
 - a REPOINT's old dir on EVERY pod, always — there is no floor on that path;
 - a dir whose source_id is unknowable because the prior record would not parse
   (see ``scopes/api.py``).

--- a/packages/opal-server/opal_server/scopes/service.py
+++ b/packages/opal-server/opal_server/scopes/service.py
@@ -218,8 +218,26 @@ class ScopesService:
                     err=e,
                 )
             except Exception as e:
-                logger.exception(
-                    f"Could not fetch policy for scope {scope.scope_id}, got error: {e}"
+                # ERROR without the traceback: with a broken tail of dozens of
+                # sources this line is emitted per source per pass, and the
+                # ~40-line traceback that used to ride along rotated the
+                # container log (10 MiB) within minutes of a boot — the boot
+                # markers were gone before anyone could read them, and in prod
+                # it is the mechanism behind opal-server being 56% of the org's
+                # log bytes. The traceback is still there at DEBUG for anyone
+                # chasing a specific source; the source, scope and reason are
+                # in the ERROR line.
+                logger.error(
+                    "Could not fetch policy for scope {scope_id} "
+                    "(remote: {url}): {etype}: {err}",
+                    scope_id=scope.scope_id,
+                    url=redact_url(scope.policy.url),
+                    etype=type(e).__name__,
+                    err=e,
+                )
+                logger.opt(exception=True).debug(
+                    "traceback for the failed sync of scope {scope_id}",
+                    scope_id=scope.scope_id,
                 )
 
     async def delete_scope(self, scope_id: str):
@@ -551,7 +569,19 @@ class ScopesService:
                     logger.info(
                         f"scope {scope.scope_id} was deleted while sync was queued, skipping"
                     )
-                except Exception:
-                    logger.exception(f"sync_scope failed for {scope.scope_id}")
+                except Exception as e:
+                    # sync_scope already logs its own git failures without a
+                    # traceback (see there); this catches anything that escaped
+                    # it. Same rule: one ERROR line, traceback at DEBUG.
+                    logger.error(
+                        "sync_scope failed for {scope_id}: {etype}: {err}",
+                        scope_id=scope.scope_id,
+                        etype=type(e).__name__,
+                        err=e,
+                    )
+                    logger.opt(exception=True).debug(
+                        "traceback for the failed sync of scope {scope_id}",
+                        scope_id=scope.scope_id,
+                    )
 
         await asyncio.gather(*(_sync_one(scope) for scope in scopes))

--- a/packages/opal-server/opal_server/scopes/task.py
+++ b/packages/opal-server/opal_server/scopes/task.py
@@ -7,13 +7,13 @@ from fastapi_websocket_pubsub import Topic
 from opal_common.logger import logger
 from opal_common.monitoring import metrics
 from opal_server.config import opal_server_config
-from opal_server.metrics_setup import configure_server_metrics
 from opal_server.git_fetcher import (
     GitPolicyFetcher,
     drain_git_ops,
     git_busy_count,
     shutdown_git_executor,
 )
+from opal_server.metrics_setup import configure_server_metrics
 from opal_server.policy.watcher.task import BasePolicyWatcherTask
 from opal_server.redis_utils import RedisDB
 from opal_server.scopes.purge import LeaderScopePurger

--- a/packages/opal-server/opal_server/scopes/task.py
+++ b/packages/opal-server/opal_server/scopes/task.py
@@ -7,6 +7,7 @@ from fastapi_websocket_pubsub import Topic
 from opal_common.logger import logger
 from opal_common.monitoring import metrics
 from opal_server.config import opal_server_config
+from opal_server.metrics_setup import configure_server_metrics
 from opal_server.git_fetcher import (
     GitPolicyFetcher,
     drain_git_ops,
@@ -205,6 +206,12 @@ class ScopesPolicyWatcherTask(BasePolicyWatcherTask):
         started.
         """
         if opal_server_config.SCOPES:
+            # This runs in the gunicorn MASTER (scripts/gunicorn_conf.py:when_ready)
+            # before any worker configured monitoring. Without this the git
+            # metrics emitted during preload (git_ops_in_flight, scopes.count,
+            # sources_in_backoff, git_op_failures...) go out un-namespaced and
+            # never reach the dashboards/monitors built on permit.opal.*.
+            configure_server_metrics()
             logger.info("Preloading repo clones for scopes")
 
             service = ScopesService(

--- a/packages/opal-server/opal_server/scopes/task.py
+++ b/packages/opal-server/opal_server/scopes/task.py
@@ -248,11 +248,14 @@ class ScopesPolicyWatcherTask(BasePolicyWatcherTask):
             # Drop every cached repo handle/lock/timestamp built during preload
             # so none of it is inherited by forked workers. Sync (the only path
             # that populates these caches) is leader-only, so a non-leader worker
-            # that inherited a handle could never purge it — the fleet-wide purge
-            # broadcast reaches a worker only when its broadcaster reader runs
-            # (STATISTICS_ENABLED or a connected client), leaving a client-less
-            # non-leader to pin the handle for life. The on-disk clones remain;
-            # workers re-open handles lazily.
+            # that inherited a handle would only ever release it through the
+            # fleet-wide purge broadcast. Since 0.9.9-rc.3 every worker keeps a
+            # backbone reader when SCOPES is on and the broadcaster is the
+            # reconnecting one, so that broadcast does reach client-less workers;
+            # with BROADCAST_RECONNECT_ENABLED=false (legacy broadcaster) the reader
+            # runs only while a client is connected and an inherited handle could
+            # still be pinned for life — clearing here keeps both cases safe. The
+            # on-disk clones remain; workers re-open handles lazily.
             GitPolicyFetcher.reset_caches()
 
             logger.warning("Finished preloading repo clones for scopes.")

--- a/packages/opal-server/opal_server/server.py
+++ b/packages/opal-server/opal_server/server.py
@@ -196,12 +196,26 @@ class OpalServer:
         self.broadcast_listening_context: Optional[
             EventBroadcasterContextManager
         ] = None
-        if self.broadcaster_uri is not None and (
-            opal_common_config.STATISTICS_ENABLED or opal_server_config.SCOPES
-        ):
-            self.broadcast_listening_context = (
-                self.pubsub.endpoint.broadcaster.get_listening_context()
+        if self.broadcaster_uri is not None:
+            wants_reader_for_scopes = bool(opal_server_config.SCOPES) and isinstance(
+                self.pubsub.broadcaster, ReconnectingBroadcaster
             )
+            if opal_server_config.SCOPES and not wants_reader_for_scopes:
+                # Legacy EventBroadcaster (BROADCAST_RECONNECT_ENABLED=false):
+                # its reader connects EAGERLY in __aenter__ and re-raises, so a
+                # backbone that is down at boot would abort the background
+                # task before the purge subscription and the leadership lock.
+                # The reconnecting broadcaster connects lazily and never raises
+                # here, so the scopes reason is honoured only for it.
+                logger.info(
+                    "OPAL_SCOPES is on but BROADCAST_RECONNECT_ENABLED is off: "
+                    "workers without a WebSocket client keep no backbone reader, "
+                    "so fleet purge delivery to them is not guaranteed"
+                )
+            if opal_common_config.STATISTICS_ENABLED or wants_reader_for_scopes:
+                self.broadcast_listening_context = (
+                    self.pubsub.endpoint.broadcaster.get_listening_context()
+                )
 
         self.watcher: PolicyWatcherTask = None
         self.leadership_lock: Optional[NamedLock] = None
@@ -433,15 +447,40 @@ class OpalServer:
                         stats=self.opal_statistics is not None,
                         scopes=bool(opal_server_config.SCOPES),
                     )
-                    await self.broadcast_listening_context.__aenter__()
-                    if self.opal_statistics is not None:
+                    try:
+                        await self.broadcast_listening_context.__aenter__()
+                    except (
+                        Exception
+                    ) as exc:  # noqa: BLE001 — everything below must still run
+                        # Belt and braces for the eager-connect case the isinstance
+                        # gate above should already exclude: an unreadable backbone
+                        # must not cost this worker its purge subscription, the
+                        # leadership lock and the watcher. Leave the context None
+                        # so the exit path does not touch a half-entered manager.
+                        logger.warning(
+                            "Could not start listening on the broadcast channel on "
+                            "this worker ({etype}: {err}); continuing without a "
+                            "global reader — fleet purges reach this worker only "
+                            "while it has a WebSocket client",
+                            etype=type(exc).__name__,
+                            err=exc,
+                        )
+                        self.broadcast_listening_context = None
+                    if (
+                        self.broadcast_listening_context is not None
+                        and self.opal_statistics is not None
+                    ):
                         # if the broadcast channel is closed, we want to restart worker process because statistics can't be reliable anymore
                         self.broadcast_listening_context._event_broadcaster.get_reader_task().add_done_callback(
                             lambda _: self._graceful_shutdown()
                         )
-                    # For scopes-only workers a reader that gives up is handled by
-                    # _wire_broadcaster_give_up (graceful restart on give-up,
-                    # never on clean cancellation), so no done-callback here.
+                    # No done-callback for the scopes reason: the context exists
+                    # for scopes only on a ReconnectingBroadcaster (see __init__),
+                    # whose reader never completes on its own except by GIVING UP
+                    # after BROADCAST_RECONNECT_MAX_RETRIES — and that case already
+                    # restarts every worker through _wire_broadcaster_give_up
+                    # (fires on give-up, never on clean cancellation). The legacy
+                    # broadcaster is skipped for scopes altogether.
                 if self.opal_statistics is not None:
                     asyncio.create_task(self.opal_statistics.run())
                     self.pubsub.endpoint.notifier.register_unsubscribe_event(
@@ -490,7 +529,11 @@ class OpalServer:
                             self._graceful_shutdown()
 
                 if self.broadcast_listening_context is not None:
-                    await self.broadcast_listening_context.__aexit__()
+                    # __aexit__(exc_type, exc, tb): the real
+                    # EventBroadcasterContextManager has no defaults, and a
+                    # TypeError here (in an un-awaited background task) leaves
+                    # _listen_count at 1 and the reader never cancelled.
+                    await self.broadcast_listening_context.__aexit__(None, None, None)
                     logger.info(
                         "stopped listening on the broadcast channel on this worker"
                     )

--- a/packages/opal-server/opal_server/server.py
+++ b/packages/opal-server/opal_server/server.py
@@ -197,24 +197,27 @@ class OpalServer:
             EventBroadcasterContextManager
         ] = None
         if self.broadcaster_uri is not None:
+            # Legacy EventBroadcaster (BROADCAST_RECONNECT_ENABLED=false): its
+            # reader connects EAGERLY in __aenter__ and re-raises, so a backbone
+            # that is down at boot would abort the background task before the
+            # purge subscription and the leadership lock. The reconnecting
+            # broadcaster connects lazily and never raises here, so the scopes
+            # reason is honoured only for it.
             wants_reader_for_scopes = bool(opal_server_config.SCOPES) and isinstance(
                 self.pubsub.broadcaster, ReconnectingBroadcaster
             )
-            if opal_server_config.SCOPES and not wants_reader_for_scopes:
-                # Legacy EventBroadcaster (BROADCAST_RECONNECT_ENABLED=false):
-                # its reader connects EAGERLY in __aenter__ and re-raises, so a
-                # backbone that is down at boot would abort the background
-                # task before the purge subscription and the leadership lock.
-                # The reconnecting broadcaster connects lazily and never raises
-                # here, so the scopes reason is honoured only for it.
+            if opal_common_config.STATISTICS_ENABLED or wants_reader_for_scopes:
+                self.broadcast_listening_context = (
+                    self.pubsub.endpoint.broadcaster.get_listening_context()
+                )
+            if opal_server_config.SCOPES and self.broadcast_listening_context is None:
+                # Accurate in all four combinations: statistics on the legacy
+                # broadcaster DOES arm the context (for its own reason), and
+                # then purges are delivered too.
                 logger.info(
                     "OPAL_SCOPES is on but BROADCAST_RECONNECT_ENABLED is off: "
                     "workers without a WebSocket client keep no backbone reader, "
                     "so fleet purge delivery to them is not guaranteed"
-                )
-            if opal_common_config.STATISTICS_ENABLED or wants_reader_for_scopes:
-                self.broadcast_listening_context = (
-                    self.pubsub.endpoint.broadcaster.get_listening_context()
                 )
 
         self.watcher: PolicyWatcherTask = None
@@ -465,6 +468,23 @@ class OpalServer:
                             etype=type(exc).__name__,
                             err=exc,
                         )
+                        # UNWIND before dropping the reference: the library's
+                        # __aenter__ increments _listen_count BEFORE it starts the
+                        # reader, so a raise leaves the count at 1. Left there,
+                        # every later client context takes it to 2, 3, ... and
+                        # start_reader_task() never fires again — that worker
+                        # would serve clients that never receive a broadcast,
+                        # forever, with /healthcheck 200. __aexit__ decrements to
+                        # 0, skips the cancel (no task) and swallows its own errors.
+                        try:
+                            await self.broadcast_listening_context.__aexit__(
+                                None, None, None
+                            )
+                        except Exception:  # noqa: BLE001 — best effort, already failing
+                            logger.exception(
+                                "Could not unwind the broadcast listening context "
+                                "after a failed enter"
+                            )
                         self.broadcast_listening_context = None
                     if (
                         self.broadcast_listening_context is not None

--- a/packages/opal-server/opal_server/server.py
+++ b/packages/opal-server/opal_server/server.py
@@ -30,11 +30,11 @@ from opal_server.data.api import init_data_updates_router
 from opal_server.data.data_update_publisher import DataUpdatePublisher
 from opal_server.debug_stats import register_internal_stats_route
 from opal_server.loadlimiting import init_loadlimit_router
+from opal_server.metrics_setup import configure_server_metrics
 from opal_server.policy.bundles.api import router as bundles_router
 from opal_server.policy.watcher.factory import setup_watcher_task
 from opal_server.policy.watcher.task import PolicyWatcherTask
 from opal_server.policy.webhook.api import init_git_webhook_router
-from opal_server.metrics_setup import configure_server_metrics
 from opal_server.publisher import setup_broadcaster_keepalive_task
 from opal_server.pubsub import PubSub
 from opal_server.pubsub_resilience import ReconnectingBroadcaster

--- a/packages/opal-server/opal_server/server.py
+++ b/packages/opal-server/opal_server/server.py
@@ -210,6 +210,23 @@ class OpalServer:
             self._redis_db = RedisDB(opal_server_config.REDIS_URL)
             self._scopes = ScopeRepository(self._redis_db)
             logger.info("OPAL Scopes: server is connected to scopes repository")
+            if not self._init_policy_watcher:
+                # The flag's name reads as "single-repo watcher", but in scopes
+                # mode it gates setup_watcher_task() -> ScopesPolicyWatcherTask:
+                # the periodic sync_scopes pass, the boot sync-all and the fleet
+                # purger. With it off the leader parks on the keepalive forever,
+                # nothing is ever cloned/synced/purged, and the pods still report
+                # Ready. A WARNING rather than a hard refusal: an existing
+                # deployment must not stop booting on upgrade over a flag it may
+                # have set deliberately (e.g. a read-only replica behind another
+                # OPAL that does the syncing).
+                logger.warning(
+                    "OPAL_REPO_WATCHER_ENABLED is off while OPAL_SCOPES is on: this "
+                    "server will REGISTER and SERVE scopes but never SYNC or PURGE "
+                    "them (no periodic sync_scopes pass, no boot sync-all, no "
+                    "fleet purge). If that is not intended, set "
+                    "OPAL_REPO_WATCHER_ENABLED=true."
+                )
 
         # Set BEFORE _init_fast_api_app(): _configure_api_routes assigns it,
         # and it must exist even when SCOPES is off (shutdown reads it).

--- a/packages/opal-server/opal_server/server.py
+++ b/packages/opal-server/opal_server/server.py
@@ -203,6 +203,12 @@ class OpalServer:
             # purge subscription and the leadership lock. The reconnecting
             # broadcaster connects lazily and never raises here, so the scopes
             # reason is honoured only for it.
+            # Rollout cost (Postgres backbone): entering the context makes THIS
+            # worker open the broadcaster pool - asyncpg's default min_size is
+            # 10 eager connections at boot, decaying to ~1 after ~300 s
+            # (BROADCASTER_PG_MAX_POOL_SIZE can only raise the ceiling, not
+            # lower the floor). Budget the broadcast DB's max_connections for
+            # 10 x workers x pods at a rolling restart, not the steady state.
             wants_reader_for_scopes = bool(opal_server_config.SCOPES) and isinstance(
                 self.pubsub.broadcaster, ReconnectingBroadcaster
             )
@@ -230,19 +236,26 @@ class OpalServer:
             if not self._init_policy_watcher:
                 # The flag's name reads as "single-repo watcher", but in scopes
                 # mode it gates setup_watcher_task() -> ScopesPolicyWatcherTask:
-                # the periodic sync_scopes pass, the boot sync-all and the fleet
-                # purger. With it off the leader parks on the keepalive forever,
-                # nothing is ever cloned/synced/purged, and the pods still report
+                # the periodic sync_scopes pass, the leader's post-leadership
+                # sync-all and the fleet purger. It does NOT gate the gunicorn
+                # master's pre-fork preload (gunicorn_conf.py when_ready ->
+                # preload_scopes), which clones/fetches every registered scope
+                # on every boot regardless - the flag cannot mean "no git
+                # activity", only "no ongoing sync". With it off the leader
+                # parks on the keepalive forever and the pods still report
                 # Ready. A WARNING rather than a hard refusal: an existing
                 # deployment must not stop booting on upgrade over a flag it may
                 # have set deliberately (e.g. a read-only replica behind another
                 # OPAL that does the syncing).
                 logger.warning(
-                    "OPAL_REPO_WATCHER_ENABLED is off while OPAL_SCOPES is on: this "
-                    "server will REGISTER and SERVE scopes but never SYNC or PURGE "
-                    "them (no periodic sync_scopes pass, no boot sync-all, no "
-                    "fleet purge). If that is not intended, set "
-                    "OPAL_REPO_WATCHER_ENABLED=true."
+                    "OPAL_REPO_WATCHER_ENABLED is off while OPAL_SCOPES is on: the "
+                    "leader worker will never SYNC or PURGE scopes (no periodic "
+                    "sync_scopes pass, no post-leadership sync-all, no fleet "
+                    "purge). NOTE the gunicorn master's PRE-FORK PRELOAD still "
+                    "clones/fetches every registered scope on every boot - this "
+                    "flag does not gate it, so git traffic and clone-tree growth "
+                    "at boot are expected regardless. If ongoing sync is "
+                    "intended, set OPAL_REPO_WATCHER_ENABLED=true."
                 )
 
         # Set BEFORE _init_fast_api_app(): _configure_api_routes assigns it,
@@ -490,9 +503,23 @@ class OpalServer:
                         self.broadcast_listening_context is not None
                         and self.opal_statistics is not None
                     ):
-                        # if the broadcast channel is closed, we want to restart worker process because statistics can't be reliable anymore
+                        # If the broadcast channel DIES, statistics on this worker
+                        # can't be trusted anymore - restart. Guarded against the
+                        # exit path's own clean cancellation (__aexit__ cancels the
+                        # reader): on master the zero-arg __aexit__ raised TypeError
+                        # before the reader was ever cancelled, so this callback
+                        # never saw a cancelled task - firing on one now would be a
+                        # NEW self-SIGTERM at the end of every fall-through boot
+                        # (statistics on + keepalive off + watcher off = a restart
+                        # loop of the leader slot). Give-up (the task RETURNING) is
+                        # also covered fleet-wide by _wire_broadcaster_give_up; the
+                        # duplicate SIGTERM in that overlap is a harmless no-op.
+                        def _restart_if_reader_died(task):
+                            if not task.cancelled():
+                                self._graceful_shutdown()
+
                         self.broadcast_listening_context._event_broadcaster.get_reader_task().add_done_callback(
-                            lambda _: self._graceful_shutdown()
+                            _restart_if_reader_died
                         )
                     # No done-callback for the scopes reason: the context exists
                     # for scopes only on a ReconnectingBroadcaster (see __init__),

--- a/packages/opal-server/opal_server/server.py
+++ b/packages/opal-server/opal_server/server.py
@@ -34,6 +34,7 @@ from opal_server.policy.bundles.api import router as bundles_router
 from opal_server.policy.watcher.factory import setup_watcher_task
 from opal_server.policy.watcher.task import PolicyWatcherTask
 from opal_server.policy.webhook.api import init_git_webhook_router
+from opal_server.metrics_setup import configure_server_metrics
 from opal_server.publisher import setup_broadcaster_keepalive_task
 from opal_server.pubsub import PubSub
 from opal_server.pubsub_resilience import ReconnectingBroadcaster
@@ -242,12 +243,7 @@ class OpalServer:
 
         apm.configure_apm(opal_server_config.ENABLE_DATADOG_APM, "opal-server")
 
-        metrics.configure_metrics(
-            enable_metrics=opal_common_config.ENABLE_METRICS,
-            statsd_host=os.environ.get("DD_AGENT_HOST", "localhost"),
-            statsd_port=8125,
-            namespace="opal",
-        )
+        configure_server_metrics()
 
     def _configure_api_routes(self, app: FastAPI):
         """Mounts the api routes on the app object."""

--- a/packages/opal-server/opal_server/server.py
+++ b/packages/opal-server/opal_server/server.py
@@ -179,13 +179,25 @@ class OpalServer:
         else:
             self.opal_statistics = None
 
-        # if stats are enabled, the server workers must be listening on the broadcast
-        # channel for their own synchronization, not just for their clients. therefore
-        # we need a "global" listening context
+        # A worker's backbone READER (EventBroadcaster listening context) is
+        # otherwise only entered while a WebSocket client is connected to that
+        # worker: server-side subscriptions on a worker with zero clients hear
+        # nothing from the fleet. Two features need every worker listening for
+        # its own sake, not its clients':
+        #   - statistics: workers synchronise their own view over the backbone
+        #   - scopes: the fleet purge broadcast (scopes/purge.py) must reach
+        #     EVERY worker so it drops its GitPolicyFetcher caches for a
+        #     deleted/repointed source. Measured on staging (~23 WS conns over
+        #     16 workers): 5 of 8 workers per pod never received a single purge
+        #     and kept stale repo_locks entries for the life of the process.
+        # So the "global" listening context is held whenever either is on and a
+        # broadcaster exists (single-process deployments have nothing to read).
         self.broadcast_listening_context: Optional[
             EventBroadcasterContextManager
         ] = None
-        if self.broadcaster_uri is not None and opal_common_config.STATISTICS_ENABLED:
+        if self.broadcaster_uri is not None and (
+            opal_common_config.STATISTICS_ENABLED or opal_server_config.SCOPES
+        ):
             self.broadcast_listening_context = (
                 self.pubsub.endpoint.broadcaster.get_listening_context()
             )
@@ -398,16 +410,26 @@ class OpalServer:
         """
         if self.publisher is not None:
             async with self.publisher:
-                if self.opal_statistics is not None:
-                    if self.broadcast_listening_context is not None:
-                        logger.info(
-                            "listening on broadcast channel for statistics events..."
-                        )
-                        await self.broadcast_listening_context.__aenter__()
+                if self.broadcast_listening_context is not None:
+                    # Entered ONCE per worker, whatever the reason(s) it exists for
+                    # (statistics and/or scopes — see __init__). Entering it twice
+                    # would double the listener count and leak a reader on exit.
+                    logger.info(
+                        "listening on the broadcast channel on this worker "
+                        "(statistics={stats}, scopes={scopes})",
+                        stats=self.opal_statistics is not None,
+                        scopes=bool(opal_server_config.SCOPES),
+                    )
+                    await self.broadcast_listening_context.__aenter__()
+                    if self.opal_statistics is not None:
                         # if the broadcast channel is closed, we want to restart worker process because statistics can't be reliable anymore
                         self.broadcast_listening_context._event_broadcaster.get_reader_task().add_done_callback(
                             lambda _: self._graceful_shutdown()
                         )
+                    # For scopes-only workers a reader that gives up is handled by
+                    # _wire_broadcaster_give_up (graceful restart on give-up,
+                    # never on clean cancellation), so no done-callback here.
+                if self.opal_statistics is not None:
                     asyncio.create_task(self.opal_statistics.run())
                     self.pubsub.endpoint.notifier.register_unsubscribe_event(
                         self.opal_statistics.remove_client
@@ -454,13 +476,10 @@ class OpalServer:
                             # Worker should restart when watcher stops
                             self._graceful_shutdown()
 
-                if (
-                    self.opal_statistics is not None
-                    and self.broadcast_listening_context is not None
-                ):
+                if self.broadcast_listening_context is not None:
                     await self.broadcast_listening_context.__aexit__()
                     logger.info(
-                        "stopped listening for statistics events on the broadcast channel"
+                        "stopped listening on the broadcast channel on this worker"
                     )
 
     async def stop_server_background_tasks(self):

--- a/packages/opal-server/opal_server/tests/preload_metrics_namespace_test.py
+++ b/packages/opal-server/opal_server/tests/preload_metrics_namespace_test.py
@@ -1,0 +1,87 @@
+"""P1 (PR3 fixes): metrics emitted by the gunicorn MASTER during the pre-fork
+scope preload must carry the same ``permit.opal`` namespace as the workers'.
+
+Observed after the 0.9.9-rc.2 staging rollout: ``opal_server.scopes.count`` /
+``opal_server.scopes.git_ops_in_flight{pid:<master>}`` next to the workers'
+``permit.opal.opal_server.scopes.*`` — the master never configured the
+DogStatsD client, so its gauges went out bare and no dashboard/monitor built on
+the namespaced names could see the boot phase.
+"""
+import datadog
+import pytest
+from opal_common.config import opal_common_config
+from opal_common.monitoring import metrics
+from opal_server import metrics_setup
+from opal_server.scopes import task as task_module
+from opal_server.config import opal_server_config
+
+
+@pytest.fixture
+def statsd_reset(monkeypatch):
+    """Isolate the process-wide client: fresh namespace before, restore after."""
+    saved_ns = datadog.statsd.namespace
+    datadog.statsd.namespace = None
+    yield
+    datadog.statsd.namespace = saved_ns
+
+
+def test_configure_server_metrics_sets_the_permit_opal_namespace(monkeypatch, statsd_reset):
+    monkeypatch.setattr(opal_common_config, "ENABLE_METRICS", True)
+    metrics_setup.configure_server_metrics()
+    assert datadog.statsd.namespace == "permit.opal"
+
+
+def test_configure_server_metrics_is_fail_silent_when_disabled(monkeypatch, statsd_reset):
+    monkeypatch.setattr(opal_common_config, "ENABLE_METRICS", False)
+    metrics_setup.configure_server_metrics()
+    assert datadog.statsd.namespace is None, "disabled metrics must not touch the client"
+
+
+def test_gauge_after_configure_is_namespaced_on_the_wire(monkeypatch, statsd_reset):
+    """The property the dashboards depend on: the serialized packet name."""
+    monkeypatch.setattr(opal_common_config, "ENABLE_METRICS", True)
+    metrics_setup.configure_server_metrics()
+    payloads = []
+    orig = datadog.statsd._serialize_metric
+
+    def record(*a, **k):
+        p = orig(*a, **k)
+        payloads.append(p)
+        return p
+
+    monkeypatch.setattr(datadog.statsd, "_serialize_metric", record)
+    monkeypatch.setattr(datadog.statsd, "_send_to_server", lambda payload: None)
+    monkeypatch.setattr(datadog.statsd, "_send_to_buffer", lambda payload: None)
+    datadog.statsd.disable_aggregation()
+    metrics.gauge("opal_server.scopes.count", 593)
+    assert payloads and payloads[-1].startswith(
+        "permit.opal.opal_server.scopes.count:593|g"
+    ), payloads
+
+
+def test_preload_configures_metrics_before_syncing(monkeypatch):
+    """The master's preload path is the one that was missing it: it must
+    configure the client BEFORE the first sync emits anything."""
+    order = []
+    monkeypatch.setattr(opal_server_config, "SCOPES", True)
+    monkeypatch.setattr(
+        task_module, "configure_server_metrics", lambda: order.append("configure")
+    )
+
+    class _FakeService:
+        def __init__(self, *a, **k):
+            pass
+
+        async def sync_scopes(self, *a, **k):
+            order.append("sync")
+
+    monkeypatch.setattr(task_module, "ScopesService", _FakeService)
+    monkeypatch.setattr(task_module, "RedisDB", lambda url: object())
+    monkeypatch.setattr(task_module, "ScopeRepository", lambda db: object())
+    monkeypatch.setattr(task_module, "drain_git_ops", lambda t: True)
+    monkeypatch.setattr(task_module, "shutdown_git_executor", lambda: None)
+    monkeypatch.setattr(task_module.GitPolicyFetcher, "reset_caches", staticmethod(lambda: None))
+
+    task_module.ScopesPolicyWatcherTask.preload_scopes()
+
+    assert order == ["configure", "sync"], order

--- a/packages/opal-server/opal_server/tests/preload_metrics_namespace_test.py
+++ b/packages/opal-server/opal_server/tests/preload_metrics_namespace_test.py
@@ -12,8 +12,8 @@ import pytest
 from opal_common.config import opal_common_config
 from opal_common.monitoring import metrics
 from opal_server import metrics_setup
-from opal_server.scopes import task as task_module
 from opal_server.config import opal_server_config
+from opal_server.scopes import task as task_module
 
 
 @pytest.fixture
@@ -25,16 +25,22 @@ def statsd_reset(monkeypatch):
     datadog.statsd.namespace = saved_ns
 
 
-def test_configure_server_metrics_sets_the_permit_opal_namespace(monkeypatch, statsd_reset):
+def test_configure_server_metrics_sets_the_permit_opal_namespace(
+    monkeypatch, statsd_reset
+):
     monkeypatch.setattr(opal_common_config, "ENABLE_METRICS", True)
     metrics_setup.configure_server_metrics()
     assert datadog.statsd.namespace == "permit.opal"
 
 
-def test_configure_server_metrics_is_fail_silent_when_disabled(monkeypatch, statsd_reset):
+def test_configure_server_metrics_is_fail_silent_when_disabled(
+    monkeypatch, statsd_reset
+):
     monkeypatch.setattr(opal_common_config, "ENABLE_METRICS", False)
     metrics_setup.configure_server_metrics()
-    assert datadog.statsd.namespace is None, "disabled metrics must not touch the client"
+    assert (
+        datadog.statsd.namespace is None
+    ), "disabled metrics must not touch the client"
 
 
 def test_gauge_after_configure_is_namespaced_on_the_wire(monkeypatch, statsd_reset):
@@ -80,7 +86,9 @@ def test_preload_configures_metrics_before_syncing(monkeypatch):
     monkeypatch.setattr(task_module, "ScopeRepository", lambda db: object())
     monkeypatch.setattr(task_module, "drain_git_ops", lambda t: True)
     monkeypatch.setattr(task_module, "shutdown_git_executor", lambda: None)
-    monkeypatch.setattr(task_module.GitPolicyFetcher, "reset_caches", staticmethod(lambda: None))
+    monkeypatch.setattr(
+        task_module.GitPolicyFetcher, "reset_caches", staticmethod(lambda: None)
+    )
 
     task_module.ScopesPolicyWatcherTask.preload_scopes()
 

--- a/packages/opal-server/opal_server/tests/preload_metrics_namespace_test.py
+++ b/packages/opal-server/opal_server/tests/preload_metrics_namespace_test.py
@@ -35,7 +35,12 @@ def statsd_reset(monkeypatch):
     client.namespace = saved["namespace"]
     client.host = saved["host"]
     client.port = saved["port"]
-    client.socket = saved["socket"]
+    # datadog.initialize() closes the previous socket; the setter probes the
+    # new one with getsockopt and a closed socket raises EBADF. A closed one
+    # is worth nothing to the next test either: leave None and let the client
+    # re-create it lazily, exactly as it does on first use.
+    sock = saved["socket"]
+    client.socket = sock if (sock is not None and sock.fileno() != -1) else None
     if saved["aggregation_disabled"] is False and client._disable_aggregation:
         client.enable_aggregation()
     elif saved["aggregation_disabled"] is True and not client._disable_aggregation:

--- a/packages/opal-server/opal_server/tests/preload_metrics_namespace_test.py
+++ b/packages/opal-server/opal_server/tests/preload_metrics_namespace_test.py
@@ -18,11 +18,28 @@ from opal_server.scopes import task as task_module
 
 @pytest.fixture
 def statsd_reset(monkeypatch):
-    """Isolate the process-wide client: fresh namespace before, restore after."""
-    saved_ns = datadog.statsd.namespace
-    datadog.statsd.namespace = None
+    """Isolate the process-wide DogStatsD client: snapshot namespace, host,
+    port, socket and the aggregation toggle before, restore all of them after
+    (configure_metrics re-initialises the global client; one test disables
+    aggregation) so no global state leaks into other tests."""
+    client = datadog.statsd
+    saved = {
+        "namespace": client.namespace,
+        "host": client.host,
+        "port": client.port,
+        "socket": client.socket,
+        "aggregation_disabled": getattr(client, "_disable_aggregation", None),
+    }
+    client.namespace = None
     yield
-    datadog.statsd.namespace = saved_ns
+    client.namespace = saved["namespace"]
+    client.host = saved["host"]
+    client.port = saved["port"]
+    client.socket = saved["socket"]
+    if saved["aggregation_disabled"] is False and client._disable_aggregation:
+        client.enable_aggregation()
+    elif saved["aggregation_disabled"] is True and not client._disable_aggregation:
+        client.disable_aggregation()
 
 
 def test_configure_server_metrics_sets_the_permit_opal_namespace(

--- a/packages/opal-server/opal_server/tests/preload_metrics_namespace_test.py
+++ b/packages/opal-server/opal_server/tests/preload_metrics_namespace_test.py
@@ -7,6 +7,8 @@ Observed after the 0.9.9-rc.2 staging rollout: ``opal_server.scopes.count`` /
 DogStatsD client, so its gauges went out bare and no dashboard/monitor built on
 the namespaced names could see the boot phase.
 """
+import asyncio
+
 import datadog
 import pytest
 from opal_common.config import opal_common_config
@@ -112,6 +114,13 @@ def test_preload_configures_metrics_before_syncing(monkeypatch):
         task_module.GitPolicyFetcher, "reset_caches", staticmethod(lambda: None)
     )
 
-    task_module.ScopesPolicyWatcherTask.preload_scopes()
+    try:
+        task_module.ScopesPolicyWatcherTask.preload_scopes()
+    finally:
+        # preload_scopes runs asyncio.run(), which unsets the main thread's
+        # event loop on exit; on Python 3.9 the next sync test that builds an
+        # asyncio primitive would raise "no current event loop". Restore one
+        # so this test never poisons whatever sorts after it.
+        asyncio.set_event_loop(asyncio.new_event_loop())
 
     assert order == ["configure", "sync"], order

--- a/packages/opal-server/opal_server/tests/preload_reset_test.py
+++ b/packages/opal-server/opal_server/tests/preload_reset_test.py
@@ -18,20 +18,22 @@ from opal_server.config import opal_server_config
 
 
 @pytest.fixture(autouse=True)
-def _fresh_loop_and_stubbed_redis(monkeypatch):
-    """Two isolation guards these tests need on Python 3.9.
+def _stub_redis_layer(monkeypatch):
+    """preload_scopes() evaluates ``ScopeRepository(RedisDB(...))`` before the
+    stubbed ScopesService ever sees the arguments, so without this stub these
+    unit tests construct a REAL redis client. That is wrong in itself, and on
+    Python 3.9 it is the CI failure this fixture pins: redis.asyncio's
+    ConnectionPool builds an ``asyncio.Lock()`` in ``__init__``, which on 3.9
+    (and only 3.9) calls ``get_event_loop()`` — and an earlier test's
+    ``asyncio.run()`` (e.g. preload_metrics_namespace_test.py, which sorts
+    right before this file) leaves the main thread with no current loop.
 
-    An earlier test's asyncio.run() (e.g. the preload call in
-    preload_metrics_namespace_test.py, which sorts right before this file)
-    leaves the main thread with NO current event loop. preload_scopes()
-    evaluates ``ScopeRepository(RedisDB(...))`` before the stubbed
-    ScopesService ever sees the arguments, and redis.asyncio's
-    ConnectionPool builds an ``asyncio.Lock()`` in ``__init__`` — which on
-    3.9 (and only 3.9) calls ``get_event_loop()`` and raises "no current
-    event loop". Give every test a fresh loop AND stub the redis layer: a
-    unit test of preload wiring must not construct a real redis client.
+    NOTE this stub is load-bearing ONLY on 3.9: on 3.10+ asyncio
+    primitives don't grab a loop at construction, so removing it keeps
+    3.10+ green and breaks the 3.9 CI matrix job. The sibling file stubs
+    RedisDB per-test in its arrange instead — same mechanism, applied
+    where each file needs it.
     """
-    asyncio.set_event_loop(asyncio.new_event_loop())
     monkeypatch.setattr(task_module, "RedisDB", lambda url: object())
     monkeypatch.setattr(task_module, "ScopeRepository", lambda db: object())
     yield

--- a/packages/opal-server/opal_server/tests/preload_reset_test.py
+++ b/packages/opal-server/opal_server/tests/preload_reset_test.py
@@ -13,7 +13,28 @@ stay) empty.
 import asyncio
 
 import opal_server.scopes.task as task_module
+import pytest
 from opal_server.config import opal_server_config
+
+
+@pytest.fixture(autouse=True)
+def _fresh_loop_and_stubbed_redis(monkeypatch):
+    """Two isolation guards these tests need on Python 3.9.
+
+    An earlier test's asyncio.run() (e.g. the preload call in
+    preload_metrics_namespace_test.py, which sorts right before this file)
+    leaves the main thread with NO current event loop. preload_scopes()
+    evaluates ``ScopeRepository(RedisDB(...))`` before the stubbed
+    ScopesService ever sees the arguments, and redis.asyncio's
+    ConnectionPool builds an ``asyncio.Lock()`` in ``__init__`` — which on
+    3.9 (and only 3.9) calls ``get_event_loop()`` and raises "no current
+    event loop". Give every test a fresh loop AND stub the redis layer: a
+    unit test of preload wiring must not construct a real redis client.
+    """
+    asyncio.set_event_loop(asyncio.new_event_loop())
+    monkeypatch.setattr(task_module, "RedisDB", lambda url: object())
+    monkeypatch.setattr(task_module, "ScopeRepository", lambda db: object())
+    yield
 
 
 def test_preload_scopes_resets_fetcher_caches_after_shutdown(monkeypatch):

--- a/packages/opal-server/opal_server/tests/scopes_watcher_flag_warning_test.py
+++ b/packages/opal-server/opal_server/tests/scopes_watcher_flag_warning_test.py
@@ -1,10 +1,11 @@
 """P3 (PR3 fixes): OPAL_REPO_WATCHER_ENABLED gates the scopes sync task.
 
-The flag reads as "single-repo watcher", but in scopes mode it decides whether
-setup_watcher_task() -> ScopesPolicyWatcherTask ever runs — i.e. whether scopes
-are synced and purged at all. A fleet booted with it off registered 2160
-scopes, stayed Ready and never cloned a thing (env B bring-up, 2026-08-18).
-The server now says so loudly at startup; it does not refuse to boot.
+The flag reads as "single-repo watcher", but in scopes mode it decides
+whether setup_watcher_task() -> ScopesPolicyWatcherTask ever runs — i.e.
+whether scopes are synced and purged at all. A fleet booted with it off
+registered 2160 scopes, stayed Ready and never cloned a thing (env B
+bring-up, 2026-08-18). The server now says so loudly at startup; it does
+not refuse to boot.
 """
 import pytest
 from opal_server import server as server_module
@@ -23,10 +24,20 @@ class _RecordingLogger:
     def _rec(self, level):
         def _log(msg, *a, **k):
             self.calls.append((level, str(msg)))
+
         return _log
 
     def __getattr__(self, name):
-        if name in ("info", "warning", "error", "debug", "exception", "critical", "success", "trace"):
+        if name in (
+            "info",
+            "warning",
+            "error",
+            "debug",
+            "exception",
+            "critical",
+            "success",
+            "trace",
+        ):
             return self._rec(name)
         raise AttributeError(name)
 
@@ -34,7 +45,9 @@ class _RecordingLogger:
 @pytest.fixture
 def scopes_on(monkeypatch):
     monkeypatch.setattr(opal_server_config, "SCOPES", True)
-    monkeypatch.setattr(opal_server_config, "REDIS_URL", "redis://localhost:6379")  # never connected
+    monkeypatch.setattr(
+        opal_server_config, "REDIS_URL", "redis://localhost:6379"
+    )  # never connected
 
 
 @pytest.fixture
@@ -55,7 +68,12 @@ def _build(watcher: bool):
 
 def test_scopes_without_the_watcher_warns_that_nothing_will_sync(scopes_on, warnings):
     _build(watcher=False)
-    hits = [m for lvl, m in warnings if lvl == "warning" and "OPAL_REPO_WATCHER_ENABLED is off while OPAL_SCOPES is on" in m]
+    hits = [
+        m
+        for lvl, m in warnings
+        if lvl == "warning"
+        and "OPAL_REPO_WATCHER_ENABLED is off while OPAL_SCOPES is on" in m
+    ]
     assert hits, warnings
     assert "never SYNC or PURGE" in hits[0]
 

--- a/packages/opal-server/opal_server/tests/scopes_watcher_flag_warning_test.py
+++ b/packages/opal-server/opal_server/tests/scopes_watcher_flag_warning_test.py
@@ -1,0 +1,78 @@
+"""P3 (PR3 fixes): OPAL_REPO_WATCHER_ENABLED gates the scopes sync task.
+
+The flag reads as "single-repo watcher", but in scopes mode it decides whether
+setup_watcher_task() -> ScopesPolicyWatcherTask ever runs — i.e. whether scopes
+are synced and purged at all. A fleet booted with it off registered 2160
+scopes, stayed Ready and never cloned a thing (env B bring-up, 2026-08-18).
+The server now says so loudly at startup; it does not refuse to boot.
+"""
+import pytest
+from opal_server import server as server_module
+from opal_server.config import opal_server_config
+from opal_server.server import OpalServer
+
+
+class _RecordingLogger:
+    """OpalServer.__init__ reconfigures loguru (removes every sink), so a sink
+    added by the test does not survive construction; record calls on the
+    module's logger reference instead."""
+
+    def __init__(self):
+        self.calls = []
+
+    def _rec(self, level):
+        def _log(msg, *a, **k):
+            self.calls.append((level, str(msg)))
+        return _log
+
+    def __getattr__(self, name):
+        if name in ("info", "warning", "error", "debug", "exception", "critical", "success", "trace"):
+            return self._rec(name)
+        raise AttributeError(name)
+
+
+@pytest.fixture
+def scopes_on(monkeypatch):
+    monkeypatch.setattr(opal_server_config, "SCOPES", True)
+    monkeypatch.setattr(opal_server_config, "REDIS_URL", "redis://localhost:6379")  # never connected
+
+
+@pytest.fixture
+def warnings(monkeypatch):
+    rec = _RecordingLogger()
+    monkeypatch.setattr(server_module, "logger", rec)
+    return rec.calls
+
+
+def _build(watcher: bool):
+    return OpalServer(
+        init_policy_watcher=watcher,
+        init_publisher=False,
+        broadcaster_uri=None,
+        enable_jwks_endpoint=False,
+    )
+
+
+def test_scopes_without_the_watcher_warns_that_nothing_will_sync(scopes_on, warnings):
+    _build(watcher=False)
+    hits = [m for lvl, m in warnings if lvl == "warning" and "OPAL_REPO_WATCHER_ENABLED is off while OPAL_SCOPES is on" in m]
+    assert hits, warnings
+    assert "never SYNC or PURGE" in hits[0]
+
+
+def test_scopes_with_the_watcher_is_quiet(scopes_on, warnings):
+    _build(watcher=True)
+    assert not [m for lvl, m in warnings if "OPAL_REPO_WATCHER_ENABLED" in m]
+
+
+def test_the_flag_description_mentions_scopes_mode():
+    """The config reference (and the generated docs) must tell an operator what
+    the flag really controls in scopes mode."""
+    from pathlib import Path
+
+    import opal_server.config as cfg
+
+    src = Path(cfg.__file__).read_text()
+    block = src[src.index('"REPO_WATCHER_ENABLED"') :]
+    block = block[: block.index("\n    )")]  # end of the confi.bool(...) call
+    assert "scopes" in block.lower() and "purge" in block.lower(), block

--- a/packages/opal-server/opal_server/tests/scopes_worker_listening_context_test.py
+++ b/packages/opal-server/opal_server/tests/scopes_worker_listening_context_test.py
@@ -16,8 +16,8 @@ import asyncio
 
 import pytest
 from opal_common.config import opal_common_config
-from opal_server.config import opal_server_config
 from opal_server import server as server_module
+from opal_server.config import opal_server_config
 from opal_server.server import OpalServer
 
 
@@ -121,7 +121,9 @@ async def _run_until_entered(server, ctx, monkeypatch, timeout=5.0):
     async def _fake_subscribe(endpoint):
         subscribed.append(endpoint)
 
-    monkeypatch.setattr(server_module, "subscribe_worker_purge_handler", _fake_subscribe)
+    monkeypatch.setattr(
+        server_module, "subscribe_worker_purge_handler", _fake_subscribe
+    )
     server.publisher = _FakePublisher()
     server.broadcast_keepalive = None
     task = asyncio.create_task(server.start_server_background_tasks())
@@ -156,7 +158,9 @@ async def test_scopes_worker_enters_the_listening_context_without_statistics(
 
     subscribed = await _run_until_entered(server, ctx, monkeypatch)
 
-    assert ctx.entered == 1, "client-less worker never started reading the backbone: fleet purges would not reach it"
+    assert (
+        ctx.entered == 1
+    ), "client-less worker never started reading the backbone: fleet purges would not reach it"
     assert subscribed, "purge handler subscription must still be registered"
 
 
@@ -173,10 +177,14 @@ async def test_scopes_and_statistics_enter_the_context_exactly_once(
 
     await _run_until_entered(server, ctx, monkeypatch)
 
-    assert ctx.entered == 1, "the context must be entered once even when both statistics and scopes want it"
+    assert (
+        ctx.entered == 1
+    ), "the context must be entered once even when both statistics and scopes want it"
 
 
 def test_no_broadcaster_means_no_listening_context(scopes_config, statistics):
     statistics(False)
     server = _build(None)
-    assert server.broadcast_listening_context is None, "single-process deployment: nothing to read from"
+    assert (
+        server.broadcast_listening_context is None
+    ), "single-process deployment: nothing to read from"

--- a/packages/opal-server/opal_server/tests/scopes_worker_listening_context_test.py
+++ b/packages/opal-server/opal_server/tests/scopes_worker_listening_context_test.py
@@ -32,29 +32,38 @@ class _FakeEventBroadcaster:
 
 
 class _FakeListeningContext:
-    """Stands in for EventBroadcasterContextManager: counts enters/exits."""
+    """Stands in for EventBroadcasterContextManager: counts enters/exits AND
+    mirrors the library's shared ``_listen_count`` — incremented in __aenter__
+    BEFORE the reader is started, decremented in __aexit__ — because that
+    ordering is what the failed-enter unwind is about."""
 
     def __init__(self):
         self.entered = 0
         self.exited = 0
+        self.listen_count = 0
         self.entered_event = asyncio.Event()
         self._event_broadcaster = _FakeEventBroadcaster()
 
     async def __aenter__(self):
+        self.listen_count += 1  # library: count first...
         self.entered += 1
         self.entered_event.set()
+        await self._start_reader()  # ...then start the reader (may raise)
         return self
 
+    async def _start_reader(self):
+        pass
+
     async def __aexit__(self, exc_type, exc, tb):  # STRICT arity, like the real one
+        self.listen_count -= 1
         self.exited += 1
 
 
 class _RaisingListeningContext(_FakeListeningContext):
-    """The eager-connect failure of the legacy broadcaster: __aenter__ raises."""
+    """The eager-connect failure of the legacy broadcaster: the reader start
+    inside __aenter__ raises — AFTER the shared count was incremented."""
 
-    async def __aenter__(self):
-        self.entered += 1
-        self.entered_event.set()
+    async def _start_reader(self):
         raise ConnectionRefusedError("backbone down at boot")
 
 
@@ -84,10 +93,10 @@ class _GrantingLock:
     """A leadership lock that grants immediately: the worker under test becomes
     the leader, runs the (stubbed) leader block and reaches the exit path."""
 
+    acquired = 0
+
     def __init__(self, *a, **k):
         _GrantingLock.acquired += 1
-
-    acquired = 0
 
     async def __aenter__(self):
         return self
@@ -309,4 +318,81 @@ async def test_a_raising_enter_is_logged_and_the_rest_of_the_background_task_sti
     assert any(
         "Could not start listening on the broadcast channel" in m for m in warnings
     ), warnings
-    assert ctx.exited == 0, "a context that failed to enter must not be exited"
+    # The real __aenter__ increments the shared listen count BEFORE it starts the
+    # reader, so a raise leaves it at 1 unless we unwind: every later client
+    # context would take it to 2, 3, ... and the reader would never start again.
+    assert ctx.exited == 1, "a failed enter must be unwound with __aexit__"
+    assert ctx.listen_count == 0, "listen count must be back to 0 after the unwind"
+
+
+def test_legacy_broadcaster_with_statistics_arms_the_context_and_stays_quiet(
+    scopes_config, statistics, monkeypatch
+):
+    """Statistics arm the context on ANY broadcaster (pre-existing behaviour),
+    and then purges are delivered too — so the "not guaranteed" INFO line must
+    not be logged in that combination."""
+    statistics(True)
+    monkeypatch.setattr(opal_server_config, "BROADCAST_RECONNECT_ENABLED", False)
+    infos = []
+    monkeypatch.setattr(
+        server_module.logger, "info", lambda msg, *a, **k: infos.append(str(msg))
+    )
+    server = _build("postgres://localhost/test")
+    assert server.broadcast_listening_context is not None
+    assert not any("BROADCAST_RECONNECT_ENABLED is off" in m for m in infos), infos
+
+
+class _FakeWatcher:
+    """A watcher whose run ends immediately: the mainline leader shape
+    (watcher stops -> _graceful_shutdown -> exit path)."""
+
+    def __init__(self, *a, **k):
+        pass
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc):
+        return False
+
+    async def wait_until_should_stop(self):
+        return None
+
+
+@pytest.mark.asyncio
+async def test_exit_path_through_the_mainline_watcher_shape(
+    scopes_config, statistics, monkeypatch
+):
+    """Same invariant as the fall-through test, but through the shape prod
+    actually takes: leader runs the watcher, the watcher stops, the worker
+    asks for a graceful shutdown and the listening context is exited once."""
+    statistics(False)
+    server = _build("postgres://localhost/test")
+    ctx = _FakeListeningContext()
+    server.broadcast_listening_context = ctx
+    shutdowns = []
+    monkeypatch.setattr(server, "_graceful_shutdown", lambda: shutdowns.append(1))
+    monkeypatch.setattr(
+        server_module, "setup_watcher_task", lambda *a, **k: _FakeWatcher()
+    )
+    _GrantingLock.acquired = 0
+    monkeypatch.setattr(server_module, "NamedLock", _GrantingLock)
+
+    async def _fake_load(scopes):
+        pass
+
+    async def _fake_subscribe(endpoint):
+        pass
+
+    monkeypatch.setattr(server_module, "load_scopes", _fake_load)
+    monkeypatch.setattr(
+        server_module, "subscribe_worker_purge_handler", _fake_subscribe
+    )
+    server.publisher = _FakePublisher()
+    server.broadcast_keepalive = None
+    server._init_policy_watcher = True
+
+    await asyncio.wait_for(server.start_server_background_tasks(), 5.0)
+
+    assert shutdowns == [1], "watcher stop must request a graceful shutdown"
+    assert ctx.entered == 1 and ctx.exited == 1 and ctx.listen_count == 0

--- a/packages/opal-server/opal_server/tests/scopes_worker_listening_context_test.py
+++ b/packages/opal-server/opal_server/tests/scopes_worker_listening_context_test.py
@@ -45,8 +45,17 @@ class _FakeListeningContext:
         self.entered_event.set()
         return self
 
-    async def __aexit__(self, *exc):
+    async def __aexit__(self, exc_type, exc, tb):  # STRICT arity, like the real one
         self.exited += 1
+
+
+class _RaisingListeningContext(_FakeListeningContext):
+    """The eager-connect failure of the legacy broadcaster: __aenter__ raises."""
+
+    async def __aenter__(self):
+        self.entered += 1
+        self.entered_event.set()
+        raise ConnectionRefusedError("backbone down at boot")
 
 
 class _FakePublisher:
@@ -66,6 +75,22 @@ class _BlockingLock:
 
     async def __aenter__(self):
         await asyncio.Event().wait()  # block until cancelled
+
+    async def __aexit__(self, *exc):
+        return False
+
+
+class _GrantingLock:
+    """A leadership lock that grants immediately: the worker under test becomes
+    the leader, runs the (stubbed) leader block and reaches the exit path."""
+
+    def __init__(self, *a, **k):
+        _GrantingLock.acquired += 1
+
+    acquired = 0
+
+    async def __aenter__(self):
+        return self
 
     async def __aexit__(self, *exc):
         return False
@@ -140,6 +165,32 @@ async def _run_until_entered(server, ctx, monkeypatch, timeout=5.0):
     return subscribed
 
 
+async def _run_to_completion(server, monkeypatch, timeout=5.0):
+    """Drive start_server_background_tasks on a worker that WINS leadership,
+    with no keepalive and no watcher, so the whole background task returns and
+    the exit path (listening-context __aexit__) actually executes."""
+    _GrantingLock.acquired = 0
+    monkeypatch.setattr(server_module, "NamedLock", _GrantingLock)
+
+    async def _fake_load(scopes):
+        pass
+
+    monkeypatch.setattr(server_module, "load_scopes", _fake_load)
+    subscribed = []
+
+    async def _fake_subscribe(endpoint):
+        subscribed.append(endpoint)
+
+    monkeypatch.setattr(
+        server_module, "subscribe_worker_purge_handler", _fake_subscribe
+    )
+    server.publisher = _FakePublisher()
+    server.broadcast_keepalive = None
+    server._init_policy_watcher = False
+    await asyncio.wait_for(server.start_server_background_tasks(), timeout)
+    return subscribed
+
+
 async def _never_called(*a, **k):
     raise AssertionError("load_scopes is leader-only and this worker is not the leader")
 
@@ -188,3 +239,74 @@ def test_no_broadcaster_means_no_listening_context(scopes_config, statistics):
     assert (
         server.broadcast_listening_context is None
     ), "single-process deployment: nothing to read from"
+
+
+@pytest.mark.asyncio
+async def test_exit_path_leaves_the_listening_context_with_the_right_arity(
+    scopes_config, statistics, monkeypatch
+):
+    """The real EventBroadcasterContextManager.__aexit__(exc_type, exc, tb) has
+    no defaults: a zero-arg call raises TypeError inside the un-awaited
+    background task, leaving _listen_count at 1 and the reader never
+    cancelled — on every scopes LEADER whose watcher stops. The double is
+    strict about arity so this cannot regress silently."""
+    statistics(False)
+    server = _build("postgres://localhost/test")
+    ctx = _FakeListeningContext()
+    server.broadcast_listening_context = ctx
+
+    await _run_to_completion(server, monkeypatch)
+
+    assert ctx.entered == 1 and ctx.exited == 1, (ctx.entered, ctx.exited)
+
+
+def test_legacy_broadcaster_does_not_get_a_scopes_reader(
+    scopes_config, statistics, monkeypatch
+):
+    """BROADCAST_RECONNECT_ENABLED=false builds the legacy EventBroadcaster,
+    whose reader connects EAGERLY in __aenter__ and re-raises: with the
+    backbone down at boot that would abort the background task before the
+    purge subscription and the leadership lock. The scopes reason therefore
+    applies only to the ReconnectingBroadcaster."""
+    statistics(False)
+    monkeypatch.setattr(opal_server_config, "BROADCAST_RECONNECT_ENABLED", False)
+    infos = []
+    monkeypatch.setattr(
+        server_module.logger, "info", lambda msg, *a, **k: infos.append(str(msg))
+    )
+    server = _build("postgres://localhost/test")
+    assert not isinstance(
+        server.pubsub.broadcaster, server_module.ReconnectingBroadcaster
+    )
+    assert server.broadcast_listening_context is None
+    assert any("BROADCAST_RECONNECT_ENABLED is off" in m for m in infos), infos
+
+
+@pytest.mark.asyncio
+async def test_a_raising_enter_is_logged_and_the_rest_of_the_background_task_still_runs(
+    scopes_config, statistics, monkeypatch
+):
+    """Belt and braces: if entering the context raises anyway, the worker must
+    still subscribe the purge handler and take the leadership lock; the failure
+    is one WARNING and the context is dropped (so exit does not touch it)."""
+    statistics(False)
+    server = _build("postgres://localhost/test")
+    ctx = _RaisingListeningContext()
+    server.broadcast_listening_context = ctx
+    warnings = []
+    monkeypatch.setattr(
+        server_module.logger, "warning", lambda msg, *a, **k: warnings.append(str(msg))
+    )
+
+    subscribed = await _run_to_completion(server, monkeypatch)
+
+    assert ctx.entered == 1
+    assert subscribed, "purge subscription must still happen after a failed enter"
+    assert (
+        _GrantingLock.acquired == 1
+    ), "leadership must still be attempted after a failed enter"
+    assert server.broadcast_listening_context is None
+    assert any(
+        "Could not start listening on the broadcast channel" in m for m in warnings
+    ), warnings
+    assert ctx.exited == 0, "a context that failed to enter must not be exited"

--- a/packages/opal-server/opal_server/tests/scopes_worker_listening_context_test.py
+++ b/packages/opal-server/opal_server/tests/scopes_worker_listening_context_test.py
@@ -22,13 +22,38 @@ from opal_server.server import OpalServer
 
 
 class _FakeReaderTask:
+    """Stable stand-in for the reader asyncio.Task.
+
+    STABLE matters: the real
+    ``get_reader_task()`` returns the same task on every call, so a done
+    callback attached to it can actually fire — an earlier double returned a
+    fresh object per call, which made every callback assertion vacuous.
+    """
+
+    def __init__(self):
+        self.callbacks = []
+        self._cancelled = False
+
     def add_done_callback(self, cb):
-        self.cb = cb
+        self.callbacks.append(cb)
+
+    def cancelled(self):
+        return self._cancelled
+
+    def complete(self, cancelled):
+        """Finish the task the way asyncio would: mark the state, then run
+        the done callbacks with the task as the argument."""
+        self._cancelled = cancelled
+        for cb in list(self.callbacks):
+            cb(self)
 
 
 class _FakeEventBroadcaster:
+    def __init__(self):
+        self.reader_task = _FakeReaderTask()
+
     def get_reader_task(self):
-        return _FakeReaderTask()
+        return self.reader_task
 
 
 class _FakeListeningContext:
@@ -57,6 +82,9 @@ class _FakeListeningContext:
     async def __aexit__(self, exc_type, exc, tb):  # STRICT arity, like the real one
         self.listen_count -= 1
         self.exited += 1
+        if self.listen_count == 0:
+            # library behaviour: the last exit CANCELS the reader task
+            self._event_broadcaster.reader_task.complete(cancelled=True)
 
 
 class _RaisingListeningContext(_FakeListeningContext):
@@ -396,3 +424,101 @@ async def test_exit_path_through_the_mainline_watcher_shape(
 
     assert shutdowns == [1], "watcher stop must request a graceful shutdown"
     assert ctx.entered == 1 and ctx.exited == 1 and ctx.listen_count == 0
+
+
+def test_no_context_without_scopes_even_on_a_reconnecting_broadcaster(
+    scopes_config, statistics, monkeypatch
+):
+    """Pins the SCOPES half of the arming gate (P5's blast radius): an ordinary
+    SCOPES=False server with a reconnecting broadcaster and statistics off must
+    NOT gain a permanent backbone reader.
+
+    Dropping the
+    ``SCOPES`` condition from ``wants_reader_for_scopes`` fails here.
+    """
+    statistics(False)
+    monkeypatch.setattr(opal_server_config, "SCOPES", False)
+    server = _build("postgres://localhost/test")
+    assert server.broadcast_listening_context is None, (
+        "SCOPES=False must not arm the listening context: widening P5 to every "
+        "broadcaster deployment would give non-scopes servers a reader (and a "
+        "10-connection pool at boot) they have no purge handler to feed"
+    )
+
+
+@pytest.mark.asyncio
+async def test_statistics_off_attaches_no_reader_done_callback(
+    scopes_config, statistics, monkeypatch
+):
+    """Pins the ``opal_statistics is not None`` guard on the restart
+    callback: a scopes-only worker must not restart itself over reader
+    completion (give-up is _wire_broadcaster_give_up's job)."""
+    statistics(False)
+    server = _build("postgres://localhost/test")
+    ctx = _FakeListeningContext()
+    server.broadcast_listening_context = ctx
+    server.opal_statistics = None
+
+    await _run_until_entered(server, ctx, monkeypatch)
+
+    assert (
+        ctx._event_broadcaster.reader_task.callbacks == []
+    ), "with statistics off no done-callback may be attached to the reader"
+
+
+@pytest.mark.asyncio
+async def test_clean_exit_with_statistics_does_not_restart_the_worker(
+    scopes_config, statistics, monkeypatch
+):
+    """The arity fix makes __aexit__ actually cancel the reader on the way out.
+
+    With statistics on, the restart callback must NOT fire on that clean
+    cancellation — on master it never did (the zero-arg __aexit__ raised
+    first), so firing would be a new self-SIGTERM: a boot restart loop
+    of the leader slot under statistics on + keepalive off + watcher
+    off.
+    """
+    statistics(True)
+    server = _build("postgres://localhost/test")
+    ctx = _FakeListeningContext()
+    server.broadcast_listening_context = ctx
+    server.opal_statistics = _FakeStatistics()
+    shutdowns = []
+    monkeypatch.setattr(server, "_graceful_shutdown", lambda: shutdowns.append(1))
+
+    await _run_to_completion(server, monkeypatch)
+
+    assert ctx.exited == 1, "the exit path must leave the context"
+    assert (
+        ctx._event_broadcaster.reader_task.cancelled()
+    ), "the last __aexit__ cancels the reader (library behaviour the double mirrors)"
+    assert (
+        shutdowns == []
+    ), "clean cancellation on the exit path must not trigger a worker restart"
+
+
+@pytest.mark.asyncio
+async def test_reader_death_with_statistics_still_restarts_the_worker(
+    scopes_config, statistics, monkeypatch
+):
+    """The counterpart guard-rail: when the reader task completes WITHOUT
+    being cancelled (backbone died / gave up), statistics are no longer
+    reliable and the worker must restart — the pre-existing behaviour the
+    cancellation guard must not lose."""
+    statistics(True)
+    server = _build("postgres://localhost/test")
+    ctx = _FakeListeningContext()
+    server.broadcast_listening_context = ctx
+    server.opal_statistics = _FakeStatistics()
+    shutdowns = []
+    monkeypatch.setattr(server, "_graceful_shutdown", lambda: shutdowns.append(1))
+
+    await _run_until_entered(server, ctx, monkeypatch)
+    assert (
+        ctx._event_broadcaster.reader_task.callbacks
+    ), "with statistics on, the restart callback must be attached"
+    ctx._event_broadcaster.reader_task.complete(cancelled=False)
+
+    assert shutdowns == [
+        1
+    ], "a reader that died (not cancelled) must still restart the worker"

--- a/packages/opal-server/opal_server/tests/scopes_worker_listening_context_test.py
+++ b/packages/opal-server/opal_server/tests/scopes_worker_listening_context_test.py
@@ -1,0 +1,182 @@
+"""P5 (PR3 fixes): every worker must READ the backbone when scopes are on.
+
+The fleet purge (scopes/purge.py) is delivered over the broadcast channel, but a
+worker's EventBroadcaster reader is only started while that worker has a
+WebSocket client (or by the statistics path, which is off in every Permit env).
+So the confirmed purge never reached client-less workers and they kept stale
+GitPolicyFetcher caches for the life of the process (staging, 2026-08-18: 5 of
+8 workers per pod never purged once). These tests pin the wiring:
+
+  * SCOPES on, STATISTICS off, broadcaster configured -> the worker enters the
+    global listening context exactly once (before it blocks on leadership);
+  * SCOPES on AND STATISTICS on -> still exactly once (no double-enter);
+  * no broadcaster (single process) -> no context at all.
+"""
+import asyncio
+
+import pytest
+from opal_common.config import opal_common_config
+from opal_server.config import opal_server_config
+from opal_server import server as server_module
+from opal_server.server import OpalServer
+
+
+class _FakeReaderTask:
+    def add_done_callback(self, cb):
+        self.cb = cb
+
+
+class _FakeEventBroadcaster:
+    def get_reader_task(self):
+        return _FakeReaderTask()
+
+
+class _FakeListeningContext:
+    """Stands in for EventBroadcasterContextManager: counts enters/exits."""
+
+    def __init__(self):
+        self.entered = 0
+        self.exited = 0
+        self.entered_event = asyncio.Event()
+        self._event_broadcaster = _FakeEventBroadcaster()
+
+    async def __aenter__(self):
+        self.entered += 1
+        self.entered_event.set()
+        return self
+
+    async def __aexit__(self, *exc):
+        self.exited += 1
+
+
+class _FakePublisher:
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc):
+        return False
+
+
+class _BlockingLock:
+    """A leadership lock that never grants: the worker under test is a NON-leader
+    (the case that matters — leaders always listen for their own reasons)."""
+
+    def __init__(self, *a, **k):
+        pass
+
+    async def __aenter__(self):
+        await asyncio.Event().wait()  # block until cancelled
+
+    async def __aexit__(self, *exc):
+        return False
+
+
+class _FakeStatistics:
+    async def run(self):
+        await asyncio.Event().wait()
+
+    def remove_client(self, *a, **k):
+        pass
+
+
+@pytest.fixture
+def scopes_config(monkeypatch, tmp_path):
+    saved = {
+        "SCOPES": opal_server_config.SCOPES,
+        "REDIS_URL": opal_server_config.REDIS_URL,
+        "LEADER_LOCK_FILE_PATH": opal_server_config.LEADER_LOCK_FILE_PATH,
+    }
+    opal_server_config.SCOPES = True
+    opal_server_config.REDIS_URL = "redis://localhost:6379"  # never connected
+    opal_server_config.LEADER_LOCK_FILE_PATH = str(tmp_path / "leader.lock")
+    yield
+    for key, value in saved.items():
+        setattr(opal_server_config, key, value)
+
+
+@pytest.fixture
+def statistics(monkeypatch):
+    def _set(enabled: bool):
+        monkeypatch.setattr(opal_common_config, "STATISTICS_ENABLED", enabled)
+
+    return _set
+
+
+def _build(broadcaster_uri):
+    return OpalServer(
+        init_policy_watcher=False,
+        init_publisher=False,  # replaced by a fake below; a real one would publish
+        broadcaster_uri=broadcaster_uri,
+        enable_jwks_endpoint=False,
+    )
+
+
+async def _run_until_entered(server, ctx, monkeypatch, timeout=5.0):
+    """Drive start_server_background_tasks on a non-leader worker until the
+    listening context is entered (or the timeout), then cancel it."""
+    monkeypatch.setattr(server_module, "NamedLock", _BlockingLock)
+    monkeypatch.setattr(server_module, "load_scopes", _never_called)
+    subscribed = []
+
+    async def _fake_subscribe(endpoint):
+        subscribed.append(endpoint)
+
+    monkeypatch.setattr(server_module, "subscribe_worker_purge_handler", _fake_subscribe)
+    server.publisher = _FakePublisher()
+    server.broadcast_keepalive = None
+    task = asyncio.create_task(server.start_server_background_tasks())
+    try:
+        await asyncio.wait_for(ctx.entered_event.wait(), timeout)
+    except asyncio.TimeoutError:
+        pass
+    finally:
+        task.cancel()
+        try:
+            await task
+        except (asyncio.CancelledError, Exception):
+            pass
+    return subscribed
+
+
+async def _never_called(*a, **k):
+    raise AssertionError("load_scopes is leader-only and this worker is not the leader")
+
+
+@pytest.mark.asyncio
+async def test_scopes_worker_enters_the_listening_context_without_statistics(
+    scopes_config, statistics, monkeypatch
+):
+    statistics(False)
+    server = _build("postgres://localhost/test")
+    assert (
+        server.broadcast_listening_context is not None
+    ), "with SCOPES on and a broadcaster, every worker must hold the global listening context"
+    ctx = _FakeListeningContext()
+    server.broadcast_listening_context = ctx
+
+    subscribed = await _run_until_entered(server, ctx, monkeypatch)
+
+    assert ctx.entered == 1, "client-less worker never started reading the backbone: fleet purges would not reach it"
+    assert subscribed, "purge handler subscription must still be registered"
+
+
+@pytest.mark.asyncio
+async def test_scopes_and_statistics_enter_the_context_exactly_once(
+    scopes_config, statistics, monkeypatch
+):
+    statistics(True)
+    server = _build("postgres://localhost/test")
+    assert server.broadcast_listening_context is not None
+    ctx = _FakeListeningContext()
+    server.broadcast_listening_context = ctx
+    server.opal_statistics = _FakeStatistics()
+
+    await _run_until_entered(server, ctx, monkeypatch)
+
+    assert ctx.entered == 1, "the context must be entered once even when both statistics and scopes want it"
+
+
+def test_no_broadcaster_means_no_listening_context(scopes_config, statistics):
+    statistics(False)
+    server = _build(None)
+    assert server.broadcast_listening_context is None, "single-process deployment: nothing to read from"

--- a/packages/opal-server/opal_server/tests/sync_failure_log_volume_test.py
+++ b/packages/opal-server/opal_server/tests/sync_failure_log_volume_test.py
@@ -79,45 +79,64 @@ def _errors(records):
 
 
 def _debug_tracebacks(records):
-    return [r for r in records if r["level"].name == "DEBUG" and r["exception"] is not None]
+    return [
+        r for r in records if r["level"].name == "DEBUG" and r["exception"] is not None
+    ]
 
 
 @pytest.mark.asyncio
-async def test_failed_sync_logs_one_error_line_without_a_traceback(monkeypatch, tmp_path, captured_logs):
+async def test_failed_sync_logs_one_error_line_without_a_traceback(
+    monkeypatch, tmp_path, captured_logs
+):
     monkeypatch.setattr(service_module, "GitPolicyFetcher", _ExplodingFetcher)
     service = ScopesService(
-        base_dir=Path(tmp_path), scopes=FakeScopeRepository([_scope("gitops-http401-0")]), pubsub_endpoint=None
+        base_dir=Path(tmp_path),
+        scopes=FakeScopeRepository([_scope("gitops-http401-0")]),
+        pubsub_endpoint=None,
     )
 
     await service.sync_scope(scope_id="gitops-http401-0", notify_on_changes=False)
     await service.sync_scope(scope_id="gitops-http401-0", notify_on_changes=False)
 
     errors = _errors(captured_logs)
-    assert len(errors) == 2, [r["message"] for r in captured_logs]  # one per failed sync, nothing extra
+    assert len(errors) == 2, [
+        r["message"] for r in captured_logs
+    ]  # one per failed sync, nothing extra
     for r in errors:
         msg = r["message"]
         assert "gitops-http401-0" in msg and "broken.invalid" in msg, msg
         assert "ValueError" in msg and "invalid credential type" in msg, msg
         # The traceback is NOT on the ERROR record...
-        assert r["exception"] is None, "ERROR record carries a traceback again — the log firehose is back"
+        assert (
+            r["exception"] is None
+        ), "ERROR record carries a traceback again — the log firehose is back"
     # ...it is available at DEBUG for anyone chasing that source.
     tb = _debug_tracebacks(captured_logs)
-    assert len(tb) == 2 and all("gitops-http401-0" in r["message"] for r in tb), [r["message"] for r in tb]
+    assert len(tb) == 2 and all("gitops-http401-0" in r["message"] for r in tb), [
+        r["message"] for r in tb
+    ]
 
 
 @pytest.mark.asyncio
-async def test_sync_scopes_pass_wrapper_also_stays_traceback_free(monkeypatch, tmp_path, captured_logs):
+async def test_sync_scopes_pass_wrapper_also_stays_traceback_free(
+    monkeypatch, tmp_path, captured_logs
+):
     """The per-pass wrapper (_sync_one) catches anything sync_scope lets
     escape; make it explode there and check the same rule holds."""
+
     async def _boom(self, *a, **k):
         raise RuntimeError("store hiccup")
 
     monkeypatch.setattr(ScopesService, "sync_scope", _boom)
     service = ScopesService(
-        base_dir=Path(tmp_path), scopes=FakeScopeRepository([_scope("s1"), _scope("s2")]), pubsub_endpoint=None
+        base_dir=Path(tmp_path),
+        scopes=FakeScopeRepository([_scope("s1"), _scope("s2")]),
+        pubsub_endpoint=None,
     )
     await service.sync_scopes(notify_on_changes=False)
     errors = _errors(captured_logs)
-    assert len(errors) == 2 and all("RuntimeError: store hiccup" in r["message"] for r in errors), [r["message"] for r in captured_logs]
+    assert len(errors) == 2 and all(
+        "RuntimeError: store hiccup" in r["message"] for r in errors
+    ), [r["message"] for r in captured_logs]
     assert all(r["exception"] is None for r in errors)
     assert len(_debug_tracebacks(captured_logs)) == 2, "one DEBUG traceback per failure"

--- a/packages/opal-server/opal_server/tests/sync_failure_log_volume_test.py
+++ b/packages/opal-server/opal_server/tests/sync_failure_log_volume_test.py
@@ -1,0 +1,123 @@
+"""P6 (PR3 fixes): a failed scope sync is ONE error line, not a traceback.
+
+With dozens of broken sources every pass logged
+``Could not fetch policy for scope ...`` WITH a ~40-line traceback per source:
+the container log rotated (10 MiB) within minutes of a boot and the boot
+markers were gone; in prod the same mechanism made opal-server the largest log
+producer in the org. The rule now: ERROR names the scope, remote and reason
+without a traceback; the traceback is emitted at DEBUG only.
+"""
+import asyncio
+from pathlib import Path
+
+import pytest
+from loguru import logger
+from opal_common.schemas.policy_source import GitPolicyScopeSource, NoAuthData
+from opal_common.schemas.scopes import Scope
+from opal_server.scopes import service as service_module
+from opal_server.scopes.scope_repository import ScopeNotFoundError
+from opal_server.scopes.service import ScopesService
+
+
+class FakeScopeRepository:
+    def __init__(self, scopes):
+        self._scopes = {s.scope_id: s for s in scopes}
+
+    async def get(self, scope_id):
+        await asyncio.sleep(0)
+        if scope_id not in self._scopes:
+            raise ScopeNotFoundError(scope_id)
+        return self._scopes[scope_id]
+
+    async def all(self):
+        await asyncio.sleep(0)
+        return list(self._scopes.values())
+
+
+class _ExplodingFetcher:
+    """Stands in for GitPolicyFetcher: the sync raises the way a broken remote
+    with a bad credential type does (an exception the clone path does not
+    swallow itself)."""
+
+    calls = 0
+
+    def __init__(self, *a, **k):
+        pass
+
+    @staticmethod
+    def source_id(source):
+        return "src-1"
+
+    async def fetch_and_notify_on_changes(self, **kwargs):
+        _ExplodingFetcher.calls += 1
+        raise ValueError("invalid credential type")
+
+
+def _scope(scope_id, url="http://broken.invalid/repo.git"):
+    return Scope(
+        scope_id=scope_id,
+        policy=GitPolicyScopeSource(
+            source_type="git", url=url, branch="main", auth=NoAuthData(auth_type="none")
+        ),
+        data={"entries": []},
+    )
+
+
+@pytest.fixture
+def captured_logs():
+    """Capture loguru RECORDS at DEBUG: each carries its level, message and
+    whether an exception (traceback) is attached — which is exactly the
+    property under test, and one that a text sink cannot attribute reliably."""
+    records = []
+    sink_id = logger.add(lambda m: records.append(m.record), level="DEBUG")
+    yield records
+    logger.remove(sink_id)
+
+
+def _errors(records):
+    return [r for r in records if r["level"].name == "ERROR"]
+
+
+def _debug_tracebacks(records):
+    return [r for r in records if r["level"].name == "DEBUG" and r["exception"] is not None]
+
+
+@pytest.mark.asyncio
+async def test_failed_sync_logs_one_error_line_without_a_traceback(monkeypatch, tmp_path, captured_logs):
+    monkeypatch.setattr(service_module, "GitPolicyFetcher", _ExplodingFetcher)
+    service = ScopesService(
+        base_dir=Path(tmp_path), scopes=FakeScopeRepository([_scope("gitops-http401-0")]), pubsub_endpoint=None
+    )
+
+    await service.sync_scope(scope_id="gitops-http401-0", notify_on_changes=False)
+    await service.sync_scope(scope_id="gitops-http401-0", notify_on_changes=False)
+
+    errors = _errors(captured_logs)
+    assert len(errors) == 2, [r["message"] for r in captured_logs]  # one per failed sync, nothing extra
+    for r in errors:
+        msg = r["message"]
+        assert "gitops-http401-0" in msg and "broken.invalid" in msg, msg
+        assert "ValueError" in msg and "invalid credential type" in msg, msg
+        # The traceback is NOT on the ERROR record...
+        assert r["exception"] is None, "ERROR record carries a traceback again — the log firehose is back"
+    # ...it is available at DEBUG for anyone chasing that source.
+    tb = _debug_tracebacks(captured_logs)
+    assert len(tb) == 2 and all("gitops-http401-0" in r["message"] for r in tb), [r["message"] for r in tb]
+
+
+@pytest.mark.asyncio
+async def test_sync_scopes_pass_wrapper_also_stays_traceback_free(monkeypatch, tmp_path, captured_logs):
+    """The per-pass wrapper (_sync_one) catches anything sync_scope lets
+    escape; make it explode there and check the same rule holds."""
+    async def _boom(self, *a, **k):
+        raise RuntimeError("store hiccup")
+
+    monkeypatch.setattr(ScopesService, "sync_scope", _boom)
+    service = ScopesService(
+        base_dir=Path(tmp_path), scopes=FakeScopeRepository([_scope("s1"), _scope("s2")]), pubsub_endpoint=None
+    )
+    await service.sync_scopes(notify_on_changes=False)
+    errors = _errors(captured_logs)
+    assert len(errors) == 2 and all("RuntimeError: store hiccup" in r["message"] for r in errors), [r["message"] for r in captured_logs]
+    assert all(r["exception"] is None for r in errors)
+    assert len(_debug_tracebacks(captured_logs)) == 2, "one DEBUG traceback per failure"

--- a/packages/opal-server/requires.txt
+++ b/packages/opal-server/requires.txt
@@ -1,5 +1,5 @@
 click>=8.1.3,<9
-permit-broadcaster[postgres,redis,kafka]==0.2.6
+permit-broadcaster[postgres,redis,kafka]==0.2.7
 gitpython>=3.1.32,<4
 pyjwt[crypto]>=2.1.0,<3
 slowapi>=0.1.5,<1


### PR DESCRIPTION
## fix(opal-server): PR3 follow-ups from the staging campaign (rc.3)

Four narrow fixes found while running the PR3 stability campaign on staging and on a prod-shaped fleet on 2026-08-18 (evidence in the private staging test kit's punch list, items P1/P3/P5/P6), plus the `permit-broadcaster` **0.2.6 → 0.2.7** pin bump (P9). None changes a public route or a wire format; all are behind existing config. Branch is `master` (#924 merged) + these commits.

### P9 — dependency bump: permit-broadcaster 0.2.7 (TCP keepalive on the Postgres backbone)
**What:** one line in `requires.txt`. 0.2.7 ([permitio/broadcaster#28](https://github.com/permitio/broadcaster/pull/28)) enables TCP keepalive on every pooled asyncpg connection of the broadcaster's Postgres backend — on by default (idle 30 s / interval 10 s / count 3), tunable or disableable with libpq-style `keepalives*` parameters in the broadcast URL. **Rollback constraint:** only set those parameters once every server sharing the URI runs ≥ rc.3 — 0.2.6 forwards them to Postgres as session settings and every backbone connection is refused (documented with a danger callout under `OPAL_BROADCAST_URI`). The defaults need no URI change.
**Why:** a `LISTEN` connection is idle by nature; when the database's address goes silent without closing the socket (a Multi-AZ failover), the reader stays `ESTABLISHED`-and-deaf forever while the publisher reconnects by DNS — the process ends up notifying the new primary while listening to the old one. asyncpg exposes no keepalive option (MagicStack/asyncpg#606), so the library sets it on the socket.
**Verified:** on a prod-shaped staging fleet (base image + only this library change), a forced Multi-AZ failover: every worker detected the dead listener in ~30 s, reconnected and resynced in 2–5 s, and a fleet-wide publish converged with zero intervention; post-failover socket tables show all listener connections on the new primary with the keepalive timer armed. Full test suite passes against the published 0.2.7.

### P5 — fleet purge must reach workers with no WebSocket client
**What:** when `OPAL_SCOPES` is on and a broadcaster is configured, every worker now holds the global broadcast listening context for its lifetime (the same context the statistics path already used), so server-side subscriptions — the fleet purge handler — actually receive messages on workers that have zero clients.
**Why:** `subscribe_worker_purge_handler` was registered on every worker, but a worker's `EventBroadcaster` reader only ran while it had a WS client (or under `STATISTICS_ENABLED`, off in typical deployments). Client-less workers never received the confirmed purge and kept stale `GitPolicyFetcher.repo_locks` entries for the life of the process. Measured on a staging deployment (~23 WS connections over 16 workers): 5 of 8 workers per pod never logged a single purge across 12 purge events; after a full drain 8 non-leader pids still held the deleted source's lock key (`test_keys_zero` FAIL in T1.2/T1.3). Bytes are negligible; the "fleet purge" guarantee (invariant I4) was not.
**How:** `server.py` — the context is created whenever `broadcaster_uri` and (`STATISTICS_ENABLED`, or `SCOPES` **on the `ReconnectingBroadcaster`** — the default); entered exactly once per worker before the leadership lock (in a try/except: a raising enter is one WARNING, the half-entered context is **unwound** with `__aexit__(None, None, None)` so the library's shared listen count goes back to 0 — otherwise later client contexts would count 2, 3, … and the reader would never start on that worker — and the worker still subscribes the purge handler, takes leadership and runs the watcher); exited with the correct `__aexit__(None, None, None)` arity on the way out. Legacy `EventBroadcaster` (`BROADCAST_RECONNECT_ENABLED=false`) connects eagerly and would abort the background task with the backbone down at boot, so it gets one INFO line ("purge delivery to client-less workers not guaranteed") instead of a reader. Restart-on-give-up for scopes-only workers is `_wire_broadcaster_give_up` (fires on give-up, never on clean cancellation); the statistics done-callback stays statistics-only. Single-process deployments (no broadcaster) are untouched.
**Also fixed on the way:** the pre-existing zero-arg `__aexit__()` call — the real context manager has no defaults, so it raised `TypeError` inside the un-awaited background task; with the widened guard that path is now hit by every scopes leader whose watcher stops.
**Operational note:** each previously client-less worker opens the broadcaster pool: **10 eager connections at boot** (asyncpg default `min_size`; `BROADCASTER_PG_MAX_POOL_SIZE` only raises the ceiling), decaying to ~1 after ~300 s. Budget `max_connections` for 10 × workers × pods at a rolling restart.
**Tests:** `scopes_worker_listening_context_test.py` (8) — non-leader with SCOPES on/STATISTICS off enters once; SCOPES+STATISTICS enters once (no double-enter); no broadcaster → no context; leader path enters and EXITS once (strict-arity double that mirrors the shared listen count), both through the fall-through shape and the mainline watcher shape (fake watcher stops → graceful shutdown → exit); legacy broadcaster → no scopes reader + one INFO; legacy broadcaster + statistics → context armed and no INFO; raising `__aenter__` → WARNING, unwound (`exited == 1`, listen count 0), purge subscription and leadership still run. (Unit-level around `start_server_background_tasks`; the bed's git-leak gates don't model client-less workers, so no bed gate was added.)

### P1 — DogStatsD configured in the gunicorn master before the scope preload
**What:** new `opal_server/metrics_setup.py:configure_server_metrics()`, called by the worker app (unchanged behaviour) AND by `ScopesPolicyWatcherTask.preload_scopes()` before the first sync.
**Why:** the master runs the preload from `scripts/gunicorn_conf.py:when_ready` before any worker exists and never configured the client, so its metrics went out without the `permit.opal` namespace: after the staging rollout Datadog showed `opal_server.scopes.git_ops_in_flight{pid:7}` / `opal_server.scopes.count` (master) next to the workers' `permit.opal.opal_server.scopes.*` — the boot phase was invisible to every dashboard/monitor built on the namespaced names.
**Note for dashboard readers:** the master's pid-tagged series (`git_ops_in_flight`, `sources_in_backoff`, `git_ops_refused` for the master pid) now appear namespaced during preload and go NO DATA after fork (the master stops emitting) — expected; the kit monitors use `notify_no_data=false`.
**Tests:** `preload_metrics_namespace_test.py` — namespace `permit.opal` after configure; fail-silent when metrics disabled; the serialized packet for a gauge starts with `permit.opal.opal_server.scopes.count:`; `preload_scopes` calls configure BEFORE `sync_scopes`.

### P6 — a failed scope sync is one ERROR line; the traceback moves to DEBUG
**What:** `scopes/service.py` `sync_scope` (and the per-pass `_sync_one` wrapper) log `Could not fetch policy for scope <id> (remote: <url>): <ExcType>: <msg>` at ERROR without a traceback, and the traceback at DEBUG.
**Why:** per broken source per pass the previous `logger.exception` emitted ~40 traceback lines. On the prod-shaped fleet (64 broken repos) the container log rotated (10 MiB) within minutes of a boot and the boot markers were gone before anyone could read them; in production this same mechanism dominates opal-server's log volume. The per-source backoff (#924) makes it decay, but the first hour after any boot was still a firehose. The clone/fetch paths in `git_fetcher.py` already logged without a traceback. At the usual production log level (INFO) the DEBUG traceback is effectively never emitted — that is the intent: the ERROR line carries scope, remote and reason, and anyone chasing one source turns DEBUG on for that pod.
**Tests:** `sync_failure_log_volume_test.py` — a repeated failure yields ERROR records naming scope/remote/reason with no exception attached, and one DEBUG record with the traceback per failure; same for the pass wrapper.

### P3 — `OPAL_REPO_WATCHER_ENABLED` gates the scopes sync task: say so
**What:** startup WARNING when `SCOPES=true` and `REPO_WATCHER_ENABLED=false` ("this server will REGISTER and SERVE scopes but never SYNC or PURGE them"); config description and `configuration.mdx` explain that in scopes mode the flag enables the periodic `sync_scopes` pass, the boot sync-all and the fleet purger.
**Why:** the flag reads as "single-repo watcher". A prod-shaped fleet booted with it off registered 2160 scopes, reported Ready and never cloned anything (leader parked on the keepalive) — 21 minutes to diagnose. A warning rather than a refusal so an upgrade cannot break a deliberate read-only replica. The docs paragraph is precise about what the task does: boot sync-all, the periodic pass only when `OPAL_POLICY_REFRESH_INTERVAL > 0` (default 0 skips it), and the fleet purge handler.
**Tests:** `scopes_watcher_flag_warning_test.py` — warning present with the flag off, absent with it on; the description mentions scopes/purge. Docs-drift test still green.

### Not in this PR (deliberately) / follow-ups
- With `BROADCAST_RECONNECT_ENABLED=false` (legacy `EventBroadcaster`) P5 does not apply: the per-client reader lifecycle is preserved as before (a reader only while a client is connected), and the server logs one INFO line at startup saying purge delivery to client-less workers is not guaranteed in that mode. Enabling reconnect (the default) is the fix there.
- Rollout check (from P5): each previously client-less worker opens the broadcaster **pool** — asyncpg's default `min_size` is **10 eager connections at boot**, decaying to ~1 after ~300 s (`BROADCASTER_PG_MAX_POOL_SIZE` can only raise the ceiling). Budget the broadcast database's `max_connections` for **10 × workers × pods during a rolling restart**, not the steady state. Lowering `min_size` at source is a permit-broadcaster follow-up.
- P2 `POST /scopes/{id}/data/update` payloads are ignored by scoped opal-clients (server rewrites entry topics to `data:<t>`, client filters on `<scope>:data:<t>`): public-route semantics, needs its own discussion; publishers that use `/data/config` with fully-qualified topics are unaffected.
- P4 prod probe/preStop values (startup `initialDelaySeconds` 300→60, `preStop sleep 120` vs 30 s grace) — permit-deployments values PR.
- Boot-structure follow-ups from T2 (persist backoff across restarts, stall-based fetch timeout, serve healthy tenants before the broken tail) — separate PR.

### Verification
`packages/opal-server`: 324 tests on master → **341** here (17 new), all green; each new test mutation-checked (fix reverted → test fails → restored; for P5 specifically: zero-arg `__aexit__` → fails, scopes no longer arming the context → fails, try/except removed → fails, isinstance gate inverted → fails, unwind after a failed enter removed → fails, INFO guard made inaccurate → fails). pre-commit (black/isort/codespell/docformatter) clean.

### Release note (rc.3)
opal-server 0.9.9-rc.3: fleet purge now reaches workers without WebSocket clients; boot-phase metrics carry the `permit.opal` namespace; failed scope syncs log one line (traceback at DEBUG); `OPAL_REPO_WATCHER_ENABLED=false` with scopes on warns at startup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nxg7e1Jtk5qykAdYoYENdw


