### PR TITLE
fix(opal-server): bound the process-global pygit2 handle cache

### DIFF
--- a/documentation/docs/getting-started/configuration.mdx
+++ b/documentation/docs/getting-started/configuration.mdx
@@ -479,6 +479,11 @@ Default: `1`
 
 The max number of local clones to use for the same repo (reused across scopes).
 
+#### OPAL_SCOPES_REPO_HANDLE_CACHE_SIZE
+
+Default: `1024`
+
+Maximum open pygit2 repository handles kept per worker process. Each cached handle pins OS file descriptors and mmapped pack indexes, so this cache is a memory cost that scales with the number of DISTINCT sources a worker has touched, not with fleet activity. Before this key the cache had no bound and exactly one runtime eviction path - a scope purge (delete/repoint) - so a deployment that rarely deletes scopes grew it for the life of the process. Eviction is least-recently-used and drops only the in-memory handle: the clone stays on disk and the next access reopens it lazily, so a miss costs a local open, never a re-clone. A source with a git op in flight is never evicted (freeing a handle a pool thread still reads is a use-after-free), so the live size can exceed this bound transiently. Size it above the number of sources one worker touches in a pass, or 0 to disable the bound and restore the previous unbounded behaviour.
 #### OPAL_SCOPES_GIT_FETCH_TIMEOUT
 
 Default: `120.0`

--- a/packages/opal-server/opal_server/config.py
+++ b/packages/opal-server/opal_server/config.py
@@ -631,6 +631,25 @@ class OpalServerConfig(Confi):
         description="The max number of local clones to use for the same repo (reused across scopes)",
     )
 
+    SCOPES_REPO_HANDLE_CACHE_SIZE = confi.int(
+        "SCOPES_REPO_HANDLE_CACHE_SIZE",
+        1024,
+        description="Maximum open pygit2 repository handles kept per worker "
+        "process. Each cached handle pins OS file descriptors and mmapped pack "
+        "indexes, so this cache is a memory cost that scales with the number of "
+        "DISTINCT sources a worker has touched, not with fleet activity. Before "
+        "this key the cache had no bound and exactly one runtime eviction path "
+        "- a scope purge (delete/repoint) - so a deployment that rarely deletes "
+        "scopes grew it for the life of the process. Eviction is "
+        "least-recently-used and drops only the in-memory handle: the clone "
+        "stays on disk and the next access reopens it lazily, so a miss costs a "
+        "local open, never a re-clone. A source with a git op in flight is never "
+        "evicted (freeing a handle a pool thread still reads is a use-after-"
+        "free), so the live size can exceed this bound transiently. Size it "
+        "above the number of sources one worker touches in a pass, or 0 to "
+        "disable the bound and restore the previous unbounded behaviour.",
+    )
+
     REDIS_URL = confi.str(
         "REDIS_URL",
         default="redis://localhost",

--- a/packages/opal-server/opal_server/git_fetcher.py
+++ b/packages/opal-server/opal_server/git_fetcher.py
@@ -9,6 +9,7 @@ import shutil
 import threading
 import time
 import weakref
+from collections import OrderedDict
 from concurrent.futures import ThreadPoolExecutor
 from concurrent.futures import thread as cf_thread
 from contextlib import asynccontextmanager
@@ -635,7 +636,10 @@ class RepoInterface:
 
 class GitPolicyFetcher(PolicyFetcher):
     repo_locks = {}
-    repos = {}
+    # Ordered so the bound in SCOPES_REPO_HANDLE_CACHE_SIZE can evict the
+    # least-recently-used handle. Insertion order alone would drop a repo that
+    # is read every pass in favour of one nothing has touched in hours.
+    repos = OrderedDict()
     repos_last_fetched = {}
     # source_id -> how long the periodic pass keeps skipping this source after
     # consecutive clone/fetch failures. Per process and in memory only.
@@ -1071,7 +1075,7 @@ class GitPolicyFetcher(PolicyFetcher):
             self._clear_source_backoff()
             # Cache the fresh handle so the next sync's _get_repo() reuses it
             # instead of reopening (or hitting a stale predecessor).
-            GitPolicyFetcher.repos[str(self._repo_path)] = repo
+            GitPolicyFetcher.cache_repo(str(self._repo_path), repo)
             # A reclone just downloaded current remote state — record it so
             # _was_fetched_after() doesn't force a redundant fetch next cycle.
             GitPolicyFetcher.repos_last_fetched[self._source_id] = clone_started
@@ -1079,9 +1083,13 @@ class GitPolicyFetcher(PolicyFetcher):
 
     def _get_repo(self) -> Repository:
         path = str(self._repo_path)
-        if path not in GitPolicyFetcher.repos:
-            GitPolicyFetcher.repos[path] = Repository(path)
-        return GitPolicyFetcher.repos[path]
+        repo = GitPolicyFetcher.repos.get(path)
+        if repo is None:
+            repo = Repository(path)
+            GitPolicyFetcher.cache_repo(path, repo)
+        else:
+            GitPolicyFetcher.touch_repo(path)
+        return repo
 
     def _get_valid_repo(self) -> Optional[Repository]:
         try:
@@ -1275,6 +1283,60 @@ class GitPolicyFetcher(PolicyFetcher):
     @staticmethod
     def repo_clone_path(base_dir: Path, source: GitPolicyScopeSource) -> Path:
         return GitPolicyFetcher.base_dir(base_dir) / GitPolicyFetcher.source_id(source)
+
+    @staticmethod
+    def touch_repo(path: str) -> None:
+        """Mark a cached handle as most-recently-used.
+
+        Called on every cache hit, so the bound evicts genuinely cold
+        sources rather than whichever happened to be opened first.
+        """
+        if path in GitPolicyFetcher.repos:
+            GitPolicyFetcher.repos.move_to_end(path)
+
+    @staticmethod
+    def cache_repo(path: str, repo: Repository) -> None:
+        """Admit a handle to the cache, then evict down to the bound.
+
+        The single admission point for both callers (a completed clone
+        and a lazy open), so the bound cannot be bypassed by adding a
+        third.
+        """
+        GitPolicyFetcher.repos[path] = repo
+        GitPolicyFetcher.repos.move_to_end(path)
+        GitPolicyFetcher._evict_repo_handles_over_cap(protect=path)
+
+    @staticmethod
+    def _evict_repo_handles_over_cap(protect: Optional[str] = None) -> None:
+        """Drop least-recently-used handles until the cache fits the bound.
+
+        Only the in-memory handle goes: the clone stays on disk and _get_repo
+        reopens it lazily, so a miss costs a local open and never a re-clone
+        (the same property the post-fork purge relies on).
+
+        Two entries are skipped rather than freed. ``protect`` is the handle the
+        caller is about to return -- freeing it would hand back a dead object.
+        A source with a git op in flight is skipped for the reason
+        purge_local_memory documents: Repository.free() while a pool thread is
+        still reading is a use-after-free. Both mean the live size can sit above
+        the bound transiently; correctness outranks the bound, and the next
+        admission retries the eviction.
+
+        A cap of 0 (or negative) disables the bound entirely, restoring the
+        unbounded behaviour that shipped before this key existed.
+        """
+        cap = opal_server_config.SCOPES_REPO_HANDLE_CACHE_SIZE
+        if cap <= 0:
+            return
+        # list() because forget_repo mutates the dict we are walking.
+        for path in list(GitPolicyFetcher.repos):
+            if len(GitPolicyFetcher.repos) <= cap:
+                break
+            if path == protect:
+                continue
+            if git_op_in_flight(os.path.basename(path.rstrip("/"))):
+                continue
+            GitPolicyFetcher.forget_repo(path)
 
     @staticmethod
     def forget_repo(path: str) -> None:

--- a/packages/opal-server/opal_server/tests/repo_handle_cache_test.py
+++ b/packages/opal-server/opal_server/tests/repo_handle_cache_test.py
@@ -1,0 +1,159 @@
+"""Bounded LRU for the process-global pygit2 handle cache.
+
+The production shape this encodes: ``GitPolicyFetcher.repos`` is keyed per clone
+path and, before this change, had no size bound, no TTL and exactly one runtime
+eviction path -- a scope purge (delete/repoint). On prod-us-east that path is
+effectively never taken: 43,026 scopes, net +5 over six hours, one purge-related
+log line in the same window. So every scope a worker touched pinned a
+``pygit2.Repository`` -- open fds and mmapped pack indexes -- for the life of the
+process, and RSS climbed ~129 MB/h with no plateau.
+
+It did not reproduce on the staging bed because the bed had 40 repos (the cache
+saturates at 40 entries and cannot grow) and its leak test was hours of
+create/delete churn, which exercises the purge path continuously. High-churn /
+low-cardinality hid it; prod is zero-churn / high-cardinality.
+
+Each test names, in its docstring, the mutation it catches.
+"""
+import pytest
+from opal_server.config import opal_server_config
+from opal_server.git_fetcher import GitPolicyFetcher
+
+# Small enough that the LRU arithmetic is readable; nothing here depends on the
+# shipped default.
+_CAP = 3
+
+
+class _FakeRepo:
+    """Stands in for pygit2.Repository.
+
+    ``free()`` is the call that actually
+    releases fds and mmapped pack indexes, so the tests assert on it.
+    """
+
+    def __init__(self, name: str):
+        self.name = name
+        self.freed = False
+
+    def free(self) -> None:
+        self.freed = True
+
+
+@pytest.fixture(autouse=True)
+def _reset_class_state(monkeypatch):
+    """Repos is process-global class state -- a leaked entry would make a later
+    test pass for the wrong reason."""
+    for d in (
+        GitPolicyFetcher.repos,
+        GitPolicyFetcher.repos_last_fetched,
+        GitPolicyFetcher.repo_locks,
+        GitPolicyFetcher.source_backoff,
+    ):
+        d.clear()
+    monkeypatch.setattr(opal_server_config, "SCOPES_REPO_HANDLE_CACHE_SIZE", _CAP)
+    yield
+    for d in (
+        GitPolicyFetcher.repos,
+        GitPolicyFetcher.repos_last_fetched,
+        GitPolicyFetcher.repo_locks,
+        GitPolicyFetcher.source_backoff,
+    ):
+        d.clear()
+
+
+def _put(path: str) -> _FakeRepo:
+    """Insert through the same helper the clone and open paths use, so the test
+    exercises the real admission + eviction sequence."""
+    repo = _FakeRepo(path)
+    GitPolicyFetcher.cache_repo(path, repo)
+    return repo
+
+
+def _paths():
+    return list(GitPolicyFetcher.repos)
+
+
+def test_cache_is_bounded_by_the_configured_cap():
+    """Catches removing the eviction call from cache_repo: without it the dict
+    grows to one entry per source touched, which is the prod leak."""
+    for i in range(10):
+        _put(f"/clones/s{i}")
+
+    assert len(GitPolicyFetcher.repos) == _CAP
+
+
+def test_eviction_is_least_recently_used_not_insertion_order():
+    """Catches evicting by insertion order: re-reading an old source must renew
+    it, or a hot repo touched every pass gets dropped while a cold one survives."""
+    a, b, c = (_put(f"/clones/{n}") for n in ("a", "b", "c"))
+
+    # Touch 'a' through the read path so it becomes the most recent.
+    GitPolicyFetcher.touch_repo("/clones/a")
+    _put("/clones/d")
+
+    assert "/clones/a" in _paths(), "renewed entry was evicted"
+    assert "/clones/b" not in _paths(), "true LRU victim survived"
+    assert b.freed is True
+    assert a.freed is False
+
+
+def test_eviction_frees_the_handle():
+    """Catches evicting with a bare dict pop: dropping the reference without
+    free() leaves fds and mmapped pack indexes pinned until GC, which is the
+    resource this change exists to reclaim."""
+    victim = _put("/clones/victim")
+    for i in range(_CAP):
+        _put(f"/clones/keep{i}")
+
+    assert "/clones/victim" not in _paths()
+    assert victim.freed is True
+
+
+def test_never_evicts_a_source_with_a_git_op_in_flight(monkeypatch):
+    """Catches dropping the in-flight guard: free()ing a handle a pool thread is
+    still reading is a use-after-free. The entry may stay over cap -- correctness
+    outranks the bound."""
+    monkeypatch.setattr(
+        "opal_server.git_fetcher.git_op_in_flight",
+        lambda source_id: source_id == "busy",
+    )
+    busy = _put("/clones/busy")
+    for i in range(_CAP + 2):
+        _put(f"/clones/idle{i}")
+
+    assert "/clones/busy" in _paths(), "evicted a handle with a git op in flight"
+    assert busy.freed is False
+
+
+def test_never_evicts_the_entry_just_admitted(monkeypatch):
+    """Catches evicting without protecting the new entry: at cap 1 the caller
+    would get back a handle that was freed on the way out."""
+    monkeypatch.setattr(opal_server_config, "SCOPES_REPO_HANDLE_CACHE_SIZE", 1)
+    _put("/clones/first")
+    fresh = _put("/clones/second")
+
+    assert _paths() == ["/clones/second"]
+    assert fresh.freed is False
+
+
+def test_zero_disables_the_bound(monkeypatch):
+    """Catches treating 0 as 'evict everything'.
+
+    0 is the documented escape hatch back to the pre-change unbounded
+    behaviour.
+    """
+    monkeypatch.setattr(opal_server_config, "SCOPES_REPO_HANDLE_CACHE_SIZE", 0)
+    for i in range(50):
+        _put(f"/clones/s{i}")
+
+    assert len(GitPolicyFetcher.repos) == 50
+
+
+def test_purge_still_evicts_regardless_of_cap():
+    """Catches making the cap the only eviction path: forget_repo is what the
+    scope purge calls, and it must keep working for a deleted source."""
+    repo = _put("/clones/gone")
+    GitPolicyFetcher.forget_repo("/clones/gone")
+
+    assert "/clones/gone" not in _paths()
+    assert repo.freed is True


### PR DESCRIPTION
## The bug

`GitPolicyFetcher.repos` is keyed per clone path and has **no size bound, no TTL, and exactly one runtime eviction path** — a scope purge (delete/repoint), reached via `purge_local_memory` → `forget_repo`. Every other site only inserts.

So the cache is bounded by the deployment's scope **deletion rate**, not by memory. A deployment that rarely deletes scopes grows it for the life of the process, and every entry pins a `pygit2.Repository` holding OS file descriptors and mmapped pack indexes.

## Production evidence (prod-us-east, 0.9.9)

| | |
|---|---|
| scopes | **43,026**, net **+5** over 6h |
| purge-related log lines in that window | **1** |
| RSS 16:23 → 21:46 | 5.15 → 5.84 GB (**129 MB/h**) |
| working_set, same window | 8.17 → 8.88 GB (**131 MB/h**) |
| documented rate on 0.9.8-rc.1 | 25–50 MB **per 6 h** |

RSS and working_set climbing at the *same* rate is the tell — page cache from git activity moves `working_set` only, so this is anonymous heap. Scope count was flat across the window (rules out "more work"), and the clone volume is a disk-backed `emptyDir` (rules out memory-backed clone storage). All four pods showed it at 83–130 MB/h.

## Why the staging campaign passed it for weeks

Two independent maskers, either of which alone would have hidden it:

1. **The bed had 40 repos.** The cache saturates at ~40 entries and cannot grow. An unbounded cache with 40 possible keys is indistinguishable from a bounded one.
2. **The leak test exercised the eviction path continuously.** T1 was hours of create/delete scope churn, and its pass criterion was literally *"caches empty after every purge"* — it verified that teardown reclaims, which it does. It never asked whether a process that never tears anything down accumulates.

High-churn / low-cardinality cannot express this shape. Prod is zero-churn / high-cardinality.

## The fix

Admit through `cache_repo()`, evict least-recently-used down to `OPAL_SCOPES_REPO_HANDLE_CACHE_SIZE` (default `1024`, `0` disables and restores the previous behaviour).

Eviction drops **only the in-memory handle** and calls `Repository.free()`. The clone stays on disk and `_get_repo` reopens it lazily — a miss costs a local open, never a re-clone. That's the same property the post-fork purge already relies on (*"Workers re-open handles lazily from the on-disk clones (preserved)"*). Reads go through `touch_repo()`, so a repo synced every pass isn't evicted in favour of one nothing has touched.

Two entries are skipped rather than freed:
- the handle the caller is about to return, and
- any source with a git op in flight — `free()`ing a handle a pool thread still reads is a use-after-free, the hazard `purge_local_memory` already documents.

Live size can therefore exceed the bound transiently. Correctness outranks the bound; the next admission retries.

### Why not "periodic purges"

The purge command is addressed to a single `source_id`, the leader sibling-checks it and **refuses a source still backing a live scope**, and the DELETE path also removes the clone directory. None of that is what a cache policy wants.

## Tests

7 new tests in `repo_handle_cache_test.py`, each naming the mutation it catches: the bound itself, LRU-vs-insertion-order, `free()` on evict, the in-flight guard, protecting the just-admitted entry, `0` disabling the bound, and purge still working independently.

Full `opal-server` suite: **353 passed**. Docs-drift guard satisfied (the new key is quoted verbatim in `configuration.mdx`).

## Reviewer notes

- Default `1024` is a judgement call — it should sit above the number of distinct sources one worker touches in a pass. Happy to change it.
- This does **not** replace the purge path; it adds a second, memory-driven eviction alongside it.
- Base is `master` (`dfec1c22` = the 0.9.9 running in prod), so it applies directly to the leaking build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RDt9cxxHhnVGYn9A65zwsg
