### PR TITLE
feat(opal-server): attribute allocations from the internal stats endpoint

### DIFF
--- a/packages/opal-server/opal_server/debug_stats.py
+++ b/packages/opal-server/opal_server/debug_stats.py
@@ -3,12 +3,20 @@
 Used only by the off-by-default /internal stats endpoint so tests can
 observe the cache growth that the memory-leak fix (PR2) eliminates.
 """
+import collections
+import gc
 import os
+import tracemalloc
 from pathlib import Path
-from typing import Dict, List, Optional
+from typing import Dict, List, Optional, Tuple
 
-from fastapi import FastAPI, params
+import pygit2
+from fastapi import FastAPI, Query, params
 from opal_server.git_fetcher import GitPolicyFetcher
+
+# How many allocation sites to report. Enough to see a culprit stand out from
+# the interpreter's own baseline, short enough to read in a terminal.
+_TRACEMALLOC_TOP = 15
 
 
 def _read_rss_kb() -> int:
@@ -22,7 +30,72 @@ def _read_rss_kb() -> int:
     return 0
 
 
-def git_fetcher_cache_stats() -> Dict:
+def _libgit2_cache_bytes() -> Optional[Tuple[int, int]]:
+    """Libgit2's own object cache as (used, max) bytes.
+
+    The one suspect here that no Python tool can see: it is a native allocation,
+    so it never appears in gc, in tracemalloc, or in an object census. Capped at
+    256 MB by default and never tuned in this repo, which makes it a bounded
+    contributor rather than an unbounded leak -- but bounded-and-full still hides
+    a quarter gigabyte from every other number on this endpoint.
+
+    Returns None rather than raising when pygit2 does not expose it, because a
+    diagnostic endpoint that 500s on an older pygit2 is worse than one that says
+    it cannot see the value.
+    """
+    try:
+        used, maximum = pygit2.settings.cached_memory
+        return int(used), int(maximum)
+    except Exception:
+        return None
+
+
+def _tracemalloc_stats() -> Dict:
+    """Top Python allocation sites, when the operator has tracing on.
+
+    Deliberately does NOT start tracing: tracemalloc roughly doubles the
+    interpreter's allocation bookkeeping, which is not a decision this endpoint
+    should make for a running production worker. Start it out of band with
+    PYTHONTRACEMALLOC=<frames> in the environment -- stdlib, no code change --
+    and this reports what it found.
+
+    `tracing: False` is reported distinctly from a zero measurement: "not
+    looking" and "looked, found nothing" are different answers, and conflating
+    them would let a leak hide behind an unstarted tracer.
+    """
+    if not tracemalloc.is_tracing():
+        return {"tracing": False}
+
+    traced, peak = tracemalloc.get_traced_memory()
+    top = [
+        {
+            "location": str(stat.traceback),
+            "size_kb": stat.size // 1024,
+            "count": stat.count,
+        }
+        for stat in tracemalloc.take_snapshot().statistics("lineno")[:_TRACEMALLOC_TOP]
+    ]
+    return {
+        "tracing": True,
+        "traced_kb": traced // 1024,
+        "peak_kb": peak // 1024,
+        "top": top,
+    }
+
+
+def _object_census(top_n: int) -> List[Dict]:
+    """Live Python objects grouped by type, biggest first.
+
+    Catches a growing container the named cache counters do not cover.
+    It walks every tracked object while holding the GIL, so on a multi-
+    GB worker this is a stall rather than a stat -- hence opt-in per
+    request, never on by default.
+    """
+    counts = collections.Counter(type(obj).__name__ for obj in gc.get_objects())
+    return [{"type": name, "count": count} for name, count in counts.most_common(top_n)]
+
+
+def git_fetcher_cache_stats(top_objects: int = 0) -> Dict:
     """Sizes + keys of the three process-global GitPolicyFetcher caches, RSS,
     and the worker pid (per-process caches: the pid identifies WHICH worker
     answered, so multi-worker bed tests can assert per-worker drain)."""
@@ -35,7 +108,7 @@ def git_fetcher_cache_stats() -> Dict:
     repo_locks = GitPolicyFetcher.repo_locks.copy()
     repos = GitPolicyFetcher.repos.copy()
     repos_last_fetched = GitPolicyFetcher.repos_last_fetched.copy()
-    return {
+    stats: Dict = {
         "pid": os.getpid(),
         "repo_locks": len(repo_locks),
         "repos": len(repos),
@@ -44,7 +117,12 @@ def git_fetcher_cache_stats() -> Dict:
         "repo_locks_keys": sorted(repo_locks.keys()),
         "repos_keys": sorted(repos.keys()),
         "repos_last_fetched_keys": sorted(repos_last_fetched.keys()),
+        "libgit2_cache_bytes": _libgit2_cache_bytes(),
+        "tracemalloc": _tracemalloc_stats(),
     }
+    if top_objects > 0:
+        stats["object_counts"] = _object_census(top_objects)
+    return stats
 
 
 def register_internal_stats_route(
@@ -73,5 +151,15 @@ def register_internal_stats_route(
         include_in_schema=False,
         dependencies=dependencies or [],
     )
-    def _git_fetcher_cache_stats() -> Dict:
-        return git_fetcher_cache_stats()
+    def _git_fetcher_cache_stats(
+        top_objects: int = Query(
+            0,
+            ge=0,
+            description=(
+                "Include the top N live object types from a gc census. "
+                "Walks every tracked object under the GIL, so leave it at 0 "
+                "unless you are actively hunting a growing container."
+            ),
+        ),
+    ) -> Dict:
+        return git_fetcher_cache_stats(top_objects=top_objects)

--- a/packages/opal-server/opal_server/tests/debug_stats_attribution_test.py
+++ b/packages/opal-server/opal_server/tests/debug_stats_attribution_test.py
@@ -1,0 +1,122 @@
+"""Allocation attribution for the /internal stats endpoint.
+
+The cache counters already there answer "are the caches big?". On prod-us that
+question is now closed -- 157 sources, flat since boot -- while RSS keeps
+climbing ~129 MB/h with a flat scope count, flat thread count, and no clone
+activity. So the counters eliminate a suspect but name no culprit, and nothing
+else deployed attributes an allocation.
+
+These three additions do:
+
+* ``libgit2_cache_bytes`` -- libgit2 keeps its own object cache (256 MB cap by
+  default, never tuned here). It is invisible to gc, to tracemalloc and to any
+  Python object census, so flat Python state with climbing RSS is exactly its
+  signature. One cheap read rules it in or out.
+* ``tracemalloc`` -- names the Python file and line holding the memory, when the
+  operator started tracing. Reported only when already tracing: starting it from
+  here would double the process's bookkeeping without asking.
+* ``object_counts`` -- a gc census catches a growing container the cache
+  counters do not cover. It walks every object under the GIL, so it is opt-in
+  per request and never runs by default.
+
+Together they answer the one question that decides where the hunt goes next:
+Python or native.
+"""
+import gc
+import tracemalloc
+
+import pytest
+from opal_server import debug_stats
+from opal_server.debug_stats import git_fetcher_cache_stats
+
+
+def test_libgit2_cache_is_always_reported():
+    """Catches leaving the native cache out: it is the only suspect here that no
+    Python-level tool can see, and reading it costs nothing."""
+    stats = git_fetcher_cache_stats()
+
+    used, cap = stats["libgit2_cache_bytes"]
+    assert isinstance(used, int) and isinstance(cap, int)
+    assert used >= 0 and cap > 0
+
+
+def test_libgit2_cache_degrades_when_pygit2_lacks_it(monkeypatch):
+    """Catches assuming the attribute exists: a diagnostic endpoint that 500s on
+    an older pygit2 is worse than one reporting it cannot see the value."""
+
+    class _NoSettings:
+        pass
+
+    monkeypatch.setattr(debug_stats, "pygit2", _NoSettings())
+
+    stats = git_fetcher_cache_stats()
+
+    assert stats["libgit2_cache_bytes"] is None
+
+
+def test_tracemalloc_absent_when_not_tracing():
+    """Catches reporting a zero as though it were a measurement.
+
+    Not tracing and tracing-with-nothing-allocated must not look alike.
+    """
+    if tracemalloc.is_tracing():
+        tracemalloc.stop()
+
+    stats = git_fetcher_cache_stats()
+
+    assert stats["tracemalloc"] == {"tracing": False}
+
+
+def test_tracemalloc_reports_top_allocators_when_tracing():
+    """Catches wiring the key without the snapshot: the whole point is the
+    file:line of whoever is holding the memory."""
+    tracemalloc.start(1)
+    try:
+        ballast = [bytearray(50_000) for _ in range(40)]  # noqa: F841
+
+        stats = git_fetcher_cache_stats()
+    finally:
+        tracemalloc.stop()
+
+    tm = stats["tracemalloc"]
+    assert tm["tracing"] is True
+    assert tm["traced_kb"] > 0
+    assert tm["peak_kb"] >= tm["traced_kb"]
+    assert len(tm["top"]) > 0
+    first = tm["top"][0]
+    assert "location" in first and "size_kb" in first
+    # Sorted biggest-first, or the operator reads noise off the top of the list.
+    sizes = [entry["size_kb"] for entry in tm["top"]]
+    assert sizes == sorted(sizes, reverse=True)
+
+
+def test_object_census_is_off_by_default():
+    """Catches making the gc walk unconditional: it traverses every object under
+    the GIL, which on a multi-GB worker is a stall, not a stat."""
+    stats = git_fetcher_cache_stats()
+
+    assert "object_counts" not in stats
+
+
+def test_object_census_returns_top_types_when_asked():
+    """Catches returning the raw census: thousands of type names is not a
+    diagnostic, and the caller asked for a bounded list."""
+    keep = [dict() for _ in range(500)]  # noqa: F841
+    gc.collect()
+
+    stats = git_fetcher_cache_stats(top_objects=5)
+
+    counts = stats["object_counts"]
+    assert len(counts) == 5
+    values = [c["count"] for c in counts]
+    assert values == sorted(values, reverse=True)
+    assert all("type" in c and "count" in c for c in counts)
+
+
+@pytest.mark.parametrize("bad", [0, -1])
+def test_object_census_stays_off_for_non_positive_values(bad):
+    """Catches treating 0 as 'all': the parameter is a top-N bound, and 0 must
+    mean off rather than the most expensive possible answer."""
+    stats = git_fetcher_cache_stats(top_objects=bad)
+
+    assert "object_counts" not in stats

--- a/packages/opal-server/opal_server/tests/debug_stats_endpoint_test.py
+++ b/packages/opal-server/opal_server/tests/debug_stats_endpoint_test.py
@@ -32,6 +32,8 @@ def test_endpoint_present_when_enabled():
         "repo_locks_keys",
         "repos_keys",
         "repos_last_fetched_keys",
+        "libgit2_cache_bytes",
+        "tracemalloc",
     }
 
 
@@ -95,6 +97,8 @@ def test_server_wiring_mounts_endpoint_when_flag_enabled():
         "repo_locks_keys",
         "repos_keys",
         "repos_last_fetched_keys",
+        "libgit2_cache_bytes",
+        "tracemalloc",
     }
 
 


### PR DESCRIPTION
## Why

`/internal/git-fetcher-cache-stats` reports cache sizes and RSS. That answers *"are the caches big?"* — and on prod-us that question is now **closed**, with the answer **no**:

| measurement | value |
|---|---|
| distinct git sources | **157** (not 43k scopes — the cache keys on repo URL) |
| handle cache | flat since the boot clone storm |
| clone activity after 16:30 | **none** |
| thread count | flat, 120–125 over 5.5h |
| scope count | flat, 43,021 → 43,026 |
| **RSS** | **climbing ~129 MB/h**, working_set tracking it 1:1 |

Every Python-visible container is eliminated, the growth is real and it is heap rather than page cache — and nothing deployed can say *where it went*. This endpoint is the natural place to answer that, since it already exists, is already gated behind `DEBUG_INTERNAL_STATS`, and already reads RSS.

## What's added

**`libgit2_cache_bytes`** — libgit2's own object cache as `(used, max)`.

This is the one suspect no Python tool can see: a native allocation that appears in no `gc` walk, no `tracemalloc` snapshot, no object census. Flat Python state with climbing RSS is precisely its signature. Capped at 256 MB by default and never tuned in this repo — so it's a *bounded contributor*, not an unbounded leak. But bounded-and-full still hides a quarter gigabyte from every other number on this endpoint, and one cheap read rules it in or out. Returns `None` rather than raising on a pygit2 that doesn't expose it.

**`tracemalloc`** — traced/peak totals plus the top 15 allocation sites by `file:line`, reported **only when tracing is already on**.

It deliberately does *not* start tracing. tracemalloc roughly doubles the interpreter's allocation bookkeeping, and that is not a decision an introspection endpoint should make for a running production worker. Start it out of band with `PYTHONTRACEMALLOC=<frames>` — stdlib, no code change, no new config key. `tracing: false` is reported distinctly from a zero measurement, so a leak can't hide behind an unstarted tracer.

**`object_counts`** — live objects by type, biggest first, via `?top_objects=N`.

Catches a growing container the named counters don't cover. It walks every tracked object under the GIL, which on a multi-GB worker is a stall rather than a stat — so it is opt-in per request and never runs by default. `0` and negatives mean off, not "all".

## What it settles

One question, and it decides where the hunt goes next:

- tracemalloc and the census **flat** while RSS climbs → the growth is **native**; the search moves to libgit2 and the allocator.
- either one **growing** → it names the culprit directly.

## Notes for review

- Two existing endpoint tests asserted an exact key set and are updated for the two new always-present keys. `object_counts` stays *out* of that set deliberately — its absence by default is part of the contract.
- 8 new tests, each naming the mutation it catches.
- Full `opal-server` suite: **353 passed**. pre-commit clean.
- Pairs with permit-deployments#1743, which turns the flag on for prod-us. That PR is worth holding until this merges, so the deploy ships a diagnostic that can attribute rather than only eliminate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RDt9cxxHhnVGYn9A65zwsg
