### PR TITLE
fix(scopes): namespace data update entry topics with scope ID

### DIFF
--- a/packages/opal-common/opal_common/topics/publisher.py
+++ b/packages/opal-common/opal_common/topics/publisher.py
@@ -203,6 +203,9 @@ class ScopedServerSideTopicPublisher(ServerSideTopicPublisher):
         self._scope_id = scope_id
 
     async def publish(self, topics: TopicList, data: Any = None):
-        scoped_topics = [f"{self._scope_id}:{topic}" for topic in topics]
+        scoped_topics = [
+            topic if topic.startswith(f"{self._scope_id}:") else f"{self._scope_id}:{topic}"
+            for topic in topics
+        ]
         logger.info("Publishing to topics: {topics}", topics=scoped_topics)
         await super().publish(scoped_topics, data)

--- a/packages/opal-server/opal_server/scopes/api.py
+++ b/packages/opal-server/opal_server/scopes/api.py
@@ -828,7 +828,10 @@ def init_scope_router(
             restrict_optional_topics_to_publish(authenticator, claims, update)
 
             for entry in update.entries:
-                entry.topics = [f"data:{topic}" for topic in entry.topics]
+                entry.topics = [
+                    topic if topic.startswith(f"{scope_id}:") else f"{scope_id}:data:{topic}"
+                    for topic in entry.topics
+                ]
 
             await DataUpdatePublisher(
                 ScopedServerSideTopicPublisher(pubsub_endpoint, scope_id)


### PR DESCRIPTION
### Summary
Ensures data update entry topics published via \POST /scopes/{scope_id}/data/update\ are properly scope-namespaced (\{scope_id}:data:{topic}\) to match OPAL client subscription topic expectations.

### Problem
When a data update was posted to \POST /scopes/{scope_id}/data/update\, \publish_data_update_event\ in \opal_server/scopes/api.py\ rewrote each entry's topics to \data:{topic}\. 

Although \ScopedServerSideTopicPublisher\ published to the channel \{scope_id}:data:{topic}\, the \DataUpdate\ payload received by the client contained \ntry.topics = ['data:{topic}']\. Since scoped OPAL clients subscribe to \{scope_id}:data:{topic}\, the client's topic check (\set(entry.topics).isdisjoint(self._data_topics)\) evaluated to \True\, causing every scoped data entry to be skipped as non-matching.

### Solution
1. Scope-prefix entry topics in \publish_data_update_event\ as \{scope_id}:data:{topic}\.
2. Guard \ScopedServerSideTopicPublisher.publish\ to avoid double-prefixing when topics are already scope-namespaced.

Closes #920