### PR TITLE
fix: Cannot configure opal-client from /opal/.env correctly

### DIFF
--- a/documentation/docs/getting-started/configuration.mdx
+++ b/documentation/docs/getting-started/configuration.mdx
@@ -6,10 +6,9 @@ OPAL supports multiple ways to configure your deployment:
 
 - **Environment Variables** (recommended) - `export OPAL_SERVER_URL=http://localhost:7002`
 - **Command Line Arguments** - `opal-server run --server-url http://localhost:7002`
-- **Configuration Files** - `.env` or `.ini` files in your project
+- **Configuration Files** - `.env` or `settings.ini` files, looked up in the working directory of the OPAL process and its parent directories (in the official docker images, the working directory is `/opal`, so mounting `/opal/.env` works). Environment variables take precedence over values in these files.
 
 ### Essential Configuration
-
 Let's get OPAL running! You'll need to set a few environment variables that tell OPAL where to find your policies and how to connect everything together.
 
 #### OPAL Server

--- a/packages/opal-common/opal_common/confi/confi.py
+++ b/packages/opal-common/opal_common/confi/confi.py
@@ -7,24 +7,31 @@ Adding typing support and parsing with Pydantic and Enum.
 import inspect
 import json
 import logging
+import os
 import string
 from collections import OrderedDict
 from functools import partial, wraps
 from typing import Any, Callable, Dict, List, Optional, Tuple, TypeVar, Union
 
-from decouple import Csv, UndefinedValueError, config, text_type, undefined
+from decouple import AutoConfig, Csv, UndefinedValueError, text_type, undefined
 from opal_common.authentication.casting import cast_private_key, cast_public_key
 from opal_common.authentication.types import EncryptionKeyFormat, PrivateKey, PublicKey
-from opal_common.confi.cli import get_cli_object_for_config_objects
-from opal_common.confi.types import ConfiDelay, ConfiEntry, no_cast
+from opal_common.confi.cli import get_cli_object_for_config_objectsfrom opal_common.confi.types import ConfiDelay, ConfiEntry, no_cast
 from opal_common.logging_utils.decorators import log_exception
 from pydantic import BaseModel, ValidationError
 from typer import Typer
 
 
+class WorkingDirectoryAutoConfig(AutoConfig):
+    def _caller_path(self):
+        return os.getcwd()
+
+
+config = WorkingDirectoryAutoConfig()
+
+
 class Placeholder(object):
     """Placeholder instead of default value for decouple."""
-
     pass
 
 

--- a/packages/opal-common/opal_common/tests/confi_env_file_test.py
+++ b/packages/opal-common/opal_common/tests/confi_env_file_test.py
@@ -1,0 +1,34 @@
+import pytest
+from opal_common.confi import Confi, WorkingDirectoryAutoConfig, confi
+
+
+@pytest.fixture
+def isolated_auto_config(monkeypatch):
+    monkeypatch.setattr("opal_common.confi.confi.config", WorkingDirectoryAutoConfig())
+
+
+def test_env_file_is_loaded_from_working_directory(
+    tmp_path, monkeypatch, isolated_auto_config
+):
+    (tmp_path / ".env").write_text("OPAL_TEST_CLIENT_TOKEN=token-from-env-file\n")
+    monkeypatch.chdir(tmp_path)
+
+    class ConfigWithEnvFile(Confi):
+        TEST_CLIENT_TOKEN = confi.str("TEST_CLIENT_TOKEN", "default-token")
+
+    assert ConfigWithEnvFile(prefix="OPAL_").TEST_CLIENT_TOKEN == "token-from-env-file"
+
+
+def test_environment_variables_take_precedence_over_env_file(
+    tmp_path, monkeypatch, isolated_auto_config
+):
+    (tmp_path / ".env").write_text("OPAL_TEST_CLIENT_TOKEN=token-from-env-file\n")
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("OPAL_TEST_CLIENT_TOKEN", "token-from-environment")
+
+    class ConfigWithEnvFile(Confi):
+        TEST_CLIENT_TOKEN = confi.str("TEST_CLIENT_TOKEN", "default-token")
+
+    assert (
+        ConfigWithEnvFile(prefix="OPAL_").TEST_CLIENT_TOKEN == "token-from-environment"
+    )


### PR DESCRIPTION
Fixes #516

## Root cause

Confi uses decouple's caller-path AutoConfig, so /opal/.env is never found

## Changes

- Replaced decouple's default `config` with a WorkingDirectoryAutoConfig subclass that resolves .env/settings.ini starting from the process working directory (which is /opal in the official images), added regression tests for env-file loading and env-var precedence, and documented the lookup location.